### PR TITLE
Add graph visualisation command to openclaw plugin

### DIFF
--- a/integrations/openclaw/src/client.ts
+++ b/integrations/openclaw/src/client.ts
@@ -336,6 +336,13 @@ export class CogneeHttpClient {
     return this.fetchJson<{ id: string; name: string }[]>(path, { method: "GET" });
   }
 
+  async visualise(datasetId: string): Promise<unknown> {
+    const path = this.isCloud
+      ? `/visualise?dataset_id=${datasetId}`
+      : `/api/v1/visualise?dataset_id=${datasetId}`;
+    return this.fetchJson<unknown>(path, { method: "GET" });
+  }
+
   /**
    * Poll cognify pipeline status. Returns the status string ("completed", "running", "failed", etc.).
    */

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -222,6 +222,26 @@ const memoryCogneePlugin = {
         });
 
       cognee
+        .command("visualise")
+        .description("Visualise the knowledge graph for the current dataset")
+        .action(async () => {
+          await stateReady;
+          const dsId = datasetId ?? syncIndex.datasetId;
+          if (!dsId) {
+            console.log("No dataset ID found. Run 'cognee index' first to sync files.");
+            process.exit(1);
+          }
+          try {
+            const graph = await client.visualise(dsId);
+            console.log(JSON.stringify(graph, null, 2));
+          } catch (error) {
+            console.log(`Failed to visualise graph: ${error instanceof Error ? error.message : String(error)}`);
+            process.exit(1);
+          }
+          process.exit(0);
+        });
+
+      cognee
         .command("setup")
         .description("Configure OpenClaw to use Cognee for memory (default: replaces built-in, --hybrid: alongside built-in)")
         .option("--hybrid", "Keep built-in memory providers enabled alongside Cognee")


### PR DESCRIPTION
## Summary
- Adds `visualise(datasetId)` method to `CogneeHttpClient` calling `GET /api/v1/visualise` (local) or `GET /visualise` (cloud)
- Adds `cognee visualise` CLI command that outputs the knowledge graph JSON for the current dataset

## Test plan
- [ ] Run `openclaw cognee visualise` with a synced dataset and verify graph JSON output
- [ ] Test with no dataset (should show helpful error message)
- [ ] Verify cloud mode path (`/visualise?dataset_id=...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)