### PR TITLE
feat(openclaw): add per-agent dataset routing and clarify docs

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -6,8 +6,15 @@ OpenClaw plugin that adds Cognee-backed memory with automatic recall and indexin
 
 - **Auto-recall**: Before each agent run, searches Cognee for relevant memories and injects them as context
 - **Auto-index**: On startup and after each agent run, syncs memory markdown files to Cognee (add new, update changed, delete removed, skip unchanged)
+- **Per-agent datasets**: Route each OpenClaw agent to a different Cognee dataset via `datasetNames`
 - **CLI commands**: `openclaw cognee index` to manually sync, `openclaw cognee status` to check state
 - **Configurable**: Search type, max results, score filtering, token limits, and more
+
+## Why Per-Agent Datasets
+
+When multiple agents share one OpenClaw gateway, storing all long-term memory in a single Cognee dataset can leak memories across agents. That breaks the intended boundary between agent sessions and long-term memory.
+
+This integration keeps the original single-dataset behavior by default, but also lets users decide when agents should stay isolated and when they should intentionally share memory.
 
 ## Installation
 
@@ -32,13 +39,19 @@ Enable the plugin in your OpenClaw config (`~/.openclaw/config.yaml` or project 
 
 ```yaml
 plugins:
+  slots:
+    memory: cognee-openclaw
   entries:
     cognee-openclaw:
       enabled: true
       config:
         baseUrl: "http://localhost:8000"
         apiKey: "${COGNEE_API_KEY}"
-        datasetName: "my-project"
+        datasetName: "openclaw"
+        datasetNames:
+          asst: "asst-dataset"
+          lawyer: "lawyer-dataset"
+          lexi: "lexi"
         searchType: "GRAPH_COMPLETION"
         deleteMode: "hard"
         maxResults: 6
@@ -46,11 +59,68 @@ plugins:
         autoIndex: true
 ```
 
+In `datasetNames`, each key is an OpenClaw agent id and each value is the Cognee dataset name for that agent. Integrations that also attach vaults should make the vault-side `cognee.datasetName` match one of those agent dataset names or the shared default `datasetName`.
+
+### Dataset Routing Patterns
+
+Use `datasetName` as the default fallback dataset, then override only the agents that need different memory boundaries.
+
+Mixed example:
+
+```yaml
+plugins:
+  slots:
+    memory: cognee-openclaw
+  entries:
+    cognee-openclaw:
+      enabled: true
+      config:
+        datasetName: "shared-default"
+        datasetNames:
+          asst: "shared-default"
+          lawyer: "legal-memory"
+          lexi: "media-memory"
+          elena: "shared-default"
+```
+
+This gives you three common patterns in one config:
+
+- `lawyer` uses an exclusive dataset.
+- `lexi` uses an exclusive dataset.
+- `asst` and `elena` explicitly share the default dataset.
+
+Any agent not listed in `datasetNames` also falls back to `datasetName`, which preserves the original single-dataset behavior. For example, if an agent such as `researcher` is enabled under the same gateway but does not appear in `datasetNames`, it will still use `shared-default`.
+
 Set your API key in the environment:
 
 ```bash
 export COGNEE_API_KEY="your-key-here"
 ```
+
+### Dev/Prod parity
+
+Use the same plugin id and config shape in both local development and production:
+
+1. Development (local path):
+
+```bash
+cd integrations/openclaw
+npm install
+npm run build
+openclaw plugins install -l .
+```
+
+2. Production (registry package):
+
+```bash
+openclaw plugins install @cognee/cognee-openclaw
+```
+
+Both use:
+
+- plugin id: `cognee-openclaw`
+- config key: `plugins.entries.cognee-openclaw`
+- memory slot: `plugins.slots.memory: cognee-openclaw`
 
 ## Configuration Options
 
@@ -58,7 +128,8 @@ export COGNEE_API_KEY="your-key-here"
 |--------|------|---------|-------------|
 | `baseUrl` | string | `http://localhost:8000` | Cognee API base URL |
 | `apiKey` | string | `$COGNEE_API_KEY` | API key for authentication |
-| `datasetName` | string | `openclaw` | Dataset name for storing memories |
+| `datasetName` | string | `openclaw` | Default dataset name used when an agent id does not have an entry in `datasetNames` |
+| `datasetNames` | object | `{}` | Per-agent dataset overrides keyed by agent id; values are Cognee dataset names |
 | `searchType` | string | `GRAPH_COMPLETION` | Search mode: `GRAPH_COMPLETION`, `CHUNKS`, `SUMMARIES` |
 | `maxResults` | number | `6` | Max memories to inject per recall |
 | `minScore` | number | `0` | Minimum relevance score filter |
@@ -78,7 +149,7 @@ export COGNEE_API_KEY="your-key-here"
 3. **After agent end**: Re-scans memory files and syncs any changes the agent made (including deletions)
 4. **State tracking**:
    - `~/.openclaw/memory/cognee/datasets.json` — dataset ID mapping
-   - `~/.openclaw/memory/cognee/sync-index.json` — per-file hash and Cognee data IDs
+  - `~/.openclaw/memory/cognee/sync-index.json` — per-dataset sync index (`byDataset`) with per-file hashes and Cognee data IDs
 
 Memory files detected at: `MEMORY.md` and `memory/**/*.md` (recursive)
 

--- a/integrations/openclaw/__tests__/test_syncFiles.ts
+++ b/integrations/openclaw/__tests__/test_syncFiles.ts
@@ -1,5 +1,5 @@
 import { CogneeClient } from "../index";
-import { syncFiles } from "../index";
+import { resolveDatasetNameForAgent, syncFiles } from "../index";
 import type { MemoryFile, SyncIndex, CogneePluginConfig } from "../index";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -18,10 +18,13 @@ const SYNC_INDEX_PATH = join(homedir(), ".openclaw", "memory", "cognee", "sync-i
 const STATE_PATH = join(homedir(), ".openclaw", "memory", "cognee", "datasets.json");
 
 // Mock CogneeClient
-jest.mock("../index", () => ({
-  CogneeClient: jest.fn(),
-  syncFiles: jest.requireActual("../index").syncFiles,
-}));
+jest.mock("../index", () => {
+  const actual = jest.requireActual("../index");
+  return {
+    ...actual,
+    CogneeClient: jest.fn(),
+  };
+});
 
 const mockAdd = jest.fn();
 const mockUpdate = jest.fn();
@@ -56,6 +59,7 @@ describe("syncFiles", () => {
       username: "",
       password: "",
       datasetName: "test",
+      datasetNames: {},
       searchPrompt: "",
       searchType: "GRAPH_COMPLETION",
       deleteMode: "soft",
@@ -335,5 +339,50 @@ describe("syncFiles", () => {
       expect(result.deleted).toBe(0);
       expect(mockDelete).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("resolveDatasetNameForAgent", () => {
+  const cfg: Required<CogneePluginConfig> = {
+    baseUrl: "http://test",
+    apiKey: "key",
+    username: "",
+    password: "",
+    datasetName: "shared-default",
+    datasetNames: {
+      lawyer: "legal-memory",
+      lexi: "media-memory",
+      asst: "shared-default",
+    },
+    searchPrompt: "",
+    searchType: "GRAPH_COMPLETION",
+    deleteMode: "soft",
+    maxResults: 6,
+    minScore: 0,
+    maxTokens: 512,
+    autoRecall: true,
+    autoIndex: true,
+    autoCognify: true,
+    requestTimeoutMs: 30000,
+    ingestionTimeoutMs: 300000,
+  };
+
+  it("falls back to the default dataset for agents without an override", () => {
+    expect(resolveDatasetNameForAgent(cfg, "researcher")).toBe("shared-default");
+  });
+
+  it("uses datasetName when an agent is omitted from datasetNames in a mixed config", () => {
+    expect(resolveDatasetNameForAgent(cfg, "elena")).toBe("shared-default");
+    expect(resolveDatasetNameForAgent(cfg, undefined)).toBe("shared-default");
+  });
+
+  it("returns exclusive datasets for agents with dedicated overrides", () => {
+    expect(resolveDatasetNameForAgent(cfg, "lawyer")).toBe("legal-memory");
+    expect(resolveDatasetNameForAgent(cfg, "lexi")).toBe("media-memory");
+  });
+
+  it("allows explicit sharing by pointing multiple agents at the same dataset", () => {
+    expect(resolveDatasetNameForAgent(cfg, "asst")).toBe("shared-default");
+    expect(resolveDatasetNameForAgent(cfg, "elena")).toBe("shared-default");
   });
 });

--- a/integrations/openclaw/index.ts
+++ b/integrations/openclaw/index.ts
@@ -17,6 +17,7 @@ type CogneePluginConfig = {
   username?: string;
   password?: string;
   datasetName?: string;
+  datasetNames?: Record<string, string>;
   searchType?: CogneeSearchType;
   searchPrompt?: string;
   deleteMode?: CogneeDeleteMode;
@@ -128,6 +129,15 @@ function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> {
 
   const baseUrl = raw.baseUrl?.trim() || DEFAULT_BASE_URL;
   const datasetName = raw.datasetName?.trim() || DEFAULT_DATASET_NAME;
+  const datasetNames =
+    raw.datasetNames && typeof raw.datasetNames === "object" && !Array.isArray(raw.datasetNames)
+      ? Object.fromEntries(
+          Object.entries(raw.datasetNames)
+            .filter(([agentId, name]) => typeof agentId === "string" && typeof name === "string")
+            .map(([agentId, name]) => [agentId.trim(), name.trim()])
+            .filter(([agentId, name]) => agentId.length > 0 && name.length > 0),
+        )
+      : {};
   const searchType = raw.searchType || DEFAULT_SEARCH_TYPE;
   const searchPrompt = raw.searchPrompt || DEFAULT_SEARCH_PROMPT;
   const deleteMode = raw.deleteMode === "hard" ? "hard" : DEFAULT_DELETE_MODE;
@@ -162,6 +172,7 @@ function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> {
     username,
     password,
     datasetName,
+    datasetNames,
     searchType,
     searchPrompt,
     deleteMode,
@@ -218,6 +229,52 @@ async function loadSyncIndex(): Promise<SyncIndex> {
 async function saveSyncIndex(state: SyncIndex): Promise<void> {
   await fs.mkdir(dirname(SYNC_INDEX_PATH), { recursive: true });
   await fs.writeFile(SYNC_INDEX_PATH, JSON.stringify(state, null, 2), "utf-8");
+}
+
+type SyncIndexesByDataset = Record<string, SyncIndex>;
+
+async function loadSyncIndexesByDataset(): Promise<SyncIndexesByDataset> {
+  try {
+    const raw = await fs.readFile(SYNC_INDEX_PATH, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") {
+      return {};
+    }
+    const wrapped = parsed as { byDataset?: Record<string, SyncIndex> };
+    if (wrapped.byDataset && typeof wrapped.byDataset === "object") {
+      for (const value of Object.values(wrapped.byDataset)) {
+        value.entries ??= {};
+      }
+      return wrapped.byDataset;
+    }
+
+    // Migrate legacy single-dataset format on read.
+    const legacy = parsed as SyncIndex;
+    legacy.entries ??= {};
+    const fallbackName =
+      typeof legacy.datasetName === "string" && legacy.datasetName.length > 0
+        ? legacy.datasetName
+        : DEFAULT_DATASET_NAME;
+    return { [fallbackName]: legacy };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {};
+    }
+    throw error;
+  }
+}
+
+async function saveSyncIndexesByDataset(state: SyncIndexesByDataset): Promise<void> {
+  await fs.mkdir(dirname(SYNC_INDEX_PATH), { recursive: true });
+  await fs.writeFile(SYNC_INDEX_PATH, JSON.stringify({ byDataset: state }, null, 2), "utf-8");
+}
+
+function resolveDatasetNameForAgent(
+  cfg: Required<CogneePluginConfig>,
+  agentId: string | undefined,
+): string {
+  const scoped = agentId ? cfg.datasetNames[agentId] : undefined;
+  return scoped && scoped.length > 0 ? scoped : cfg.datasetName;
 }
 
 // ---------------------------------------------------------------------------
@@ -654,6 +711,7 @@ async function syncFiles(
   logger: { info?: (msg: string) => void; warn?: (msg: string) => void },
 ): Promise<SyncResult & { datasetId?: string }> {
   const result: SyncResult = { added: 0, updated: 0, skipped: 0, errors: 0, deleted: 0 };
+  const datasetName = syncIndex.datasetName || cfg.datasetName;
   let datasetId = syncIndex.datasetId;
   let needsCognify = false;
 
@@ -684,7 +742,7 @@ async function syncFiles(
           }
           syncIndex.entries[file.path] = { hash: file.hash, dataId: newDataId };
           syncIndex.datasetId = datasetId;
-          syncIndex.datasetName = cfg.datasetName;
+          syncIndex.datasetName = datasetName;
           result.updated++;
 
           logger.info?.(`cognee-openclaw: updated ${file.path}`);
@@ -705,7 +763,7 @@ async function syncFiles(
       // New file, or changed file without dataId, or update failed → add
       const response = await client.add({
         data: dataWithMetadata,
-        datasetName: cfg.datasetName,
+        datasetName,
         datasetId,
       });
 
@@ -714,7 +772,7 @@ async function syncFiles(
 
         // Persist dataset ID mapping
         const state = await loadDatasetState();
-        state[cfg.datasetName] = response.datasetId;
+        state[datasetName] = response.datasetId;
         await saveDatasetState(state);
       }
 
@@ -723,7 +781,7 @@ async function syncFiles(
         dataId: response.dataId,
       };
       syncIndex.datasetId = datasetId;
-      syncIndex.datasetName = cfg.datasetName;
+      syncIndex.datasetName = datasetName;
       needsCognify = true;
       result.added++;
 
@@ -773,9 +831,6 @@ async function syncFiles(
     }
   }
 
-  // Save sync index to disk
-  await saveSyncIndex(syncIndex);
-
   return { ...result, datasetId };
 }
 
@@ -791,49 +846,71 @@ const memoryCogneePlugin = {
   register(api: OpenClawPluginApi) {
     const cfg = resolveConfig(api.pluginConfig);
     const client = new CogneeClient(cfg.baseUrl, cfg.apiKey, cfg.username, cfg.password, cfg.requestTimeoutMs, cfg.ingestionTimeoutMs);
-    let datasetId: string | undefined;
-    let syncIndex: SyncIndex = { entries: {} };
-    let syncIndexReady = false;
+    let datasetState: DatasetState = {};
+    let syncIndexes: SyncIndexesByDataset = {};
     let resolvedWorkspaceDir: string | undefined;  // Set by service/CLI, used by hooks
 
     // Load persisted state on startup
     const stateReady = Promise.all([
       loadDatasetState()
         .then((state) => {
-          datasetId = state[cfg.datasetName];
+          datasetState = state;
         })
         .catch((error) => {
           api.logger.warn?.(`cognee-openclaw: failed to load dataset state: ${String(error)}`);
         }),
-      loadSyncIndex()
+      loadSyncIndexesByDataset()
         .then((state) => {
-          syncIndex = state;
-          syncIndexReady = true;
-          if (!datasetId && state.datasetId && state.datasetName === cfg.datasetName) {
-            datasetId = state.datasetId;
-          }
+          syncIndexes = state;
         })
         .catch((error) => {
           api.logger.warn?.(`cognee-openclaw: failed to load sync index: ${String(error)}`);
         }),
     ]);
 
-    // Helper: run sync with a given workspace dir
-    async function runSync(workspaceDir: string, logger: { info?: (msg: string) => void; warn?: (msg: string) => void }) {
+    async function ensureDatasetContext(datasetName: string): Promise<SyncIndex> {
       await stateReady;
+
+      if (!syncIndexes[datasetName]) {
+        syncIndexes[datasetName] = {
+          datasetName,
+          entries: {},
+        };
+      }
+      const syncIndex = syncIndexes[datasetName];
+      if (!syncIndex.entries || typeof syncIndex.entries !== "object") {
+        syncIndex.entries = {};
+      }
+      if (!syncIndex.datasetId && datasetState[datasetName]) {
+        syncIndex.datasetId = datasetState[datasetName];
+      }
+      return syncIndex;
+    }
+
+    // Helper: run sync with a given workspace dir
+    async function runSync(
+      workspaceDir: string,
+      logger: { info?: (msg: string) => void; warn?: (msg: string) => void },
+      agentId: string | undefined,
+    ) {
+      const datasetName = resolveDatasetNameForAgent(cfg, agentId);
+      const syncIndex = await ensureDatasetContext(datasetName);
 
       const files = await collectMemoryFiles(workspaceDir);
       if (files.length === 0) {
-        logger.info?.("cognee-openclaw: no memory files found");
+        logger.info?.(`cognee-openclaw: no memory files found for dataset ${datasetName}`);
         return { added: 0, updated: 0, skipped: 0, errors: 0, deleted: 0 };
       }
 
-      logger.info?.(`cognee-openclaw: found ${files.length} memory file(s), syncing...`);
+      logger.info?.(`cognee-openclaw: found ${files.length} memory file(s), syncing to ${datasetName}...`);
 
       const result = await syncFiles(client, files, files, syncIndex, cfg, logger);
       if (result.datasetId) {
-        datasetId = result.datasetId;
+        datasetState[datasetName] = result.datasetId;
+        await saveDatasetState(datasetState);
       }
+      syncIndexes[datasetName] = syncIndex;
+      await saveSyncIndexesByDataset(syncIndexes);
 
       return result;
     }
@@ -850,7 +927,7 @@ const memoryCogneePlugin = {
         .command("index")
         .description("Sync memory files to Cognee (add new, update changed, skip unchanged)")
         .action(async () => {
-          const result = await runSync(resolvedWorkspaceDir, ctx.logger);
+          const result = await runSync(resolvedWorkspaceDir, ctx.logger, undefined);
           const summary = `Sync complete: ${result.added} added, ${result.updated} updated, ${result.deleted} deleted, ${result.skipped} unchanged, ${result.errors} errors`;
           ctx.logger.info?.(summary);
           console.log(summary);
@@ -861,6 +938,8 @@ const memoryCogneePlugin = {
         .description("Show Cognee sync state (files indexed, dataset info)")
         .action(async () => {
           await stateReady;
+          const datasetName = resolveDatasetNameForAgent(cfg, undefined);
+          const syncIndex = await ensureDatasetContext(datasetName);
 
           const entryCount = Object.keys(syncIndex.entries).length;
           const entriesWithDataId = Object.values(syncIndex.entries).filter((e) => e.dataId).length;
@@ -878,8 +957,8 @@ const memoryCogneePlugin = {
           }
 
           const lines = [
-            `Dataset: ${syncIndex.datasetName ?? cfg.datasetName}`,
-            `Dataset ID: ${datasetId ?? syncIndex.datasetId ?? "(not set)"}`,
+            `Dataset: ${syncIndex.datasetName ?? datasetName}`,
+            `Dataset ID: ${datasetState[datasetName] ?? syncIndex.datasetId ?? "(not set)"}`,
             `Indexed files: ${entryCount} (${entriesWithDataId} with data ID)`,
             `Workspace files: ${files.length}`,
             `New (unindexed): ${newCount}`,
@@ -902,7 +981,7 @@ const memoryCogneePlugin = {
           resolvedWorkspaceDir = ctx.workspaceDir || process.cwd();
 
           try {
-            const result = await runSync(resolvedWorkspaceDir, ctx.logger);
+            const result = await runSync(resolvedWorkspaceDir, ctx.logger, undefined);
             ctx.logger.info?.(
               `cognee-openclaw: auto-sync complete: ${result.added} added, ${result.updated} updated, ${result.deleted} deleted, ${result.skipped} unchanged`,
             );
@@ -926,6 +1005,9 @@ const memoryCogneePlugin = {
           api.logger.debug?.("cognee-openclaw: skipping recall (prompt too short)");
           return;
         }
+        const datasetName = resolveDatasetNameForAgent(cfg, ctx.agentId);
+        const syncIndex = await ensureDatasetContext(datasetName);
+        const datasetId = datasetState[datasetName] || syncIndex.datasetId;
         if (!datasetId) {
           api.logger.debug?.("cognee-openclaw: skipping recall (no datasetId)");
           return;
@@ -961,7 +1043,7 @@ const memoryCogneePlugin = {
           );
 
           api.logger.info?.(
-            `cognee-openclaw: injecting ${filtered.length} memories for session ${ctx.sessionKey ?? "unknown"}`,
+            `cognee-openclaw: injecting ${filtered.length} memories for session ${ctx.sessionKey ?? "unknown"} from dataset ${datasetName}`,
           );
 
           return {
@@ -983,19 +1065,19 @@ const memoryCogneePlugin = {
         if (!event.success) return;
 
         await stateReady;
+        const datasetName = resolveDatasetNameForAgent(cfg, ctx.agentId);
 
-        // Reload sync index from disk to pick up changes made by CLI or other processes
+        // Reload sync indexes from disk to pick up changes made by CLI or other processes.
         try {
-          const freshIndex = await loadSyncIndex();
-          syncIndex.entries = freshIndex.entries;
-          if (freshIndex.datasetId) syncIndex.datasetId = freshIndex.datasetId;
-          if (freshIndex.datasetName) syncIndex.datasetName = freshIndex.datasetName;
+          syncIndexes = await loadSyncIndexesByDataset();
         } catch {
-          // Fall through with existing in-memory index
+          // Fall through with existing in-memory indexes
         }
 
+        const syncIndex = await ensureDatasetContext(datasetName);
+
         // Need workspace dir to find memory files
-        const workspaceDir = resolvedWorkspaceDir || process.cwd();
+        const workspaceDir = ctx.workspaceDir || resolvedWorkspaceDir || process.cwd();
 
         try {
           // Collect current files and find changed ones
@@ -1011,12 +1093,15 @@ const memoryCogneePlugin = {
 
           if (changedFiles.length === 0 && !hasDeletedFiles) return;
 
-          api.logger.info?.(`cognee-openclaw: detected ${changedFiles.length} changed file(s)${hasDeletedFiles ? " + deletions" : ""}, syncing...`);
+          api.logger.info?.(`cognee-openclaw: detected ${changedFiles.length} changed file(s)${hasDeletedFiles ? " + deletions" : ""}, syncing to ${datasetName}...`);
 
           const result = await syncFiles(client, changedFiles, files, syncIndex, cfg, api.logger);
           if (result.datasetId) {
-            datasetId = result.datasetId;
+            datasetState[datasetName] = result.datasetId;
+            await saveDatasetState(datasetState);
           }
+          syncIndexes[datasetName] = syncIndex;
+          await saveSyncIndexesByDataset(syncIndexes);
 
           api.logger.info?.(
             `cognee-openclaw: post-agent sync: ${result.added} added, ${result.updated} updated, ${result.deleted} deleted`,
@@ -1032,5 +1117,5 @@ const memoryCogneePlugin = {
 export default memoryCogneePlugin;
 
 // Exports for testing
-export { CogneeClient, syncFiles };
+export { CogneeClient, resolveDatasetNameForAgent, syncFiles };
 export type { CogneeDeleteMode, CogneePluginConfig, MemoryFile, SyncIndex, SyncResult };

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -26,6 +26,13 @@
         "type": "string",
         "description": "Cognee dataset name to store memories in"
       },
+      "datasetNames": {
+        "type": "object",
+        "description": "Per-agent dataset names keyed by agent id (falls back to datasetName)",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
       "searchType": {
         "type": "string",
         "enum": [
@@ -103,6 +110,10 @@
     "datasetName": {
       "label": "Dataset Name",
       "placeholder": "openclaw"
+    },
+    "datasetNames": {
+      "label": "Dataset Names (per-agent)",
+      "placeholder": "{\"asst\":\"asst\",\"lawyer\":\"lawyer\"}"
     },
     "searchType": {
       "label": "Search Type",


### PR DESCRIPTION
## Summary
- add per-agent Cognee dataset routing for the OpenClaw integration
- preserve the existing single-dataset behavior as the default fallback
- document why separate datasets matter for agent memory isolation and show mixed sharing and fallback examples
- add tests covering default fallback, dedicated datasets, explicit sharing, and omitted-agent fallback to datasetName

## Why
When multiple agents share one OpenClaw gateway, using a single Cognee dataset for long-term memory can leak memories across agents. That breaks the intended boundary between agent sessions and long-term memory. This change lets users choose whether agents should stay isolated, share a dataset intentionally, or fall back to a shared default.

## Validation
- npx tsc --noEmit
- npm test -- --runInBand

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.