### PR TITLE
Expose recall injection position and restore memory flush in cognee-openclaw

### DIFF
--- a/integrations/openclaw/__tests__/test_flushPlan.ts
+++ b/integrations/openclaw/__tests__/test_flushPlan.ts
@@ -1,0 +1,81 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { buildMemoryFlushPlan } from "../src/flush-plan";
+
+function createConfig(overrides?: Partial<OpenClawConfig>): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        compaction: {},
+        userTimezone: "Asia/Shanghai",
+        timeFormat: "24",
+      },
+    },
+    ...overrides,
+  } as OpenClawConfig;
+}
+
+describe("buildMemoryFlushPlan", () => {
+  it("returns a default plan when enabled", () => {
+    const plan = buildMemoryFlushPlan({
+      cfg: createConfig(),
+      nowMs: Date.UTC(2026, 3, 3, 3, 4, 5),
+    });
+
+    expect(plan).not.toBeNull();
+    expect(plan?.relativePath).toBe("memory/2026-04-03.md");
+    expect(plan?.softThresholdTokens).toBe(4000);
+    expect(plan?.forceFlushTranscriptBytes).toBe(2 * 1024 * 1024);
+    expect(plan?.prompt).toContain("NO_REPLY");
+    expect(plan?.prompt).toContain("Current time:");
+    expect(plan?.systemPrompt).toContain("memory/2026-04-03.md");
+  });
+
+  it("returns null when memory flush is disabled", () => {
+    const plan = buildMemoryFlushPlan({
+      cfg: createConfig({
+        agents: {
+          defaults: {
+            compaction: {
+              memoryFlush: { enabled: false },
+            },
+          },
+        },
+      }),
+    });
+
+    expect(plan).toBeNull();
+  });
+
+  it("respects custom compaction thresholds and prompts", () => {
+    const plan = buildMemoryFlushPlan({
+      cfg: createConfig({
+        agents: {
+          defaults: {
+            userTimezone: "UTC",
+            timeFormat: "24",
+            compaction: {
+              reserveTokensFloor: 1234,
+              memoryFlush: {
+                softThresholdTokens: 567,
+                forceFlushTranscriptBytes: "3mb",
+                prompt: "Custom flush for YYYY-MM-DD",
+                systemPrompt: "System flush for YYYY-MM-DD",
+              } as unknown as OpenClawConfig["agents"]["defaults"]["compaction"]["memoryFlush"],
+            },
+          },
+        },
+      }),
+      nowMs: Date.UTC(2026, 3, 3, 0, 0, 0),
+    });
+
+    expect(plan).not.toBeNull();
+    expect(plan?.softThresholdTokens).toBe(567);
+    expect(plan?.forceFlushTranscriptBytes).toBe(3 * 1024 * 1024);
+    expect(plan?.reserveTokensFloor).toBe(1234);
+    expect(plan?.prompt).toContain("Custom flush for 2026-04-03");
+    expect(plan?.prompt).toContain("Store durable memories only in memory/2026-04-03.md");
+    expect(plan?.systemPrompt).toContain("System flush for 2026-04-03");
+    expect(plan?.systemPrompt).toContain("APPEND new content only");
+    expect(plan?.systemPrompt).toContain("NO_REPLY");
+  });
+});

--- a/integrations/openclaw/__tests__/test_pluginAgentEndWorkspace.ts
+++ b/integrations/openclaw/__tests__/test_pluginAgentEndWorkspace.ts
@@ -1,0 +1,49 @@
+import plugin from "../src/plugin";
+
+const mockRegisterMemoryFlushPlan = jest.fn();
+
+function createApi() {
+  const api = {
+    id: "cognee-openclaw",
+    name: "Memory (Cognee)",
+    source: "test",
+    config: {},
+    pluginConfig: {
+      autoIndex: false,
+      autoRecall: false,
+      enableSessions: false,
+    },
+    runtime: {},
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    },
+    registerMemoryFlushPlan: mockRegisterMemoryFlushPlan,
+    registerCli: jest.fn(),
+    registerService: jest.fn(),
+    on: jest.fn(),
+  };
+
+  plugin.register(api as never);
+  return api;
+}
+
+describe("cognee-openclaw memory flush registration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("registers a memory flush plan resolver", () => {
+    createApi();
+
+    expect(mockRegisterMemoryFlushPlan).toHaveBeenCalledTimes(1);
+    const resolver = mockRegisterMemoryFlushPlan.mock.calls[0]?.[0] as
+      | ((params?: { nowMs?: number }) => { relativePath: string } | null)
+      | undefined;
+    expect(resolver).toBeDefined();
+    expect(resolver?.({ nowMs: Date.UTC(2026, 3, 3, 0, 0, 0) })?.relativePath).toBe(
+      "memory/2026-04-03.md",
+    );
+  });
+});

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -116,6 +116,11 @@
         "type": "number",
         "description": "Token cap for recall per scope (default: 512)"
       },
+      "recallInjectionPosition": {
+        "type": "string",
+        "enum": ["prependSystemContext", "appendSystemContext", "prependContext"],
+        "description": "Where recalled memories are injected: prepend to system prompt, append to system prompt, or prepend to prompt context (default: prependSystemContext)"
+      },
       "autoRecall": {
         "type": "boolean",
         "description": "Inject memories before each agent run (default: true)"
@@ -221,6 +226,10 @@
     "maxTokens": {
       "label": "Max Tokens",
       "placeholder": "512"
+    },
+    "recallInjectionPosition": {
+      "label": "Recall Injection Position",
+      "placeholder": "prependSystemContext"
     },
     "autoRecall": {
       "label": "Auto-Recall"

--- a/integrations/openclaw/src/flush-plan.ts
+++ b/integrations/openclaw/src/flush-plan.ts
@@ -1,0 +1,213 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+
+const SILENT_REPLY_TOKEN = "NO_REPLY";
+const DEFAULT_MEMORY_FLUSH_SOFT_TOKENS = 4_000;
+const DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES = 2 * 1024 * 1024;
+const DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR = 20_000;
+
+const MEMORY_FLUSH_TARGET_HINT =
+  "Store durable memories only in memory/YYYY-MM-DD.md (create memory/ if needed).";
+const MEMORY_FLUSH_APPEND_ONLY_HINT =
+  "If memory/YYYY-MM-DD.md already exists, APPEND new content only and do not overwrite existing entries.";
+const MEMORY_FLUSH_READ_ONLY_HINT =
+  "Treat workspace bootstrap/reference files such as MEMORY.md, SOUL.md, TOOLS.md, and AGENTS.md as read-only during this flush; never overwrite, replace, or edit them.";
+const MEMORY_FLUSH_REQUIRED_HINTS = [
+  MEMORY_FLUSH_TARGET_HINT,
+  MEMORY_FLUSH_APPEND_ONLY_HINT,
+  MEMORY_FLUSH_READ_ONLY_HINT,
+];
+
+const DEFAULT_MEMORY_FLUSH_PROMPT = [
+  "Pre-compaction memory flush.",
+  MEMORY_FLUSH_TARGET_HINT,
+  MEMORY_FLUSH_READ_ONLY_HINT,
+  MEMORY_FLUSH_APPEND_ONLY_HINT,
+  "Do NOT create timestamped variant files (e.g., YYYY-MM-DD-HHMM.md); always use the canonical YYYY-MM-DD.md filename.",
+  `If nothing to store, reply with ${SILENT_REPLY_TOKEN}.`,
+].join(" ");
+
+const DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT = [
+  "Pre-compaction memory flush turn.",
+  "The session is near auto-compaction; capture durable memories to disk.",
+  MEMORY_FLUSH_TARGET_HINT,
+  MEMORY_FLUSH_READ_ONLY_HINT,
+  MEMORY_FLUSH_APPEND_ONLY_HINT,
+  `You may reply, but usually ${SILENT_REPLY_TOKEN} is correct.`,
+].join(" ");
+
+type TimeFormatPreference = "12h" | "24h";
+
+type MemoryFlushDefaultsLike = {
+  enabled?: boolean;
+  softThresholdTokens?: number;
+  forceFlushTranscriptBytes?: number | string;
+  prompt?: string;
+  systemPrompt?: string;
+};
+
+type CogneeMemoryFlushPlan = {
+  softThresholdTokens: number;
+  forceFlushTranscriptBytes: number;
+  reserveTokensFloor: number;
+  prompt: string;
+  systemPrompt: string;
+  relativePath: string;
+};
+
+function normalizeNonNegativeInt(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  const int = Math.floor(value);
+  return int >= 0 ? int : null;
+}
+
+function parseNonNegativeByteSize(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value >= 0 ? Math.floor(value) : null;
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const match = value.trim().match(/^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb)?$/i);
+  if (!match) {
+    return null;
+  }
+
+  const numeric = Number.parseFloat(match[1]);
+  if (!Number.isFinite(numeric) || numeric < 0) {
+    return null;
+  }
+
+  const unit = (match[2] ?? "b").toLowerCase();
+  const multiplier =
+    unit === "gb" ? 1024 ** 3 : unit === "mb" ? 1024 ** 2 : unit === "kb" ? 1024 : 1;
+  return Math.floor(numeric * multiplier);
+}
+
+function resolveUserTimezone(timezone?: string): string {
+  const trimmed = timezone?.trim();
+  return trimmed || "UTC";
+}
+
+function resolveUserTimeFormat(value?: string): TimeFormatPreference {
+  return value === "12" ? "12h" : "24h";
+}
+
+function formatUserTime(date: Date, timezone: string, timeFormat: TimeFormatPreference): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: timeFormat === "12h",
+  }).format(date);
+}
+
+function resolveCronStyleNow(cfg: OpenClawConfig, nowMs: number) {
+  const userTimezone = resolveUserTimezone(cfg.agents?.defaults?.userTimezone);
+  const formattedTime = formatUserTime(
+    new Date(nowMs),
+    userTimezone,
+    resolveUserTimeFormat(cfg.agents?.defaults?.timeFormat),
+  );
+  const utcTime = new Date(nowMs).toISOString().replace("T", " ").slice(0, 16) + " UTC";
+  return {
+    userTimezone,
+    timeLine: `Current time: ${formattedTime} (${userTimezone}) / ${utcTime}`,
+  };
+}
+
+function formatDateStampInTimezone(nowMs: number, timezone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(nowMs));
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const day = parts.find((part) => part.type === "day")?.value;
+  if (year && month && day) {
+    return `${year}-${month}-${day}`;
+  }
+  return new Date(nowMs).toISOString().slice(0, 10);
+}
+
+function ensureNoReplyHint(text: string): string {
+  if (text.includes(SILENT_REPLY_TOKEN)) {
+    return text;
+  }
+  return `${text}\n\nIf no user-visible reply is needed, start with ${SILENT_REPLY_TOKEN}.`;
+}
+
+function ensureMemoryFlushSafetyHints(text: string): string {
+  let next = text.trim();
+  for (const hint of MEMORY_FLUSH_REQUIRED_HINTS) {
+    if (!next.includes(hint)) {
+      next = next ? `${next}\n\n${hint}` : hint;
+    }
+  }
+  return next;
+}
+
+function appendCurrentTimeLine(text: string, timeLine: string): string {
+  const trimmed = text.trimEnd();
+  if (!trimmed) {
+    return timeLine;
+  }
+  if (trimmed.includes("Current time:")) {
+    return trimmed;
+  }
+  return `${trimmed}\n${timeLine}`;
+}
+
+export function buildMemoryFlushPlan(
+  params: {
+    cfg?: OpenClawConfig;
+    nowMs?: number;
+  } = {},
+): CogneeMemoryFlushPlan | null {
+  const cfg = params.cfg;
+  const defaults = cfg?.agents?.defaults?.compaction?.memoryFlush as
+    | MemoryFlushDefaultsLike
+    | undefined;
+  if (defaults?.enabled === false) {
+    return null;
+  }
+
+  const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
+  const softThresholdTokens =
+    normalizeNonNegativeInt(defaults?.softThresholdTokens) ?? DEFAULT_MEMORY_FLUSH_SOFT_TOKENS;
+  const forceFlushTranscriptBytes =
+    parseNonNegativeByteSize(defaults?.forceFlushTranscriptBytes) ??
+    DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES;
+  const reserveTokensFloor =
+    normalizeNonNegativeInt(cfg?.agents?.defaults?.compaction?.reserveTokensFloor) ??
+    DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR;
+
+  const { timeLine, userTimezone } = resolveCronStyleNow(cfg ?? {}, nowMs);
+  const dateStamp = formatDateStampInTimezone(nowMs, userTimezone);
+  const relativePath = `memory/${dateStamp}.md`;
+
+  const promptBase = ensureNoReplyHint(
+    ensureMemoryFlushSafetyHints(defaults?.prompt?.trim() || DEFAULT_MEMORY_FLUSH_PROMPT),
+  );
+  const systemPrompt = ensureNoReplyHint(
+    ensureMemoryFlushSafetyHints(
+      defaults?.systemPrompt?.trim() || DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT,
+    ),
+  );
+
+  return {
+    softThresholdTokens,
+    forceFlushTranscriptBytes,
+    reserveTokensFloor,
+    prompt: appendCurrentTimeLine(promptBase.replaceAll("YYYY-MM-DD", dateStamp), timeLine),
+    systemPrompt: systemPrompt.replaceAll("YYYY-MM-DD", dateStamp),
+    relativePath,
+  };
+}

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -5,6 +5,7 @@ import { MEMORY_SCOPES } from "./types.js";
 import { CogneeHttpClient } from "./client.js";
 import { resolveConfig } from "./config.js";
 import { collectMemoryFiles } from "./files.js";
+import { buildMemoryFlushPlan } from "./flush-plan.js";
 import {
   loadDatasetState,
   loadScopedSyncIndexes,
@@ -20,6 +21,9 @@ import { syncFiles, syncFilesScoped } from "./sync.js";
 // Plugin registration
 // ---------------------------------------------------------------------------
 
+type MemoryFlushPlanRegistrant = OpenClawPluginApi & {
+  registerMemoryFlushPlan?: (resolver: typeof buildMemoryFlushPlan) => void;
+};
 const memoryCogneePlugin = {
   id: "cognee-openclaw",
   name: "Memory (Cognee)",
@@ -29,6 +33,9 @@ const memoryCogneePlugin = {
     const cfg = resolveConfig(api.pluginConfig);
     const client = new CogneeHttpClient(cfg.baseUrl, cfg.apiKey, cfg.username, cfg.password, cfg.requestTimeoutMs, cfg.ingestionTimeoutMs);
     const multiScope = isMultiScopeEnabled(cfg);
+
+    (api as MemoryFlushPlanRegistrant).registerMemoryFlushPlan?.(buildMemoryFlushPlan);
+    api.logger.debug?.("cognee-openclaw: registered memory flush plan");
 
     // Legacy single-scope state
     let datasetId: string | undefined;


### PR DESCRIPTION
## Summary
- expose `recallInjectionPosition` in the plugin schema so deployments can switch recall back to `prependContext`
- restore pre-compaction memory flush support when `cognee-openclaw` owns the memory slot

## Validation
- `npm test -- --runInBand __tests__/test_flushPlan.ts __tests__/test_pluginAgentEndWorkspace.ts __tests__/test_syncFiles.ts`
- `npm run typecheck`

Also mitigates part of #26 by restoring pre-compaction memory flush when `cognee-openclaw` owns the memory slot.
