### PR TITLE
fix: bypass system proxy in httpx to resolve self-hosted connection failure

### DIFF
--- a/integrations/dify-sdk/.env.example
+++ b/integrations/dify-sdk/.env.example
@@ -1,3 +1,3 @@
 INSTALL_METHOD=remote
-REMOTE_INSTALL_URL=debug.dify.ai:5003
+REMOTE_INSTALL_URL=localhost:5003
 REMOTE_INSTALL_KEY=********-****-****-****-************

--- a/integrations/dify-sdk/provider/cognee_sdk.py
+++ b/integrations/dify-sdk/provider/cognee_sdk.py
@@ -28,7 +28,8 @@ class CogneeSdkProvider(ToolProvider):
 
         # 1. Health check
         try:
-            response = httpx.get(f"{base_url}/health", timeout=60)
+            with httpx.Client(trust_env=False) as client:
+                response = client.get(f"{base_url}/health", timeout=60)
             logger.info(f"Health check response: {response.status_code}")
             response.raise_for_status()
         except httpx.ConnectError:
@@ -48,14 +49,15 @@ class CogneeSdkProvider(ToolProvider):
 
         # 2. Login to verify credentials
         try:
-            response = httpx.post(
-                f"{base_url}/api/v1/auth/login",
-                data={
-                    "username": user_email,
-                    "password": user_password,
-                },
-                timeout=60,
-            )
+            with httpx.Client(trust_env=False) as client:
+                response = client.post(
+                    f"{base_url}/api/v1/auth/login",
+                    data={
+                        "username": user_email,
+                        "password": user_password,
+                    },
+                    timeout=60,
+                )
             logger.info(f"Login response: {response.status_code}")
             response.raise_for_status()
 

--- a/integrations/dify-sdk/tools/add_data.py
+++ b/integrations/dify-sdk/tools/add_data.py
@@ -8,8 +8,8 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
 
-def _login(base_url: str, email: str, password: str) -> str:
-    response = httpx.post(
+def _login(base_url: str, email: str, password: str, client: httpx.Client) -> str:
+    response = client.post(
         f"{base_url}/api/v1/auth/login",
         data={"username": email, "password": password},
         timeout=60,
@@ -36,49 +36,50 @@ class AddDataTool(Tool):
             return
 
         try:
-            token = _login(base_url, user_email, user_password)
+            with httpx.Client(trust_env=False) as client:
+                token = _login(base_url, user_email, user_password, client)
 
-            text_bytes = text_data.encode("utf-8")
-            file_obj = io.BytesIO(text_bytes)
+                text_bytes = text_data.encode("utf-8")
+                file_obj = io.BytesIO(text_bytes)
 
-            form_data: dict[str, Any] = {}
-            if dataset_name:
-                form_data["datasetName"] = dataset_name
-            if dataset_id:
-                form_data["datasetId"] = dataset_id
-            if node_set:
-                node_set_list = [n.strip() for n in node_set.split(",") if n.strip()]
-                for ns in node_set_list:
-                    form_data.setdefault("node_set", []).append(ns)
+                form_data: dict[str, Any] = {}
+                if dataset_name:
+                    form_data["datasetName"] = dataset_name
+                if dataset_id:
+                    form_data["datasetId"] = dataset_id
+                if node_set:
+                    node_set_list = [n.strip() for n in node_set.split(",") if n.strip()]
+                    for ns in node_set_list:
+                        form_data.setdefault("node_set", []).append(ns)
 
-            filename = f"data_{uuid.uuid4().hex[:8]}.txt"
-            response = httpx.post(
-                f"{base_url}/api/v1/add",
-                headers={"Authorization": f"Bearer {token}"},
-                files={"data": (filename, file_obj, "text/plain")},
-                data=form_data,
-                timeout=3600,
-            )
-            response.raise_for_status()
-            result = response.json()
+                filename = f"data_{uuid.uuid4().hex[:8]}.txt"
+                response = client.post(
+                    f"{base_url}/api/v1/add",
+                    headers={"Authorization": f"Bearer {token}"},
+                    files={"data": (filename, file_obj, "text/plain")},
+                    data=form_data,
+                    timeout=3600,
+                )
+                response.raise_for_status()
+                result = response.json()
 
-            resp_dataset_id = result.get("dataset_id", dataset_id or "")
-            resp_dataset_name = result.get("dataset_name", dataset_name or "")
-            data_ids: list[str] = []
-            for info in result.get("data_ingestion_info", []):
-                if isinstance(info, dict) and info.get("data_id"):
-                    data_ids.append(str(info["data_id"]))
+                resp_dataset_id = result.get("dataset_id", dataset_id or "")
+                resp_dataset_name = result.get("dataset_name", dataset_name or "")
+                data_ids: list[str] = []
+                for info in result.get("data_ingestion_info", []):
+                    if isinstance(info, dict) and info.get("data_id"):
+                        data_ids.append(str(info["data_id"]))
 
-            first_data_id = data_ids[0] if data_ids else ""
+                first_data_id = data_ids[0] if data_ids else ""
 
-            yield self.create_json_message(result)
-            yield self.create_variable_message("dataset_name", resp_dataset_name)
-            yield self.create_variable_message("dataset_id", resp_dataset_id)
-            yield self.create_variable_message("data_id", first_data_id)
-            yield self.create_variable_message("items_count", len(data_ids))
-            yield self.create_text_message(
-                f"Successfully added data to dataset '{resp_dataset_name}' (id: {resp_dataset_id})."
-            )
+                yield self.create_json_message(result)
+                yield self.create_variable_message("dataset_name", resp_dataset_name)
+                yield self.create_variable_message("dataset_id", resp_dataset_id)
+                yield self.create_variable_message("data_id", first_data_id)
+                yield self.create_variable_message("items_count", len(data_ids))
+                yield self.create_text_message(
+                    f"Successfully added data to dataset '{resp_dataset_name}' (id: {resp_dataset_id})."
+                )
         except httpx.HTTPStatusError as e:
             error_msg = f"Cognee API error {e.response.status_code}: {e.response.text}"
             yield self.create_json_message({"error": error_msg})

--- a/integrations/dify-sdk/tools/cognify.py
+++ b/integrations/dify-sdk/tools/cognify.py
@@ -6,8 +6,8 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
 
-def _login(base_url: str, email: str, password: str) -> str:
-    response = httpx.post(
+def _login(base_url: str, email: str, password: str, client: httpx.Client) -> str:
+    response = client.post(
         f"{base_url}/api/v1/auth/login",
         data={"username": email, "password": password},
         timeout=60,
@@ -49,28 +49,29 @@ class CognifyTool(Tool):
             body["ontologyKey"] = [k.strip() for k in ontology_key_str.split(",") if k.strip()]
 
         try:
-            token = _login(base_url, user_email, user_password)
+            with httpx.Client(trust_env=False) as client:
+                token = _login(base_url, user_email, user_password, client)
 
-            response = httpx.post(
-                f"{base_url}/api/v1/cognify",
-                json=body,
-                headers={
-                    "Authorization": f"Bearer {token}",
-                    "Content-Type": "application/json",
-                },
-                timeout=21600,
-            )
-            response.raise_for_status()
+                response = client.post(
+                    f"{base_url}/api/v1/cognify",
+                    json=body,
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Content-Type": "application/json",
+                    },
+                    timeout=21600,
+                )
+                response.raise_for_status()
 
-            try:
-                result = response.json()
-            except Exception:
-                result = {"status": "ok"}
+                try:
+                    result = response.json()
+                except Exception:
+                    result = {"status": "ok"}
 
-            label = ", ".join(datasets) if datasets else ", ".join(dataset_ids)
-            yield self.create_json_message(result)
-            yield self.create_variable_message("datasets", label)
-            yield self.create_text_message(f"Successfully cognified dataset(s): {label}")
+                label = ", ".join(datasets) if datasets else ", ".join(dataset_ids)
+                yield self.create_json_message(result)
+                yield self.create_variable_message("datasets", label)
+                yield self.create_text_message(f"Successfully cognified dataset(s): {label}")
         except httpx.HTTPStatusError as e:
             error_msg = f"Cognee API error {e.response.status_code}: {e.response.text}"
             yield self.create_json_message({"error": error_msg})

--- a/integrations/dify-sdk/tools/delete_data.py
+++ b/integrations/dify-sdk/tools/delete_data.py
@@ -6,8 +6,8 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
 
-def _login(base_url: str, email: str, password: str) -> str:
-    response = httpx.post(
+def _login(base_url: str, email: str, password: str, client: httpx.Client) -> str:
+    response = client.post(
         f"{base_url}/api/v1/auth/login",
         data={"username": email, "password": password},
         timeout=60,
@@ -26,24 +26,25 @@ class DeleteDataTool(Tool):
         data_id = tool_parameters["data_id"]
 
         try:
-            token = _login(base_url, user_email, user_password)
+            with httpx.Client(trust_env=False) as client:
+                token = _login(base_url, user_email, user_password, client)
 
-            response = httpx.delete(
-                f"{base_url}/api/v1/datasets/{dataset_id}/data/{data_id}",
-                headers={"Authorization": f"Bearer {token}"},
-                timeout=600,
-            )
-            response.raise_for_status()
+                response = client.delete(
+                    f"{base_url}/api/v1/datasets/{dataset_id}/data/{data_id}",
+                    headers={"Authorization": f"Bearer {token}"},
+                    timeout=600,
+                )
+                response.raise_for_status()
 
-            yield self.create_json_message(
-                {"succeeded": True, "dataset_id": dataset_id, "data_id": data_id}
-            )
-            yield self.create_variable_message("succeeded", True)
-            yield self.create_variable_message("dataset_id", dataset_id)
-            yield self.create_variable_message("data_id", data_id)
-            yield self.create_text_message(
-                f"Successfully deleted data item '{data_id}' from dataset '{dataset_id}'."
-            )
+                yield self.create_json_message(
+                    {"succeeded": True, "dataset_id": dataset_id, "data_id": data_id}
+                )
+                yield self.create_variable_message("succeeded", True)
+                yield self.create_variable_message("dataset_id", dataset_id)
+                yield self.create_variable_message("data_id", data_id)
+                yield self.create_text_message(
+                    f"Successfully deleted data item '{data_id}' from dataset '{dataset_id}'."
+                )
         except Exception as e:
             yield self.create_json_message(
                 {"succeeded": False, "dataset_id": dataset_id, "data_id": data_id}

--- a/integrations/dify-sdk/tools/delete_dataset.py
+++ b/integrations/dify-sdk/tools/delete_dataset.py
@@ -6,8 +6,8 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
 
-def _login(base_url: str, email: str, password: str) -> str:
-    response = httpx.post(
+def _login(base_url: str, email: str, password: str, client: httpx.Client) -> str:
+    response = client.post(
         f"{base_url}/api/v1/auth/login",
         data={"username": email, "password": password},
         timeout=60,
@@ -25,19 +25,20 @@ class DeleteDatasetTool(Tool):
         dataset_id = tool_parameters["dataset_id"]
 
         try:
-            token = _login(base_url, user_email, user_password)
+            with httpx.Client(trust_env=False) as client:
+                token = _login(base_url, user_email, user_password, client)
 
-            response = httpx.delete(
-                f"{base_url}/api/v1/datasets/{dataset_id}",
-                headers={"Authorization": f"Bearer {token}"},
-                timeout=600,
-            )
-            response.raise_for_status()
+                response = client.delete(
+                    f"{base_url}/api/v1/datasets/{dataset_id}",
+                    headers={"Authorization": f"Bearer {token}"},
+                    timeout=600,
+                )
+                response.raise_for_status()
 
-            yield self.create_json_message({"succeeded": True, "dataset_id": dataset_id})
-            yield self.create_variable_message("succeeded", True)
-            yield self.create_variable_message("dataset_id", dataset_id)
-            yield self.create_text_message(f"Successfully deleted dataset '{dataset_id}'.")
+                yield self.create_json_message({"succeeded": True, "dataset_id": dataset_id})
+                yield self.create_variable_message("succeeded", True)
+                yield self.create_variable_message("dataset_id", dataset_id)
+                yield self.create_text_message(f"Successfully deleted dataset '{dataset_id}'.")
         except Exception as e:
             yield self.create_json_message({"succeeded": False, "dataset_id": dataset_id})
             yield self.create_variable_message("succeeded", False)

--- a/integrations/dify-sdk/tools/search.py
+++ b/integrations/dify-sdk/tools/search.py
@@ -6,8 +6,8 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
 
-def _login(base_url: str, email: str, password: str) -> str:
-    response = httpx.post(
+def _login(base_url: str, email: str, password: str, client: httpx.Client) -> str:
+    response = client.post(
         f"{base_url}/api/v1/auth/login",
         data={"username": email, "password": password},
         timeout=60,
@@ -49,38 +49,39 @@ class SearchTool(Tool):
             body["systemPrompt"] = system_prompt
 
         try:
-            token = _login(base_url, user_email, user_password)
+            with httpx.Client(trust_env=False) as client:
+                token = _login(base_url, user_email, user_password, client)
 
-            response = httpx.post(
-                f"{base_url}/api/v1/search",
-                json=body,
-                headers={
-                    "Authorization": f"Bearer {token}",
-                    "Content-Type": "application/json",
-                },
-                timeout=300,
-            )
-            response.raise_for_status()
-            result = response.json()
+                response = client.post(
+                    f"{base_url}/api/v1/search",
+                    json=body,
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Content-Type": "application/json",
+                    },
+                    timeout=300,
+                )
+                response.raise_for_status()
+                result = response.json()
 
-            yield self.create_json_message(result)
+                yield self.create_json_message(result)
 
-            if isinstance(result, list):
-                text_parts = [f"Found {len(result)} result(s):\n"]
-                for i, item in enumerate(result, 1):
-                    if isinstance(item, dict):
-                        content = item.get("content", item.get("text", str(item)))
-                        text_parts.append(f"{i}. {content}")
-                    else:
-                        text_parts.append(f"{i}. {item}")
-                formatted = "\n".join(text_parts)
-                yield self.create_variable_message("results_count", len(result))
-                yield self.create_variable_message("results_text", formatted)
-                yield self.create_text_message(formatted)
-            else:
-                yield self.create_variable_message("results_count", 1)
-                yield self.create_variable_message("results_text", str(result))
-                yield self.create_text_message(f"Search results: {result}")
+                if isinstance(result, list):
+                    text_parts = [f"Found {len(result)} result(s):\n"]
+                    for i, item in enumerate(result, 1):
+                        if isinstance(item, dict):
+                            content = item.get("content", item.get("text", str(item)))
+                            text_parts.append(f"{i}. {content}")
+                        else:
+                            text_parts.append(f"{i}. {item}")
+                    formatted = "\n".join(text_parts)
+                    yield self.create_variable_message("results_count", len(result))
+                    yield self.create_variable_message("results_text", formatted)
+                    yield self.create_text_message(formatted)
+                else:
+                    yield self.create_variable_message("results_count", 1)
+                    yield self.create_variable_message("results_text", str(result))
+                    yield self.create_text_message(f"Search results: {result}")
         except httpx.HTTPStatusError as e:
             error_msg = f"Cognee API error {e.response.status_code}: {e.response.text}"
             yield self.create_json_message({"error": error_msg})

--- a/integrations/dify-sdk/tools/update_data.py
+++ b/integrations/dify-sdk/tools/update_data.py
@@ -8,8 +8,8 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
 
-def _login(base_url: str, email: str, password: str) -> str:
-    response = httpx.post(
+def _login(base_url: str, email: str, password: str, client: httpx.Client) -> str:
+    response = client.post(
         f"{base_url}/api/v1/auth/login",
         data={"username": email, "password": password},
         timeout=60,
@@ -30,40 +30,41 @@ class UpdateDataTool(Tool):
         node_set = tool_parameters.get("node_set", "")
 
         try:
-            token = _login(base_url, user_email, user_password)
+            with httpx.Client(trust_env=False) as client:
+                token = _login(base_url, user_email, user_password, client)
 
-            text_bytes = text_data.encode("utf-8")
-            file_obj = io.BytesIO(text_bytes)
-            filename = f"data_{uuid.uuid4().hex[:8]}.txt"
+                text_bytes = text_data.encode("utf-8")
+                file_obj = io.BytesIO(text_bytes)
+                filename = f"data_{uuid.uuid4().hex[:8]}.txt"
 
-            form_data: dict[str, Any] = {}
-            if node_set:
-                node_set_list = [n.strip() for n in node_set.split(",") if n.strip()]
-                for ns in node_set_list:
-                    form_data.setdefault("node_set", []).append(ns)
+                form_data: dict[str, Any] = {}
+                if node_set:
+                    node_set_list = [n.strip() for n in node_set.split(",") if n.strip()]
+                    for ns in node_set_list:
+                        form_data.setdefault("node_set", []).append(ns)
 
-            response = httpx.patch(
-                f"{base_url}/api/v1/update",
-                params={"data_id": data_id, "dataset_id": dataset_id},
-                headers={"Authorization": f"Bearer {token}"},
-                files={"data": (filename, file_obj, "text/plain")},
-                data=form_data,
-                timeout=21600,
-            )
-            response.raise_for_status()
+                response = client.patch(
+                    f"{base_url}/api/v1/update",
+                    params={"data_id": data_id, "dataset_id": dataset_id},
+                    headers={"Authorization": f"Bearer {token}"},
+                    files={"data": (filename, file_obj, "text/plain")},
+                    data=form_data,
+                    timeout=21600,
+                )
+                response.raise_for_status()
 
-            try:
-                result = response.json()
-            except Exception:
-                result = {"status": "ok"}
+                try:
+                    result = response.json()
+                except Exception:
+                    result = {"status": "ok"}
 
-            yield self.create_json_message(result)
-            yield self.create_variable_message("succeeded", True)
-            yield self.create_variable_message("dataset_id", dataset_id)
-            yield self.create_variable_message("data_id", data_id)
-            yield self.create_text_message(
-                f"Successfully updated data item '{data_id}' in dataset '{dataset_id}'."
-            )
+                yield self.create_json_message(result)
+                yield self.create_variable_message("succeeded", True)
+                yield self.create_variable_message("dataset_id", dataset_id)
+                yield self.create_variable_message("data_id", data_id)
+                yield self.create_text_message(
+                    f"Successfully updated data item '{data_id}' in dataset '{dataset_id}'."
+                )
         except httpx.HTTPStatusError as e:
             error_msg = f"Cognee API error {e.response.status_code}: {e.response.text}"
             yield self.create_json_message({"succeeded": False, "error": error_msg})


### PR DESCRIPTION
## Summary
- Use `httpx.Client(trust_env=False)` across all tools and provider to bypass OS-level proxy settings that cause 502 errors when connecting to local Cognee server
- Fix .env.example URL typo: `debug.dify.ai:5003` → `localhost:5003`

## Root Cause
`httpx` honors system proxy settings (e.g. macOS system proxy at 127.0.0.1:7890), routing local requests through the proxy which returns 502 Bad Gateway. `curl` and `requests` are unaffected, making this hard to diagnose.

## Test Plan
- [x] Verified `httpx.Client(trust_env=False)` resolves the 502 on machines with system proxy
- [x] Plugin credential validation succeeds
- [x] Add Data, Cognify, and Search tools work end-to-end through Dify