### PR TITLE
Fix recall injection: use prependSystemContext instead of prependContext

### DIFF
--- a/integrations/openclaw/src/config.ts
+++ b/integrations/openclaw/src/config.ts
@@ -11,6 +11,7 @@ export const DEFAULT_DELETE_MODE = "soft" as const;
 export const DEFAULT_MAX_RESULTS = 3;
 export const DEFAULT_MIN_SCORE = 0.3;
 export const DEFAULT_MAX_TOKENS = 512;
+export const DEFAULT_RECALL_INJECTION_POSITION = "prependSystemContext" as const;
 export const DEFAULT_AUTO_RECALL = true;
 export const DEFAULT_AUTO_INDEX = true;
 export const DEFAULT_AUTO_COGNIFY = true;
@@ -87,6 +88,12 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
   const defaultWriteScope = raw.defaultWriteScope || DEFAULT_WRITE_SCOPE;
   const scopeRouting = Array.isArray(raw.scopeRouting) ? raw.scopeRouting : DEFAULT_SCOPE_ROUTING;
 
+  // Recall injection
+  const validPositions = ["prependSystemContext", "appendSystemContext", "prependContext"] as const;
+  const recallInjectionPosition = raw.recallInjectionPosition && validPositions.includes(raw.recallInjectionPosition)
+    ? raw.recallInjectionPosition
+    : DEFAULT_RECALL_INJECTION_POSITION;
+
   // Session
   const enableSessions = typeof raw.enableSessions === "boolean" ? raw.enableSessions : true;
   const persistSessionsAfterEnd = typeof raw.persistSessionsAfterEnd === "boolean" ? raw.persistSessionsAfterEnd : true;
@@ -95,6 +102,7 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
     baseUrl, apiKey, username, password, datasetName,
     companyDataset, userDatasetPrefix, agentDatasetPrefix, userId, agentId,
     recallScopes, defaultWriteScope, scopeRouting,
+    recallInjectionPosition,
     enableSessions, persistSessionsAfterEnd,
     searchType, searchPrompt, deleteMode,
     maxResults, minScore, maxTokens,

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -404,7 +404,7 @@ const memoryCogneePlugin = {
             const totalResults = Object.values(scopeResults).reduce((sum, arr) => sum + arr.length, 0);
             api.logger.info?.(`cognee-openclaw: injecting ${totalResults} memories across ${Object.keys(scopeResults).length} scope(s)`);
 
-            return { prependContext: `<cognee_memories>\n${sections.join("\n")}\n</cognee_memories>` };
+            return { [cfg.recallInjectionPosition]: `<cognee_memories>\n${sections.join("\n")}\n</cognee_memories>` };
           } else {
             // Legacy single-scope
             const results = await client.search({
@@ -431,7 +431,7 @@ const memoryCogneePlugin = {
             );
 
             api.logger.info?.(`cognee-openclaw: injecting ${filtered.length} memories`);
-            return { prependContext: `<cognee_memories>\nRelevant memories:\n${payload}\n</cognee_memories>` };
+            return { [cfg.recallInjectionPosition]: `<cognee_memories>\nRelevant memories:\n${payload}\n</cognee_memories>` };
           }
         } catch (error) {
           api.logger.warn?.(`cognee-openclaw: recall failed: ${String(error)}`);

--- a/integrations/openclaw/src/types.ts
+++ b/integrations/openclaw/src/types.ts
@@ -62,6 +62,10 @@ export type CogneePluginConfig = {
   minScore?: number;
   maxTokens?: number;
 
+  // --- Recall injection ---
+  /** Where recalled memories are injected in the prompt. Default: prependSystemContext */
+  recallInjectionPosition?: "prependSystemContext" | "appendSystemContext" | "prependContext";
+
   // --- Automation ---
   autoRecall?: boolean;
   autoIndex?: boolean;


### PR DESCRIPTION
## Summary
- Recalled memories were injected via `prependContext`, which concatenates onto the user prompt — causing context pollution (memories as visible conversation turns) and behavioral contamination (LLM treating memories as explicit user instructions that can override safety gates)
- Switch both recall return paths in `plugin.ts` to use `prependSystemContext`, so memories are injected as system-level context invisible to the conversation transcript
- Add configurable `recallInjectionPosition` option (`prependSystemContext` | `appendSystemContext` | `prependContext`) for flexibility, defaulting to `prependSystemContext`

## Test plan
- [ ] Verify recalled memories no longer appear as visible conversation turns in OpenClaw
- [ ] Confirm memories are still injected and influence agent behavior as system context
- [ ] Test `recallInjectionPosition: "appendSystemContext"` config override
- [ ] Test `recallInjectionPosition: "prependContext"` for backwards compatibility
- [ ] Run `npx tsc --noEmit --skipLibCheck` on the openclaw package

🤖 Generated with [Claude Code](https://claude.com/claude-code)