### PR TITLE
Feat/openclaw permission grants

### DIFF
--- a/integrations/openclaw/__tests__/test_syncFiles.ts
+++ b/integrations/openclaw/__tests__/test_syncFiles.ts
@@ -83,7 +83,6 @@ function baseCfg(overrides: Partial<CogneePluginConfig> = {}): Required<CogneePl
     ingestionTimeoutMs: 300000,
     enablePermissionGrants: false,
     grantReadUserIds: [],
-    permissionEndpointPath: "/api/v1/datasets/permissions",
     ...overrides,
   } as Required<CogneePluginConfig>;
 }

--- a/integrations/openclaw/__tests__/test_syncFiles.ts
+++ b/integrations/openclaw/__tests__/test_syncFiles.ts
@@ -81,6 +81,9 @@ function baseCfg(overrides: Partial<CogneePluginConfig> = {}): Required<CogneePl
     autoMemify: false,
     requestTimeoutMs: 30000,
     ingestionTimeoutMs: 300000,
+    enablePermissionGrants: false,
+    grantReadUserIds: [],
+    permissionEndpointPath: "/api/v1/datasets/permissions",
     ...overrides,
   } as Required<CogneePluginConfig>;
 }
@@ -382,6 +385,39 @@ describe("syncFiles", () => {
 
     expect(mockAdd).toHaveBeenCalledWith(expect.objectContaining({ datasetName: "acme-company" }));
   });
+
+  it("calls onNewDataset callback when a new dataset is created", async () => {
+    const files = [createFile("new.md", "content")];
+    const syncIndex: SyncIndex = { entries: {} };
+    mockAdd.mockResolvedValue({ datasetId: "ds1", datasetName: "test", dataId: "id1" });
+    const onNewDataset = jest.fn().mockResolvedValue(undefined);
+
+    await syncFiles(client, files, files, syncIndex, cfg, logger, undefined, onNewDataset);
+
+    expect(onNewDataset).toHaveBeenCalledWith("ds1");
+  });
+
+  it("does not call onNewDataset callback on updates", async () => {
+    const files = [createFile("existing.md", "new content")];
+    const syncIndex: SyncIndex = { entries: { "existing.md": { hash: "old-hash", dataId: "id1" } }, datasetId: "ds1" };
+    mockUpdate.mockResolvedValue({ datasetId: "ds1", datasetName: "test", dataId: "id1" });
+    const onNewDataset = jest.fn().mockResolvedValue(undefined);
+
+    await syncFiles(client, files, files, syncIndex, cfg, logger, undefined, onNewDataset);
+
+    expect(onNewDataset).not.toHaveBeenCalled();
+  });
+
+  it("does not call onNewDataset callback when datasetId already known", async () => {
+    const files = [createFile("new.md", "content")];
+    const syncIndex: SyncIndex = { entries: {}, datasetId: "ds1" };
+    mockAdd.mockResolvedValue({ datasetId: "ds1", datasetName: "test", dataId: "id1" });
+    const onNewDataset = jest.fn().mockResolvedValue(undefined);
+
+    await syncFiles(client, files, files, syncIndex, cfg, logger, undefined, onNewDataset);
+
+    expect(onNewDataset).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -447,6 +483,19 @@ describe("syncFilesScoped", () => {
     expect(result.added).toBe(1);
     expect(result.updated).toBe(1);
     expect(result.deleted).toBe(1);
+  });
+
+  it("forwards onNewDataset callback with scope", async () => {
+    const files = [
+      createFile("memory/company/policy.md", "company policy"),
+    ];
+    const scopedIndexes: ScopedSyncIndexes = {};
+    mockAdd.mockResolvedValue({ datasetId: "ds-company", datasetName: "acme-company", dataId: "cid1" });
+    const onNewDataset = jest.fn().mockResolvedValue(undefined);
+
+    await syncFilesScoped(client, files, files, scopedIndexes, cfg, logger, onNewDataset);
+
+    expect(onNewDataset).toHaveBeenCalledWith("ds-company", "company");
   });
 
   it("skips scopes with no changes", async () => {

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -143,6 +143,19 @@
       "searchPrompt": {
         "type": "string",
         "description": "System prompt sent to Cognee to guide search query processing (default: '')"
+      },
+      "enablePermissionGrants": {
+        "type": "boolean",
+        "description": "Automatically grant read permissions to specified users when datasets are created (default: false)"
+      },
+      "grantReadUserIds": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Cognee user IDs (email or UUID) to grant read access on created datasets (or set COGNEE_GRANT_READ_USER_IDS as comma-separated)"
+      },
+      "permissionEndpointPath": {
+        "type": "string",
+        "description": "Cognee API path for dataset permission grants (default: /api/v1/datasets/permissions)"
       }
     }
   },
@@ -241,6 +254,16 @@
     "ingestionTimeoutMs": {
       "label": "Ingestion Timeout (ms)",
       "placeholder": "300000"
+    },
+    "enablePermissionGrants": {
+      "label": "Enable Permission Grants"
+    },
+    "grantReadUserIds": {
+      "label": "Grant Read to User IDs"
+    },
+    "permissionEndpointPath": {
+      "label": "Permission Endpoint Path",
+      "placeholder": "/api/v1/datasets/permissions"
     }
   }
 }

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -153,10 +153,6 @@
         "items": { "type": "string" },
         "description": "Cognee user IDs (email or UUID) to grant read access on created datasets (or set COGNEE_GRANT_READ_USER_IDS as comma-separated)"
       },
-      "permissionEndpointPath": {
-        "type": "string",
-        "description": "Cognee API path for dataset permission grants (default: /api/v1/datasets/permissions)"
-      }
     }
   },
   "uiHints": {
@@ -261,9 +257,5 @@
     "grantReadUserIds": {
       "label": "Grant Read to User IDs"
     },
-    "permissionEndpointPath": {
-      "label": "Permission Endpoint Path",
-      "placeholder": "/api/v1/datasets/permissions"
-    }
   }
 }

--- a/integrations/openclaw/src/client.ts
+++ b/integrations/openclaw/src/client.ts
@@ -130,6 +130,16 @@ export class CogneeHttpClient {
           }
         }
 
+        if (response.status === 403) {
+          const errorText = await response.text();
+          console.warn(
+            `cognee-openclaw: 403 Forbidden on ${path}. Response: ${errorText}. ` +
+            `This typically means the authenticated user lacks permission on the target dataset. ` +
+            `Enable permission grants in plugin config or check ENABLE_BACKEND_ACCESS_CONTROL on the Cognee server.`
+          );
+          throw new Error(`Cognee request forbidden (403): ${errorText}`);
+        }
+
         if (!response.ok) {
           const errorText = await response.text();
           throw new Error(`Cognee request failed (${response.status}): ${errorText}`);
@@ -310,6 +320,71 @@ export class CogneeHttpClient {
     // Response is a dict keyed by dataset ID: { [datasetId]: "DATASET_PROCESSING_COMPLETED" }
     const status = resp[datasetId] ?? Object.values(resp)[0] ?? "unknown";
     return status.toLowerCase().replace("dataset_processing_", "");
+  }
+
+  // -- Permissions ------------------------------------------------------------
+
+  async grantPermission(params: {
+    datasetId: string;
+    recipientId: string;
+    permissionType?: string;
+    endpointPath?: string;
+  }): Promise<{ granted: boolean; error?: string }> {
+    const endpoint = params.endpointPath || "/api/v1/datasets/permissions";
+    try {
+      await this.fetchJson(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          dataset_id: params.datasetId,
+          recipient_id: params.recipientId,
+          permission_type: params.permissionType ?? "read",
+        }),
+      }, this.timeoutMs, 0); // 0 retries — permission grants are not critical path
+      return { granted: true };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      // 404/405 means the endpoint doesn't exist yet — expected, not an error
+      if (msg.includes("404") || msg.includes("405") || msg.includes("Not Found") || msg.includes("Method Not Allowed")) {
+        return { granted: false, error: "permission endpoint not available" };
+      }
+      // 409 likely means permission already exists — treat as success (idempotent)
+      if (msg.includes("409") || msg.includes("Conflict") || msg.includes("already exists")) {
+        return { granted: true };
+      }
+      return { granted: false, error: msg };
+    }
+  }
+
+  async grantPermissions(params: {
+    datasetId: string;
+    recipientIds: string[];
+    permissionType?: string;
+    endpointPath?: string;
+    logger?: { info?: (msg: string) => void; warn?: (msg: string) => void };
+  }): Promise<void> {
+    if (params.recipientIds.length === 0) return;
+
+    let endpointAvailable = true;
+    for (const recipientId of params.recipientIds) {
+      if (!endpointAvailable) break;
+
+      const result = await this.grantPermission({
+        datasetId: params.datasetId,
+        recipientId,
+        permissionType: params.permissionType,
+        endpointPath: params.endpointPath,
+      });
+
+      if (result.granted) {
+        params.logger?.info?.(`cognee-openclaw: granted ${params.permissionType ?? "read"} on dataset ${params.datasetId} to ${recipientId}`);
+      } else if (result.error === "permission endpoint not available") {
+        params.logger?.info?.("cognee-openclaw: permission endpoint not available on this Cognee version, skipping grants");
+        endpointAvailable = false;
+      } else {
+        params.logger?.warn?.(`cognee-openclaw: failed to grant permission to ${recipientId}: ${result.error}`);
+      }
+    }
   }
 }
 

--- a/integrations/openclaw/src/client.ts
+++ b/integrations/openclaw/src/client.ts
@@ -328,23 +328,23 @@ export class CogneeHttpClient {
     datasetId: string;
     recipientId: string;
     permissionType?: string;
-    endpointPath?: string;
   }): Promise<{ granted: boolean; error?: string }> {
-    const endpoint = params.endpointPath || "/api/v1/datasets/permissions";
+    const permissionName = params.permissionType ?? "read";
+    // Cognee endpoint: POST /api/v1/permissions/datasets/{principal_id}
+    // with query params: permission_name, dataset_ids
+    const query = new URLSearchParams({
+      permission_name: permissionName,
+      dataset_ids: params.datasetId,
+    });
+    const endpoint = `/api/v1/permissions/datasets/${params.recipientId}?${query.toString()}`;
     try {
       await this.fetchJson(endpoint, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          dataset_id: params.datasetId,
-          recipient_id: params.recipientId,
-          permission_type: params.permissionType ?? "read",
-        }),
       }, this.timeoutMs, 0); // 0 retries — permission grants are not critical path
       return { granted: true };
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
-      // 404/405 means the endpoint doesn't exist yet — expected, not an error
+      // 404/405 means the endpoint doesn't exist on older Cognee versions
       if (msg.includes("404") || msg.includes("405") || msg.includes("Not Found") || msg.includes("Method Not Allowed")) {
         return { granted: false, error: "permission endpoint not available" };
       }
@@ -360,7 +360,6 @@ export class CogneeHttpClient {
     datasetId: string;
     recipientIds: string[];
     permissionType?: string;
-    endpointPath?: string;
     logger?: { info?: (msg: string) => void; warn?: (msg: string) => void };
   }): Promise<void> {
     if (params.recipientIds.length === 0) return;
@@ -373,7 +372,6 @@ export class CogneeHttpClient {
         datasetId: params.datasetId,
         recipientId,
         permissionType: params.permissionType,
-        endpointPath: params.endpointPath,
       });
 
       if (result.granted) {

--- a/integrations/openclaw/src/config.ts
+++ b/integrations/openclaw/src/config.ts
@@ -97,8 +97,6 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
   const grantReadUserIds = Array.isArray(raw.grantReadUserIds)
     ? raw.grantReadUserIds
     : (process.env.COGNEE_GRANT_READ_USER_IDS?.split(",").map(s => s.trim()).filter(Boolean) ?? []);
-  const permissionEndpointPath = raw.permissionEndpointPath?.trim()
-    || "/api/v1/datasets/permissions";
 
   return {
     baseUrl, apiKey, username, password, datasetName,
@@ -109,6 +107,6 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
     maxResults, minScore, maxTokens,
     autoRecall, autoIndex, autoCognify, autoMemify,
     requestTimeoutMs, ingestionTimeoutMs,
-    enablePermissionGrants, grantReadUserIds, permissionEndpointPath,
+    enablePermissionGrants, grantReadUserIds,
   };
 }

--- a/integrations/openclaw/src/config.ts
+++ b/integrations/openclaw/src/config.ts
@@ -91,6 +91,15 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
   const enableSessions = typeof raw.enableSessions === "boolean" ? raw.enableSessions : true;
   const persistSessionsAfterEnd = typeof raw.persistSessionsAfterEnd === "boolean" ? raw.persistSessionsAfterEnd : true;
 
+  // Access control
+  const enablePermissionGrants = typeof raw.enablePermissionGrants === "boolean"
+    ? raw.enablePermissionGrants : false;
+  const grantReadUserIds = Array.isArray(raw.grantReadUserIds)
+    ? raw.grantReadUserIds
+    : (process.env.COGNEE_GRANT_READ_USER_IDS?.split(",").map(s => s.trim()).filter(Boolean) ?? []);
+  const permissionEndpointPath = raw.permissionEndpointPath?.trim()
+    || "/api/v1/datasets/permissions";
+
   return {
     baseUrl, apiKey, username, password, datasetName,
     companyDataset, userDatasetPrefix, agentDatasetPrefix, userId, agentId,
@@ -100,5 +109,6 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
     maxResults, minScore, maxTokens,
     autoRecall, autoIndex, autoCognify, autoMemify,
     requestTimeoutMs, ingestionTimeoutMs,
+    enablePermissionGrants, grantReadUserIds, permissionEndpointPath,
   };
 }

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -42,6 +42,19 @@ const memoryCogneePlugin = {
 
     let resolvedWorkspaceDir: string | undefined;
 
+    // Permission grant callback (fires when a new dataset is created)
+    const onNewDataset = cfg.enablePermissionGrants && cfg.grantReadUserIds.length > 0
+      ? async (datasetId: string) => {
+          await client.grantPermissions({
+            datasetId,
+            recipientIds: cfg.grantReadUserIds,
+            permissionType: "read",
+            endpointPath: cfg.permissionEndpointPath,
+            logger: api.logger,
+          });
+        }
+      : undefined;
+
     // Load persisted state on startup
     const stateReady = Promise.all([
       loadDatasetState()
@@ -118,9 +131,9 @@ const memoryCogneePlugin = {
       logger.info?.(`cognee-openclaw: found ${files.length} memory file(s), syncing...`);
 
       if (multiScope) {
-        return syncFilesScoped(client, files, files, scopedIndexes, cfg, logger);
+        return syncFilesScoped(client, files, files, scopedIndexes, cfg, logger, onNewDataset ? (dsId) => onNewDataset(dsId) : undefined);
       } else {
-        const result = await syncFiles(client, files, files, syncIndex, cfg, logger);
+        const result = await syncFiles(client, files, files, syncIndex, cfg, logger, undefined, onNewDataset);
         if (result.datasetId) datasetId = result.datasetId;
         return result;
       }
@@ -286,6 +299,38 @@ const memoryCogneePlugin = {
           }
           process.exit(0);
         });
+
+      cognee
+        .command("permissions")
+        .description("Grant read permissions on all known datasets to configured users")
+        .action(async () => {
+          if (!cfg.enablePermissionGrants) {
+            console.log("Permission grants are disabled. Set enablePermissionGrants: true in plugin config.");
+            process.exit(1);
+          }
+          if (cfg.grantReadUserIds.length === 0) {
+            console.log("No users configured. Set grantReadUserIds in plugin config.");
+            process.exit(1);
+          }
+          const state = await loadDatasetState();
+          const datasets = Object.entries(state);
+          if (datasets.length === 0) {
+            console.log("No datasets found. Run 'openclaw cognee index' first.");
+            process.exit(0);
+          }
+          for (const [dsName, dsId] of datasets) {
+            console.log(`\nDataset: ${dsName} (${dsId})`);
+            await client.grantPermissions({
+              datasetId: dsId,
+              recipientIds: cfg.grantReadUserIds,
+              permissionType: "read",
+              endpointPath: cfg.permissionEndpointPath,
+              logger: { info: (m) => console.log(`  ${m}`), warn: (m) => console.log(`  WARN: ${m}`) },
+            });
+          }
+          console.log("\nDone.");
+          process.exit(0);
+        });
     }, { commands: ["cognee"] });
 
     // ------------------------------------------------------------------
@@ -315,6 +360,24 @@ const memoryCogneePlugin = {
             ctx.logger.info?.(`cognee-openclaw: auto-sync complete: ${result.added} added, ${result.updated} updated, ${result.deleted} deleted, ${result.skipped} unchanged`);
           } catch (error) {
             ctx.logger.warn?.(`cognee-openclaw: auto-sync failed: ${String(error)}`);
+          }
+
+          // Re-grant permissions on all known datasets (idempotent)
+          if (cfg.enablePermissionGrants && cfg.grantReadUserIds.length > 0) {
+            try {
+              const state = await loadDatasetState();
+              for (const [, dsId] of Object.entries(state)) {
+                await client.grantPermissions({
+                  datasetId: dsId,
+                  recipientIds: cfg.grantReadUserIds,
+                  permissionType: "read",
+                  endpointPath: cfg.permissionEndpointPath,
+                  logger: ctx.logger,
+                });
+              }
+            } catch (error) {
+              ctx.logger.warn?.(`cognee-openclaw: startup permission grants failed: ${String(error)}`);
+            }
           }
         },
       });
@@ -516,7 +579,7 @@ const memoryCogneePlugin = {
             if (!hasChanges) return;
 
             api.logger.info?.("cognee-openclaw: detected changes, syncing across scopes...");
-            const result = await syncFilesScoped(client, files, files, scopedIndexes, cfg, api.logger);
+            const result = await syncFilesScoped(client, files, files, scopedIndexes, cfg, api.logger, onNewDataset ? (dsId) => onNewDataset(dsId) : undefined);
             api.logger.info?.(`cognee-openclaw: post-agent sync: ${result.added} added, ${result.updated} updated, ${result.deleted} deleted`);
           } else {
             try {
@@ -538,7 +601,7 @@ const memoryCogneePlugin = {
             if (changedFiles.length === 0 && !hasDeletedFiles) return;
 
             api.logger.info?.(`cognee-openclaw: detected ${changedFiles.length} changed file(s)${hasDeletedFiles ? " + deletions" : ""}, syncing...`);
-            const result = await syncFiles(client, changedFiles, files, syncIndex, cfg, api.logger);
+            const result = await syncFiles(client, changedFiles, files, syncIndex, cfg, api.logger, undefined, onNewDataset);
             if (result.datasetId) datasetId = result.datasetId;
             api.logger.info?.(`cognee-openclaw: post-agent sync: ${result.added} added, ${result.updated} updated, ${result.deleted} deleted`);
           }

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -49,7 +49,7 @@ const memoryCogneePlugin = {
             datasetId,
             recipientIds: cfg.grantReadUserIds,
             permissionType: "read",
-            endpointPath: cfg.permissionEndpointPath,
+
             logger: api.logger,
           });
         }
@@ -324,7 +324,7 @@ const memoryCogneePlugin = {
               datasetId: dsId,
               recipientIds: cfg.grantReadUserIds,
               permissionType: "read",
-              endpointPath: cfg.permissionEndpointPath,
+  
               logger: { info: (m) => console.log(`  ${m}`), warn: (m) => console.log(`  WARN: ${m}`) },
             });
           }
@@ -371,7 +371,7 @@ const memoryCogneePlugin = {
                   datasetId: dsId,
                   recipientIds: cfg.grantReadUserIds,
                   permissionType: "read",
-                  endpointPath: cfg.permissionEndpointPath,
+      
                   logger: ctx.logger,
                 });
               }

--- a/integrations/openclaw/src/sync.ts
+++ b/integrations/openclaw/src/sync.ts
@@ -15,6 +15,7 @@ export async function syncFiles(
   cfg: Required<CogneePluginConfig>,
   logger: { info?: (msg: string) => void; warn?: (msg: string) => void },
   overrideDatasetName?: string,
+  onNewDataset?: (datasetId: string) => Promise<void>,
 ): Promise<SyncResult & { datasetId?: string }> {
   const result: SyncResult = { added: 0, updated: 0, skipped: 0, errors: 0, deleted: 0 };
   const dsName = overrideDatasetName || cfg.datasetName;
@@ -67,6 +68,7 @@ export async function syncFiles(
         const state = await loadDatasetState();
         state[dsName] = response.datasetId;
         await saveDatasetState(state);
+        await onNewDataset?.(response.datasetId);
       }
 
       syncIndex.entries[file.path] = { hash: file.hash, dataId: response.dataId };
@@ -137,6 +139,7 @@ export async function syncFilesScoped(
   scopedIndexes: ScopedSyncIndexes,
   cfg: Required<CogneePluginConfig>,
   logger: { info?: (msg: string) => void; warn?: (msg: string) => void },
+  onNewDataset?: (datasetId: string, scope: MemoryScope) => Promise<void>,
 ): Promise<SyncResult & { datasetIds: Record<MemoryScope, string | undefined> }> {
   const totalResult: SyncResult = { added: 0, updated: 0, skipped: 0, errors: 0, deleted: 0 };
   const datasetIds: Record<MemoryScope, string | undefined> = { company: undefined, user: undefined, agent: undefined };
@@ -182,7 +185,10 @@ export async function syncFilesScoped(
 
     logger.info?.(`cognee-openclaw: [${scope}] syncing ${scopeChanged.length} changed file(s) to dataset "${dsName}"${hasDeletedFiles ? " + deletions" : ""}`);
 
-    const result = await syncFiles(client, scopeChanged, scopeFull, scopeIndex, cfg, logger, dsName);
+    const result = await syncFiles(
+      client, scopeChanged, scopeFull, scopeIndex, cfg, logger, dsName,
+      onNewDataset ? (dsId) => onNewDataset(dsId, scope) : undefined,
+    );
     totalResult.added += result.added;
     totalResult.updated += result.updated;
     totalResult.skipped += result.skipped;

--- a/integrations/openclaw/src/types.ts
+++ b/integrations/openclaw/src/types.ts
@@ -71,6 +71,11 @@ export type CogneePluginConfig = {
   // --- Timeouts ---
   requestTimeoutMs?: number;
   ingestionTimeoutMs?: number;
+
+  // --- Access control ---
+  enablePermissionGrants?: boolean;
+  grantReadUserIds?: string[];
+  permissionEndpointPath?: string;
 };
 
 export type CogneeAddResponse = {

--- a/integrations/openclaw/src/types.ts
+++ b/integrations/openclaw/src/types.ts
@@ -75,7 +75,6 @@ export type CogneePluginConfig = {
   // --- Access control ---
   enablePermissionGrants?: boolean;
   grantReadUserIds?: string[];
-  permissionEndpointPath?: string;
 };
 
 export type CogneeAddResponse = {


### PR DESCRIPTION
  ---
  ## Description                                                                                                                            
                                                                                                                                         
  When multiple OpenClaw instances share a Cognee backend with ENABLE_BACKEND_ACCESS_CONTROL=True, users hit 403 errors because the plugin creates datasets but never grants cross-user permissions. Even "superuser" accounts get blocked since Cognee uses explicit grant-based permissions with no admin bypass.
                                                                                                                                         
  This PR fixes that by:
  - Adding 403 debug logging with the actual response body so users can see which dataset/permission is missing
  - Adding auto-grant of read permissions when datasets are created, using the existing POST /api/v1/permissions/datasets/{principal_id} 
  Cognee endpoint                                                                                                                       
  - Adding a cognee permissions CLI command for manual permission management                                                             
  - Re-granting permissions on startup for pre-existing datasets (idempotent)
                                                                                                                                         
  The feature is opt-in via enablePermissionGrants: true and grantReadUserIds config.                                                    
                                                                                                                                         
  ## Acceptance Criteria                                                                                                                    
                                                                                                                                         
  - 403 errors include actionable diagnostic info (response body + guidance)                                                             
  - When enablePermissionGrants is true, read access is granted to configured user IDs on dataset creation
  - Grants are idempotent — re-running on existing datasets is safe                                                                      
  - If the Cognee permission endpoint is unavailable (older versions), the plugin logs and continues without blocking                    
  - openclaw cognee permissions CLI command grants permissions on all known datasets                                                     
  - All existing tests pass, new tests cover the callback behavior
  - Test manually on openclaw    

## Type of Change
<!-- Please check the relevant option -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Code refactoring
- [ ] Other (please specify):

## Screenshots
<!-- ADD SCREENSHOT OF LOCAL TESTS PASSING-->

## Pre-submission Checklist
<!-- Please check all boxes that apply before submitting your PR -->
- [x] **I have tested my changes thoroughly before submitting this PR** (See `CONTRIBUTING.md`)
- [x] **This PR contains minimal changes necessary to address the issue/feature**
- [x] My code follows the project's coding standards and style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if applicable)
- [x] All new and existing tests pass
- [x] I have searched existing PRs to ensure this change hasn't been submitted already
- [] I have linked any relevant issues in the description
- [x] My commits have clear and descriptive messages

## DCO Affirmation
I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.
