### PR TITLE
fix(openclaw): migrate auto-recall hook from before_agent_start to before_prompt_build

### DIFF
--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -325,7 +325,7 @@ const memoryCogneePlugin = {
     // ------------------------------------------------------------------
 
     if (cfg.autoRecall) {
-      api.on("before_agent_start", async (event, ctx) => {
+      api.on("before_prompt_build", async (event, ctx) => {
         await stateReady;
 
         if (!event.prompt || event.prompt.length < 5) {


### PR DESCRIPTION
## Summary

`before_agent_start` is a legacy compatibility hook that may run in either the model-resolve or prompt-build phase. The auto-recall hook in this plugin only reads `event.prompt` and returns `prependContext` — that is purely a prompt-mutation operation, which maps exactly to `before_prompt_build`.

**Why this matters:**
- `before_prompt_build` runs after session load (with `messages` available), which is when `event.prompt` is guaranteed to be populated
- `before_model_resolve` runs pre-session (no messages) — the wrong phase for prompt injection
- OpenClaw CHANGELOG #23289 fixed a bug where `before_agent_start` was being called twice per turn (once in each phase), causing duplicate Cognee API calls. Migrating to the explicit hook eliminates that ambiguity entirely
- CHANGELOG #36567 added `plugins.entries.<id>.hooks.allowPromptInjection`: when `false`, prompt-mutating fields from `before_agent_start` are silently stripped. On `before_prompt_build`, the same flag explicitly blocks the hook — correct behavior, no silent failures

## Change

`integrations/openclaw/src/plugin.ts` line 328:

```diff
- api.on("before_agent_start", async (event, ctx) => {
+ api.on("before_prompt_build", async (event, ctx) => {
```

No other changes. The hook body is identical — `before_prompt_build` accepts the same `event.prompt` input and `prependContext` return value.

## References

- OpenClaw docs: `docs/concepts/agent-loop.md` — hook semantics
- OpenClaw CHANGELOG entries: #23289, #36567