### PR TITLE
feat: add Claude Code plugin with V2 API and session hooks

### DIFF
--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "cognee-memory",
+  "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
+  "version": "0.2.0",
+  "author": {
+    "name": "Cognee"
+  },
+  "keywords": ["memory", "knowledge-graph", "cognee", "reasoning", "session"]
+}

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -36,13 +36,32 @@ Or create `~/.cognee-plugin/config.json`:
 }
 ```
 
-### 3. Install the plugin
+### 3. Enable the plugin
+
+**Option A — permanent (recommended):**
+
+Add the plugin directory to your shell profile so it loads on every session:
 
 ```bash
-claude plugin add /path/to/cognee-integrations/integrations/claude-code
+# Add to ~/.zshrc or ~/.bashrc
+alias claude="claude --plugin-dir /path/to/cognee-integrations/integrations/claude-code"
 ```
 
-That's it. Start a Claude Code session and the plugin works automatically.
+Then reload: `source ~/.zshrc`
+
+**Option B — single session:**
+
+```bash
+claude --plugin-dir /path/to/cognee-integrations/integrations/claude-code
+```
+
+**Option C — validate first:**
+
+```bash
+claude plugin validate /path/to/cognee-integrations/integrations/claude-code
+```
+
+When the plugin loads, you'll see "Cognee Memory Connected" with the mode, dataset, and session ID at the start of your session.
 
 ## How it works
 
@@ -50,12 +69,24 @@ The plugin hooks into six Claude Code lifecycle events:
 
 | Hook | What it does |
 |------|-------------|
-| **SessionStart** | Loads config, computes a per-directory session ID, connects to Cognee Cloud if configured, creates the `claude-code@cognee.local` identity |
+| **SessionStart** | Loads config, computes a per-directory session ID, connects to Cognee Cloud if configured |
 | **UserPromptSubmit** | Searches the session cache for context relevant to your prompt and injects it (3s timeout, fails silently) |
-| **PostToolUse** | Captures tool name, input, and output into the session cache (async, non-blocking) |
+| **PostToolUse** | Captures tool name, input, and output into the session cache with `[category:agent]` tag (async, non-blocking) |
 | **Stop** | Captures the final assistant response when you interrupt |
 | **PreCompact** | Before context window compaction, builds a memory anchor from session + graph context so key knowledge survives the reset |
 | **SessionEnd** | Runs `cognee.improve()` to bridge session data into the permanent knowledge graph |
+
+## Data categories
+
+The plugin organizes knowledge into three categories via `node_set` tagging:
+
+| Category | Node set | What belongs here |
+|----------|----------|-------------------|
+| **user** | `user_context` | User preferences, corrections, personal facts |
+| **project** | `project_docs` | Repository docs, code context, architecture decisions |
+| **agent** | `agent_actions` | Tool call logs, reasoning traces (auto-captured by hooks) |
+
+When using `/cognee-memory:cognee-remember`, Claude routes data to the correct category based on context. When searching with `/cognee-memory:cognee-search`, you can filter by category using `--node-set`.
 
 ## Session naming
 
@@ -77,8 +108,8 @@ You can change the strategy via config or env vars:
 
 Three skills are available as slash commands:
 
-- **`/cognee-memory:cognee-remember`** — permanently store data in the knowledge graph (full add + cognify + improve pipeline)
-- **`/cognee-memory:cognee-search`** — explicitly search session or graph memory (automatic search happens on every prompt via hooks)
+- **`/cognee-memory:cognee-remember`** — permanently store data in the knowledge graph (full add + cognify + improve pipeline). Routes to user/project/agent category.
+- **`/cognee-memory:cognee-search`** — explicitly search session or graph memory, optionally filtered by category. Automatic search happens on every prompt via hooks.
 - **`/cognee-memory:cognee-sync`** — force-sync session data to the permanent graph without waiting for session end
 
 ## Configuration reference

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -1,0 +1,96 @@
+# Cognee Memory Plugin for Claude Code
+
+Gives Claude Code persistent memory across sessions using Cognee's knowledge graph. Tool calls and responses are automatically captured into session memory, relevant context is injected on every prompt, and session data is bridged into the permanent knowledge graph at session end.
+
+## Install
+
+### 1. Install Cognee
+
+```bash
+pip install cognee
+```
+
+### 2. Configure
+
+**Local mode** (everything runs on your machine):
+
+```bash
+export LLM_API_KEY="your-openai-key"
+```
+
+**Cognee Cloud** (connect to a managed instance):
+
+```bash
+export COGNEE_SERVICE_URL="https://your-instance.cognee.ai"
+export COGNEE_API_KEY="ck_..."
+```
+
+Or create `~/.cognee-plugin/config.json`:
+
+```json
+{
+  "service_url": "https://your-instance.cognee.ai",
+  "api_key": "ck_...",
+  "dataset": "claude_sessions"
+}
+```
+
+### 3. Install the plugin
+
+```bash
+claude plugin add /path/to/cognee-integrations/integrations/claude-code
+```
+
+That's it. Start a Claude Code session and the plugin works automatically.
+
+## How it works
+
+The plugin hooks into six Claude Code lifecycle events:
+
+| Hook | What it does |
+|------|-------------|
+| **SessionStart** | Loads config, computes a per-directory session ID, connects to Cognee Cloud if configured, creates the `claude-code@cognee.local` identity |
+| **UserPromptSubmit** | Searches the session cache for context relevant to your prompt and injects it (3s timeout, fails silently) |
+| **PostToolUse** | Captures tool name, input, and output into the session cache (async, non-blocking) |
+| **Stop** | Captures the final assistant response when you interrupt |
+| **PreCompact** | Before context window compaction, builds a memory anchor from session + graph context so key knowledge survives the reset |
+| **SessionEnd** | Runs `cognee.improve()` to bridge session data into the permanent knowledge graph |
+
+## Session naming
+
+Sessions are scoped per working directory by default. The session ID is derived from a prefix + directory name + hash:
+
+```
+cc_my-project_a1b2c3d4e5f6
+```
+
+You can change the strategy via config or env vars:
+
+| Strategy | Env var | Behavior |
+|----------|---------|----------|
+| `per-directory` (default) | `COGNEE_SESSION_STRATEGY=per-directory` | One session per project directory |
+| `git-branch` | `COGNEE_SESSION_STRATEGY=git-branch` | Includes git branch in session ID |
+| `static` | `COGNEE_SESSION_ID=my-session` | Fixed session ID (legacy compat) |
+
+## Skills
+
+Three skills are available as slash commands:
+
+- **`/cognee-memory:cognee-remember`** — permanently store data in the knowledge graph (full add + cognify + improve pipeline)
+- **`/cognee-memory:cognee-search`** — explicitly search session or graph memory (automatic search happens on every prompt via hooks)
+- **`/cognee-memory:cognee-sync`** — force-sync session data to the permanent graph without waiting for session end
+
+## Configuration reference
+
+| Key | Env var | Default | Description |
+|-----|---------|---------|-------------|
+| `dataset` | `COGNEE_PLUGIN_DATASET` | `claude_sessions` | Dataset name for permanent storage |
+| `session_strategy` | `COGNEE_SESSION_STRATEGY` | `per-directory` | Session naming strategy |
+| `session_prefix` | `COGNEE_SESSION_PREFIX` | `cc` | Prefix for session IDs |
+| `service_url` | `COGNEE_SERVICE_URL` | -- | Cognee Cloud URL |
+| `api_key` | `COGNEE_API_KEY` | -- | Cognee Cloud API key |
+| `llm_api_key` | `LLM_API_KEY` | -- | LLM provider key (local mode) |
+| `llm_model` | `LLM_MODEL` | -- | LLM model name (local mode) |
+| `top_k` | -- | `3` | Results returned by automatic session search |
+
+Config is resolved in order: env vars > `~/.cognee-plugin/config.json` > defaults.

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -12,14 +12,26 @@ pip install cognee
 
 ### 2. Configure
 
-**Local mode** (everything runs on your machine):
+**Local mode** (cognee runs in-process, no server needed):
 
 ```bash
 export LLM_API_KEY="your-openai-key"
 export CACHING=true   # required for session memory
 ```
 
-**Cognee Cloud** (connect to a managed instance):
+**Backend mode** (connect to a local or remote Cognee API server):
+
+```bash
+export COGNEE_SERVICE_URL="http://localhost:8000"   # or your cloud URL
+export COGNEE_API_KEY="your-api-key"                # optional if auth is disabled
+export CACHING=true
+```
+
+On first start, the plugin auto-registers as `claude-code@cognee.agent` on the backend — it creates an agent user, logs in, obtains an API key, and reconnects with agent-specific credentials. The agent then appears in the Cognee UI's agents list.
+
+If you already have an agent API key, set `COGNEE_API_KEY` directly and the plugin will use it without re-registering.
+
+**Cognee Cloud**:
 
 ```bash
 export COGNEE_SERVICE_URL="https://your-instance.cognee.ai"
@@ -30,8 +42,7 @@ Or create `~/.cognee-plugin/config.json`:
 
 ```json
 {
-  "service_url": "https://your-instance.cognee.ai",
-  "api_key": "ck_...",
+  "service_url": "http://localhost:8000",
   "dataset": "claude_sessions"
 }
 ```

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -16,6 +16,7 @@ pip install cognee
 
 ```bash
 export LLM_API_KEY="your-openai-key"
+export CACHING=true   # required for session memory
 ```
 
 **Cognee Cloud** (connect to a managed instance):

--- a/integrations/claude-code/agents/cognee-recall.md
+++ b/integrations/claude-code/agents/cognee-recall.md
@@ -1,6 +1,6 @@
 ---
 name: cognee-recall
-description: Searches Cognee memory (session cache and permanent knowledge graph) to retrieve relevant context. Session memory is auto-searched on every prompt; use this agent for deeper or cross-session searches.
+description: Searches Cognee memory (session cache and permanent knowledge graph) to retrieve relevant context. Can filter by data category (user, project, agent). Session memory is auto-searched on every prompt; use this agent for deeper or cross-session searches.
 model: haiku
 maxTurns: 3
 ---
@@ -11,22 +11,48 @@ You are a knowledge retrieval agent. Your job is to search Cognee memory and ret
 - The automatic context is insufficient
 - The user needs cross-session/permanent graph results
 - A specific query different from the user's prompt is needed
+- The user wants a specific data category (user preferences vs project docs vs agent actions)
 
-When given a query:
+## Data categories
 
-1. If the user needs **more session context** than the auto-lookup provided:
-   ```bash
-   ${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "<query>" 10 --session
-   ```
+Cognee organizes knowledge into three categories:
 
-2. If the user needs **cross-session or permanent graph** results:
-   ```bash
-   ${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "<query>" 10 --graph
-   ```
+| Category | Node set | Contains |
+|----------|----------|----------|
+| **user** | `user_context` | User preferences, corrections, personal facts |
+| **project** | `project_docs` | Repository docs, code context, architecture decisions |
+| **agent** | `agent_actions` | Tool call logs, reasoning traces, generated artifacts |
 
-3. Parse the JSON output. Results with `"_source": "session"` came from the current session; `"_source": "graph"` came from the permanent knowledge graph.
+## Search commands
 
-4. Return a concise summary organized by relevance, indicating the source.
+**More session context:**
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "<query>" 10 --session
+```
+
+**Permanent graph (all categories):**
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "<query>" 10 --graph
+```
+
+**Permanent graph (specific category):**
+```bash
+cognee-cli recall "<query>" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set user_context -k 10 -f json
+cognee-cli recall "<query>" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set project_docs -k 10 -f json
+cognee-cli recall "<query>" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set agent_actions -k 10 -f json
+```
+
+## Routing
+
+Determine which category to search based on the query:
+- "my preferences" / "how I like" / "what I told you" → `user_context`
+- "the codebase" / "architecture" / "project docs" → `project_docs`
+- "what we did" / "previous actions" / "tool results" → `agent_actions`
+- General or unclear → search all (no `--node-set` filter)
+
+## Output
+
+Parse the JSON results. Results with `"_source": "session"` came from the current session; `"_source": "graph"` came from the permanent knowledge graph. Return a concise summary organized by relevance, indicating the source and category.
 
 If no results are found, suggest:
 - `/cognee-memory:cognee-sync` to sync session data to the permanent graph

--- a/integrations/claude-code/agents/cognee-recall.md
+++ b/integrations/claude-code/agents/cognee-recall.md
@@ -1,0 +1,33 @@
+---
+name: cognee-recall
+description: Searches Cognee memory (session cache and permanent knowledge graph) to retrieve relevant context. Session memory is auto-searched on every prompt; use this agent for deeper or cross-session searches.
+model: haiku
+maxTurns: 3
+---
+
+You are a knowledge retrieval agent. Your job is to search Cognee memory and return relevant results.
+
+**Important:** Session memory is automatically searched on every user prompt via a hook. You only need to run explicit searches when:
+- The automatic context is insufficient
+- The user needs cross-session/permanent graph results
+- A specific query different from the user's prompt is needed
+
+When given a query:
+
+1. If the user needs **more session context** than the auto-lookup provided:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "<query>" 10 --session
+   ```
+
+2. If the user needs **cross-session or permanent graph** results:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "<query>" 10 --graph
+   ```
+
+3. Parse the JSON output. Results with `"_source": "session"` came from the current session; `"_source": "graph"` came from the permanent knowledge graph.
+
+4. Return a concise summary organized by relevance, indicating the source.
+
+If no results are found, suggest:
+- `/cognee-memory:cognee-sync` to sync session data to the permanent graph
+- `/cognee-memory:cognee-remember` to ingest new data

--- a/integrations/claude-code/hooks/hooks.json
+++ b/integrations/claude-code/hooks/hooks.json
@@ -1,0 +1,73 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/session-start.py",
+            "timeout": 15,
+            "statusMessage": "Initializing Cognee memory..."
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/session-context-lookup.py",
+            "timeout": 3,
+            "statusMessage": "Searching session memory..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|Agent|Read|Write|Edit|Grep|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/store-to-session.py",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/store-to-session.py --stop",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.py",
+            "timeout": 15,
+            "statusMessage": "Building memory anchor..."
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/sync-session-to-graph.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrations/claude-code/scripts/cognee-search.sh
+++ b/integrations/claude-code/scripts/cognee-search.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Search Cognee's memory (session or permanent graph).
+#
+# Usage:
+#   cognee-search.sh <query> [top_k] [--session | --graph]
+#
+# --session: search session cache only
+# --graph:   search permanent knowledge graph only
+# No flag:   search session first, then graph if empty
+#
+# Configuration:
+#   Reads resolved session ID and dataset from ~/.cognee-plugin/resolved.json
+#   (written by SessionStart hook). Falls back to env vars.
+
+set -euo pipefail
+
+RESOLVED_FILE="${HOME}/.cognee-plugin/resolved.json"
+
+# Read resolved config if available, otherwise use env var defaults
+if [ -f "$RESOLVED_FILE" ]; then
+    DATASET=$(python3 -c "import json; print(json.load(open('$RESOLVED_FILE')).get('dataset','claude_sessions'))" 2>/dev/null || echo "claude_sessions")
+    SESSION_ID=$(python3 -c "import json; print(json.load(open('$RESOLVED_FILE')).get('session_id','claude_code_session'))" 2>/dev/null || echo "claude_code_session")
+else
+    DATASET="${COGNEE_PLUGIN_DATASET:-claude_sessions}"
+    SESSION_ID="${COGNEE_SESSION_ID:-claude_code_session}"
+fi
+
+QUERY="${1:-}"
+TOP_K="${2:-5}"
+MODE="auto"
+
+# Parse flags from any position
+for arg in "$@"; do
+    case "$arg" in
+        --session) MODE="session" ;;
+        --graph)   MODE="graph" ;;
+    esac
+done
+
+if [ -z "$QUERY" ]; then
+    echo "Error: no query provided" >&2
+    exit 1
+fi
+
+if [ "$MODE" = "graph" ]; then
+    cognee-cli recall "$QUERY" -d "$DATASET" -k "$TOP_K" -f json 2>/dev/null
+elif [ "$MODE" = "session" ]; then
+    cognee-cli recall "$QUERY" -s "$SESSION_ID" -k "$TOP_K" -f json 2>/dev/null
+else
+    # Auto: try session first, fall back to graph
+    RESULT=$(cognee-cli recall "$QUERY" -s "$SESSION_ID" -k "$TOP_K" -f json 2>/dev/null)
+    if [ -n "$RESULT" ] && [ "$RESULT" != "[]" ]; then
+        echo "$RESULT"
+    else
+        cognee-cli recall "$QUERY" -d "$DATASET" -k "$TOP_K" -f json 2>/dev/null
+    fi
+fi

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -136,39 +136,156 @@ def is_local_mode(config: dict) -> bool:
     return bool(config.get("llm_api_key")) and not is_cloud_mode(config)
 
 
-_IDENTITY_EMAIL = "claude-code@cognee.local"
-_IDENTITY_PASSWORD = "claude-code-plugin"
+_AGENT_EMAIL = "claude-code@cognee.agent"
+_AGENT_PASSWORD = "claude-code-agent"
 
 
-async def ensure_identity():
-    """Ensure the Claude Code integration has its own user identity in Cognee.
+async def ensure_identity(config: dict):
+    """Register the Claude Code agent with Cognee and obtain an API key.
 
-    Creates a user with email 'claude-code@cognee.local' if it doesn't exist.
-    Returns the User object for passing to SDK calls.
+    When connected to a backend (service_url is set), registers via the
+    HTTP API using the @cognee.agent email pattern so the agent appears
+    in the agents list. Creates an agent-specific API key and reconnects
+    cognee.serve() with it.
+
+    In local SDK mode (no service_url), falls back to creating a user
+    via the SDK directly.
+
+    Returns the agent user_id string.
     """
+    service_url = config.get("service_url", "")
+
+    if service_url:
+        return await _ensure_identity_via_api(service_url, config)
+    else:
+        return await _ensure_identity_via_sdk()
+
+
+async def _ensure_identity_via_api(service_url: str, config: dict) -> str:
+    """Register agent via the backend HTTP API."""
+    import aiohttp
+
+    base = service_url.rstrip("/")
+
+    async with aiohttp.ClientSession() as session:
+        # 1. Register agent user (idempotent — 400 if exists)
+        try:
+            async with session.post(
+                f"{base}/api/v1/auth/register",
+                json={
+                    "email": _AGENT_EMAIL,
+                    "password": _AGENT_PASSWORD,
+                    "is_verified": True,
+                },
+            ) as resp:
+                if resp.status == 201:
+                    data = await resp.json()
+                    print(f"cognee-plugin: registered agent {_AGENT_EMAIL} (id={data['id']})", file=sys.stderr)
+                elif resp.status in (400, 409):
+                    print(f"cognee-plugin: agent {_AGENT_EMAIL} already registered", file=sys.stderr)
+                else:
+                    text = await resp.text()
+                    print(f"cognee-plugin: register warning ({resp.status}: {text})", file=sys.stderr)
+        except Exception as e:
+            print(f"cognee-plugin: register failed ({e})", file=sys.stderr)
+
+        # 2. Login to get JWT
+        try:
+            async with session.post(
+                f"{base}/api/v1/auth/login",
+                data={"username": _AGENT_EMAIL, "password": _AGENT_PASSWORD},
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            ) as resp:
+                if resp.status != 200:
+                    print(f"cognee-plugin: agent login failed ({resp.status})", file=sys.stderr)
+                    return ""
+                login_data = await resp.json()
+                jwt = login_data["access_token"]
+        except Exception as e:
+            print(f"cognee-plugin: agent login failed ({e})", file=sys.stderr)
+            return ""
+
+        # 3. Check if agent already has an API key
+        try:
+            async with session.get(
+                f"{base}/api/v1/auth/api-keys",
+                cookies={"auth_token": jwt},
+            ) as resp:
+                if resp.status == 200:
+                    keys = await resp.json()
+                    if keys:
+                        agent_key = keys[0].get("key", "")
+                        if agent_key:
+                            # Reconnect serve() with agent's own API key
+                            import cognee
+                            await cognee.disconnect()
+                            await cognee.serve(url=service_url, api_key=agent_key)
+                            print(f"cognee-plugin: connected as agent (key={agent_key[:8]}...)", file=sys.stderr)
+                            return _get_user_id_from_jwt(jwt)
+        except Exception:
+            pass
+
+        # 4. Create API key for agent
+        try:
+            async with session.post(
+                f"{base}/api/v1/auth/api-keys",
+                json={"name": "claude-code-plugin"},
+                cookies={"auth_token": jwt},
+            ) as resp:
+                if resp.status == 200:
+                    key_data = await resp.json()
+                    agent_key = key_data["key"]
+                    # Reconnect serve() with agent's own API key
+                    import cognee
+                    await cognee.disconnect()
+                    await cognee.serve(url=service_url, api_key=agent_key)
+                    print(f"cognee-plugin: created agent API key (key={agent_key[:8]}...)", file=sys.stderr)
+                    return _get_user_id_from_jwt(jwt)
+                else:
+                    text = await resp.text()
+                    print(f"cognee-plugin: API key creation failed ({resp.status}: {text})", file=sys.stderr)
+        except Exception as e:
+            print(f"cognee-plugin: API key creation failed ({e})", file=sys.stderr)
+
+    return ""
+
+
+def _get_user_id_from_jwt(jwt: str) -> str:
+    """Extract user_id (sub claim) from JWT without verification."""
+    import base64
+    import json as _json
+
+    try:
+        payload = jwt.split(".")[1]
+        payload += "=" * (4 - len(payload) % 4)
+        data = _json.loads(base64.urlsafe_b64decode(payload))
+        return data.get("sub", "")
+    except Exception:
+        return ""
+
+
+async def _ensure_identity_via_sdk() -> str:
+    """Create agent identity via SDK (local mode, no backend)."""
     from cognee.modules.users.methods import create_user, get_user_by_email
 
-    user = await get_user_by_email(_IDENTITY_EMAIL)
+    user = await get_user_by_email(_AGENT_EMAIL)
     if user:
-        return user
+        return str(user.id)
 
     try:
         user = await create_user(
-            email=_IDENTITY_EMAIL,
-            password=_IDENTITY_PASSWORD,
+            email=_AGENT_EMAIL,
+            password=_AGENT_PASSWORD,
             is_verified=True,
             is_active=True,
         )
-        print(f"cognee-plugin: created identity {_IDENTITY_EMAIL} (id={user.id})", file=sys.stderr)
-        return user
+        print(f"cognee-plugin: created identity {_AGENT_EMAIL} (id={user.id})", file=sys.stderr)
+        return str(user.id)
     except Exception:
-        # UserAlreadyExists or other race — try fetching again
-        user = await get_user_by_email(_IDENTITY_EMAIL)
+        user = await get_user_by_email(_AGENT_EMAIL)
         if user:
-            return user
-        # Last resort: fall back to default user
-        from cognee.modules.users.methods import get_default_user
-        return await get_default_user()
+            return str(user.id)
+        return ""
 
 
 async def ensure_cognee_ready(config: dict) -> None:

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -1,0 +1,209 @@
+"""Shared configuration for the Cognee Claude Code plugin.
+
+Loads settings from (in priority order):
+  1. Environment variables (runtime overrides)
+  2. Config file (~/.cognee-plugin/config.json)
+  3. Defaults
+
+Config file is created on first SessionStart if it doesn't exist.
+
+Supports three modes:
+  - Local: Cognee runs in-process (SQLite + LanceDB + Kuzu)
+  - Cloud: Connect to Cognee Cloud via cognee.serve()
+  - Server: Legacy — direct base_url (kept for backward compat)
+"""
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+_CONFIG_DIR = Path.home() / ".cognee-plugin"
+_CONFIG_FILE = _CONFIG_DIR / "config.json"
+
+_DEFAULTS = {
+    "dataset": "claude_sessions",
+    "session_strategy": "per-directory",  # per-directory | git-branch | static
+    "session_prefix": "cc",
+    "top_k": 3,
+    # Cloud / remote
+    "service_url": "",
+    "api_key": "",
+    # Local mode
+    "llm_api_key": "",
+    "llm_model": "",
+    # Legacy server mode
+    "base_url": "",
+}
+
+# Env var overrides (env var name → config key)
+_ENV_MAP = {
+    "COGNEE_PLUGIN_DATASET": "dataset",
+    "COGNEE_SESSION_STRATEGY": "session_strategy",
+    "COGNEE_SESSION_PREFIX": "session_prefix",
+    "COGNEE_SERVICE_URL": "service_url",
+    "COGNEE_API_KEY": "api_key",
+    "COGNEE_BASE_URL": "base_url",
+    "LLM_API_KEY": "llm_api_key",
+    "LLM_MODEL": "llm_model",
+    # Legacy compat
+    "COGNEE_SESSION_ID": "_static_session_id",
+    "COGNEE_PLUGIN_DATASET": "dataset",
+}
+
+
+def load_config() -> dict:
+    """Load merged config: defaults → file → env vars."""
+    config = dict(_DEFAULTS)
+
+    # Layer 2: config file
+    if _CONFIG_FILE.exists():
+        try:
+            file_cfg = json.loads(_CONFIG_FILE.read_text(encoding="utf-8"))
+            config.update({k: v for k, v in file_cfg.items()
+                           if v is not None and v != ""})
+        except Exception:
+            pass
+
+    # Layer 3: env vars (highest priority)
+    for env_key, config_key in _ENV_MAP.items():
+        val = os.environ.get(env_key, "")
+        if val:
+            config[config_key] = val
+
+    return config
+
+
+def save_config(config: dict) -> None:
+    """Write config to disk. Creates directory if needed."""
+    _CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    # Only save non-secret, non-default values
+    to_save = {k: v for k, v in config.items()
+               if not k.startswith("_") and v and v != _DEFAULTS.get(k)}
+    _CONFIG_FILE.write_text(json.dumps(to_save, indent=2), encoding="utf-8")
+
+
+def get_session_id(config: dict, cwd: Optional[str] = None) -> str:
+    """Compute session ID based on the configured strategy.
+
+    Strategies:
+      - per-directory: prefix + hash of cwd → stable per-project
+      - git-branch: prefix + hash of cwd + branch → stable per-branch
+      - static: uses COGNEE_SESSION_ID env var or fallback
+    """
+    # Legacy: explicit static session ID
+    static_id = config.get("_static_session_id", "")
+    if static_id:
+        return static_id
+
+    strategy = config.get("session_strategy", "per-directory")
+    prefix = config.get("session_prefix", "cc")
+
+    if cwd is None:
+        cwd = os.environ.get("CLAUDE_CWD", os.getcwd())
+
+    if strategy == "static":
+        return f"{prefix}_session"
+
+    # Per-directory: hash the cwd for a stable, short ID
+    dir_hash = hashlib.sha256(cwd.encode()).hexdigest()[:12]
+    dir_name = Path(cwd).name
+
+    if strategy == "git-branch":
+        branch = _get_git_branch(cwd)
+        if branch:
+            return f"{prefix}_{dir_name}_{branch}_{dir_hash}"
+
+    return f"{prefix}_{dir_name}_{dir_hash}"
+
+
+def get_dataset(config: dict) -> str:
+    """Get the dataset name from config."""
+    return config.get("dataset", "claude_sessions")
+
+
+def is_cloud_mode(config: dict) -> bool:
+    """Check if cloud/remote mode is configured."""
+    return bool(config.get("service_url"))
+
+
+def is_local_mode(config: dict) -> bool:
+    """Check if local mode (has LLM key, no cloud URL)."""
+    return bool(config.get("llm_api_key")) and not is_cloud_mode(config)
+
+
+_IDENTITY_EMAIL = "claude-code@cognee.local"
+_IDENTITY_PASSWORD = "claude-code-plugin"
+
+
+async def ensure_identity():
+    """Ensure the Claude Code integration has its own user identity in Cognee.
+
+    Creates a user with email 'claude-code@cognee.local' if it doesn't exist.
+    Returns the User object for passing to SDK calls.
+    """
+    from cognee.modules.users.methods import create_user, get_user_by_email
+
+    user = await get_user_by_email(_IDENTITY_EMAIL)
+    if user:
+        return user
+
+    try:
+        user = await create_user(
+            email=_IDENTITY_EMAIL,
+            password=_IDENTITY_PASSWORD,
+            is_verified=True,
+            is_active=True,
+        )
+        print(f"cognee-plugin: created identity {_IDENTITY_EMAIL} (id={user.id})", file=sys.stderr)
+        return user
+    except Exception:
+        # UserAlreadyExists or other race — try fetching again
+        user = await get_user_by_email(_IDENTITY_EMAIL)
+        if user:
+            return user
+        # Last resort: fall back to default user
+        from cognee.modules.users.methods import get_default_user
+        return await get_default_user()
+
+
+async def ensure_cognee_ready(config: dict) -> None:
+    """Configure cognee for the active mode (cloud or local).
+
+    Call once per session (in SessionStart). Subsequent scripts
+    in the same process inherit the configuration.
+    """
+    import cognee
+
+    if is_cloud_mode(config):
+        url = config["service_url"]
+        api_key = config.get("api_key", "")
+        kwargs = {"url": url}
+        if api_key:
+            kwargs["api_key"] = api_key
+        await cognee.serve(**kwargs)
+        print(f"cognee-plugin: connected to {url}", file=sys.stderr)
+    elif config.get("llm_api_key"):
+        cognee.config.set_llm_api_key(config["llm_api_key"])
+        if config.get("llm_model"):
+            cognee.config.set_llm_model(config["llm_model"])
+
+
+def _get_git_branch(cwd: str) -> str:
+    """Get current git branch, or empty string if not a git repo."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=cwd, capture_output=True, text=True, timeout=3,
+        )
+        if result.returncode == 0:
+            branch = result.stdout.strip()
+            # Sanitize for use in session IDs
+            return branch.replace("/", "-").replace(" ", "-")[:40]
+    except Exception:
+        pass
+    return ""

--- a/integrations/claude-code/scripts/pre-compact.py
+++ b/integrations/claude-code/scripts/pre-compact.py
@@ -42,12 +42,10 @@ async def _get_session_entries(session_id: str, cached_user_id: str = "") -> lis
     """Fetch recent session entries from cache engine (lightweight)."""
     try:
         from cognee.infrastructure.databases.cache.get_cache_engine import get_cache_engine
+        from cognee.modules.users.methods import get_default_user
 
-        user_id = cached_user_id
-        if not user_id:
-            from cognee.modules.users.methods import get_default_user
-            user = await get_default_user()
-            user_id = str(user.id) if hasattr(user, "id") else ""
+        user = await get_default_user()
+        user_id = str(user.id) if hasattr(user, "id") else ""
         if not user_id:
             return []
 

--- a/integrations/claude-code/scripts/pre-compact.py
+++ b/integrations/claude-code/scripts/pre-compact.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Build a memory anchor before context window compaction.
+
+Runs on the PreCompact hook (triggered when the context window is full
+or when the user manually compacts). Fetches session + graph context
+and outputs a markdown block that the compactor preserves.
+
+This ensures key knowledge survives context resets.
+"""
+
+import asyncio
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Add scripts dir to path for config import
+sys.path.insert(0, os.path.dirname(__file__))
+from config import load_config, get_session_id, get_dataset
+
+
+_RESOLVED_CACHE = Path.home() / ".cognee-plugin" / "resolved.json"
+_MIN_WORD_LEN = 2
+_SESSION_TOP_K = 5
+_GRAPH_TOP_K = 3
+
+
+def _load_resolved() -> tuple:
+    """Load session ID, dataset, and user ID from resolved cache."""
+    if _RESOLVED_CACHE.exists():
+        try:
+            data = json.loads(_RESOLVED_CACHE.read_text(encoding="utf-8"))
+            return data.get("session_id", ""), data.get("dataset", ""), data.get("user_id", "")
+        except Exception:
+            pass
+    config = load_config()
+    return get_session_id(config), get_dataset(config), ""
+
+
+async def _get_session_entries(session_id: str, cached_user_id: str = "") -> list:
+    """Fetch recent session entries from cache engine (lightweight)."""
+    try:
+        from cognee.infrastructure.databases.cache.get_cache_engine import get_cache_engine
+
+        user_id = cached_user_id
+        if not user_id:
+            from cognee.modules.users.methods import get_default_user
+            user = await get_default_user()
+            user_id = str(user.id) if hasattr(user, "id") else ""
+        if not user_id:
+            return []
+
+        cache_engine = get_cache_engine()
+        if cache_engine is None:
+            return []
+
+        entries = await cache_engine.get_all_qa_entries(user_id, session_id)
+        return list(entries)[-_SESSION_TOP_K:] if entries else []
+    except Exception:
+        return []
+
+
+async def _get_graph_context(query: str, dataset: str) -> list:
+    """Fetch relevant graph context via recall (heavier, but worth it before compaction)."""
+    try:
+        import cognee
+        results = await cognee.recall(
+            query_text=query,
+            datasets=[dataset],
+            top_k=_GRAPH_TOP_K,
+            auto_route=True,
+        )
+        return results if results else []
+    except Exception:
+        return []
+
+
+def _format_anchor(session_entries: list, graph_results: list) -> str:
+    """Format the memory anchor markdown block."""
+    sections = []
+
+    if session_entries:
+        lines = ["### Session Memory (recent actions)"]
+        for entry in session_entries:
+            if not isinstance(entry, dict):
+                continue
+            answer = entry.get("answer", "")
+            if answer:
+                # Truncate long entries
+                short = answer[:300] + "..." if len(answer) > 300 else answer
+                lines.append(f"- {short}")
+        if len(lines) > 1:
+            sections.append("\n".join(lines))
+
+    if graph_results:
+        lines = ["### Knowledge Graph (persistent memory)"]
+        for r in graph_results:
+            if isinstance(r, dict):
+                text = r.get("answer", r.get("text", r.get("content", str(r))))
+                source = r.get("_source", "graph")
+                short = text[:300] + "..." if len(text) > 300 else text
+                lines.append(f"- [{source}] {short}")
+            else:
+                lines.append(f"- {str(r)[:300]}")
+        if len(lines) > 1:
+            sections.append("\n".join(lines))
+
+    if not sections:
+        return ""
+
+    header = "## Cognee Memory Anchor\nPreserved context from session and knowledge graph:\n"
+    return header + "\n\n".join(sections)
+
+
+async def _run():
+    session_id, dataset, user_id = _load_resolved()
+    if not session_id:
+        return
+
+    # Fetch session entries (fast, cache-only)
+    session_entries = await _get_session_entries(session_id, user_id)
+
+    # Build a summary query from recent session entries for graph search
+    query_parts = []
+    for entry in session_entries[-3:]:
+        if isinstance(entry, dict):
+            answer = entry.get("answer", "")
+            # Extract key words from recent entries
+            words = {w for w in re.findall(r"\b\w+\b", answer.lower())
+                     if len(w) >= _MIN_WORD_LEN}
+            query_parts.extend(list(words)[:10])
+
+    graph_results = []
+    if query_parts:
+        query = " ".join(query_parts[:20])
+        graph_results = await _get_graph_context(query, dataset)
+
+    anchor = _format_anchor(session_entries, graph_results)
+    if anchor:
+        print(anchor)
+
+
+def main():
+    # Read stdin (PreCompact payload)
+    sys.stdin.read()
+
+    try:
+        asyncio.run(_run())
+    except Exception:
+        # Non-fatal: compaction proceeds without memory anchor
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -67,13 +67,14 @@ def _search_entries(entries: list, query_text: str) -> list:
 async def _get_entries(session_id: str, cached_user_id: str = "") -> list:
     """Load session entries via cognee's cache engine (lightweight imports only)."""
     from cognee.infrastructure.databases.cache.get_cache_engine import get_cache_engine
+    from cognee.modules.users.methods import get_default_user
 
-    # Use cached user ID from SessionStart, fall back to default user
-    user_id = cached_user_id
-    if not user_id:
-        from cognee.modules.users.methods import get_default_user
-        user = await get_default_user()
-        user_id = str(user.id) if hasattr(user, "id") else ""
+    # Always resolve to default user for cache lookups. The remember()
+    # session path uses the user from shared_kwargs which resolves to
+    # default_user in local mode. Using a different user_id here would
+    # miss entries stored by the PostToolUse hook.
+    user = await get_default_user()
+    user_id = str(user.id) if hasattr(user, "id") else ""
     if not user_id:
         return []
 

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Search session memory for context relevant to the user's prompt.
+
+Reads the UserPromptSubmit hook payload from stdin, searches the session
+cache for matching entries, and returns them as additionalContext.
+
+Uses cognee's cache engine directly (avoids heavy litellm/pipeline imports).
+Total import cost: ~500ms (structlog + pydantic + sqlalchemy + diskcache).
+
+Configuration:
+    Uses resolved session ID from SessionStart hook (via ~/.cognee-plugin/resolved.json).
+    Falls back to COGNEE_SESSION_ID env var.
+"""
+
+import asyncio
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Add scripts dir to path for config import
+sys.path.insert(0, os.path.dirname(__file__))
+from config import load_config, get_session_id
+
+
+_RESOLVED_CACHE = Path.home() / ".cognee-plugin" / "resolved.json"
+TOP_K = 3
+MIN_WORD_LEN = 2
+
+
+def _load_resolved() -> tuple:
+    """Load session ID and user ID from resolved cache, falling back to config."""
+    if _RESOLVED_CACHE.exists():
+        try:
+            data = json.loads(_RESOLVED_CACHE.read_text(encoding="utf-8"))
+            return data.get("session_id", ""), data.get("user_id", "")
+        except Exception:
+            pass
+    config = load_config()
+    return get_session_id(config), ""
+
+
+def _tokenize(text: str) -> set:
+    return {w for w in re.findall(r"\b\w+\b", text.lower()) if len(w) >= MIN_WORD_LEN}
+
+
+def _search_entries(entries: list, query_text: str) -> list:
+    query_words = _tokenize(query_text)
+    if not query_words:
+        return []
+
+    scored = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_text = " ".join(str(entry.get(f, "")) for f in ("question", "context", "answer"))
+        entry_words = _tokenize(entry_text)
+        hits = len(query_words & entry_words)
+        if hits > 0:
+            scored.append((hits, entry))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [entry for _, entry in scored[:TOP_K]]
+
+
+async def _get_entries(session_id: str, cached_user_id: str = "") -> list:
+    """Load session entries via cognee's cache engine (lightweight imports only)."""
+    from cognee.infrastructure.databases.cache.get_cache_engine import get_cache_engine
+
+    # Use cached user ID from SessionStart, fall back to default user
+    user_id = cached_user_id
+    if not user_id:
+        from cognee.modules.users.methods import get_default_user
+        user = await get_default_user()
+        user_id = str(user.id) if hasattr(user, "id") else ""
+    if not user_id:
+        return []
+
+    cache_engine = get_cache_engine()
+    if cache_engine is None:
+        return []
+
+    try:
+        entries = await cache_engine.get_all_qa_entries(user_id, session_id)
+        return list(entries) if entries else []
+    except Exception:
+        return []
+
+
+async def _run(prompt: str):
+    session_id, user_id = _load_resolved()
+    if not session_id:
+        return
+
+    entries = await _get_entries(session_id, user_id)
+    if not entries:
+        return
+
+    results = _search_entries(entries, prompt)
+    if not results:
+        return
+
+    lines = ["Relevant context from this session's memory:\n"]
+    for entry in results:
+        q = entry.get("question", "")
+        a = entry.get("answer", "")
+        t = entry.get("time", "")
+        if q:
+            lines.append(f"[{t}] Q: {q}")
+        if a:
+            a_short = a[:500] + "..." if len(a) > 500 else a
+            lines.append(f"A: {a_short}")
+        lines.append("")
+
+    context = "\n".join(lines).strip()
+    if not context or context == "Relevant context from this session's memory:":
+        return
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": context,
+        }
+    }
+    print(json.dumps(output))
+
+
+def main():
+    payload_raw = sys.stdin.read()
+    if not payload_raw.strip():
+        return
+
+    try:
+        payload = json.loads(payload_raw)
+    except json.JSONDecodeError:
+        return
+
+    prompt = payload.get("prompt", "")
+    if not prompt or len(prompt) < 5:
+        return
+
+    try:
+        asyncio.run(_run(prompt))
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -77,6 +77,32 @@ async def _start():
         file=sys.stderr,
     )
 
+    # Inject system guidance so Claude knows how to route data
+    guidance = {
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "systemMessage": (
+                "## Cognee Memory Connected\n"
+                f"Mode: {mode} | Dataset: {dataset} | Session: {session_id}\n\n"
+                "Cognee organizes knowledge into three categories. "
+                "When storing data with /cognee-memory:cognee-remember, "
+                "route to the correct category:\n\n"
+                "- **user_context** — user preferences, corrections, personal facts, "
+                "communication style. Use when the user says 'remember my preference', "
+                "'I always want', or shares personal details.\n"
+                "- **project_docs** — repository docs, code context, architecture decisions, "
+                "company data. Use when storing codebase knowledge, API docs, or project context.\n"
+                "- **agent_actions** — reasoning traces, conclusions, discovered patterns. "
+                "Use when you want to persist your own findings. "
+                "Routine tool call logging is automatic (no action needed).\n\n"
+                "When searching with /cognee-memory:cognee-search, you can filter by category "
+                "using --node-set (user_context, project_docs, or agent_actions).\n"
+                "If unsure which category, default to project_docs."
+            ),
+        }
+    }
+    print(json.dumps(guidance))
+
 
 def main():
     # Read stdin (SessionStart payload) — consumed but not used

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -54,11 +54,10 @@ async def _start():
     except Exception as e:
         print(f"cognee-plugin: init warning ({e})", file=sys.stderr)
 
-    # Create integration identity (claude-code@cognee.local)
+    # Register agent identity (claude-code@cognee.agent)
     user_id = ""
     try:
-        user = await ensure_identity()
-        user_id = str(user.id)
+        user_id = await ensure_identity(config)
     except Exception as e:
         print(f"cognee-plugin: identity warning ({e})", file=sys.stderr)
 

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Initialize Cognee memory at session start.
+
+Runs on the SessionStart hook. Responsibilities:
+  1. Load config (file + env vars)
+  2. Compute per-directory session ID
+  3. Connect to Cognee Cloud if configured
+  4. Configure local LLM if local mode
+  5. Write resolved session ID to env cache for other hooks
+
+The resolved session ID and dataset are written to a cache file
+so that the other hook scripts (which run in separate processes)
+can pick them up without re-computing.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+# Add scripts dir to path for config import
+sys.path.insert(0, os.path.dirname(__file__))
+from config import (
+    load_config, get_session_id, get_dataset,
+    ensure_cognee_ready, ensure_identity, save_config,
+)
+
+
+_RESOLVED_CACHE = Path.home() / ".cognee-plugin" / "resolved.json"
+
+
+def _write_resolved(session_id: str, dataset: str, user_id: str, cwd: str) -> None:
+    """Cache resolved session ID, dataset, and user ID for other hook scripts."""
+    _RESOLVED_CACHE.parent.mkdir(parents=True, exist_ok=True)
+    _RESOLVED_CACHE.write_text(json.dumps({
+        "session_id": session_id,
+        "dataset": dataset,
+        "user_id": user_id,
+        "cwd": cwd,
+    }, indent=2), encoding="utf-8")
+
+
+async def _start():
+    config = load_config()
+    cwd = os.environ.get("CLAUDE_CWD", os.getcwd())
+
+    session_id = get_session_id(config, cwd)
+    dataset = get_dataset(config)
+
+    # Configure cognee (cloud or local)
+    try:
+        await ensure_cognee_ready(config)
+    except Exception as e:
+        print(f"cognee-plugin: init warning ({e})", file=sys.stderr)
+
+    # Create integration identity (claude-code@cognee.local)
+    user_id = ""
+    try:
+        user = await ensure_identity()
+        user_id = str(user.id)
+    except Exception as e:
+        print(f"cognee-plugin: identity warning ({e})", file=sys.stderr)
+
+    # Write resolved values for other hooks
+    _write_resolved(session_id, dataset, user_id, cwd)
+
+    # Create config file on first run if it doesn't exist
+    config_file = Path.home() / ".cognee-plugin" / "config.json"
+    if not config_file.exists():
+        save_config(config)
+
+    mode = "cloud" if config.get("service_url") else "local"
+    print(
+        f"cognee-plugin: session ready (mode={mode}, "
+        f"session={session_id}, dataset={dataset}, user={user_id[:8]}...)",
+        file=sys.stderr,
+    )
+
+
+def main():
+    # Read stdin (SessionStart payload) — consumed but not used
+    sys.stdin.read()
+
+    try:
+        asyncio.run(_start())
+    except Exception as exc:
+        print(f"cognee-plugin: session start failed ({exc})", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -43,7 +43,7 @@ def _build_tool_text(payload: dict) -> str:
     tool_input = json.dumps(payload.get("tool_input", {}))[:MAX_TEXT]
     tool_response = str(payload.get("tool_output") or payload.get("tool_response", ""))[:MAX_TEXT]
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    return f"[{ts}] Tool: {tool_name}\nInput: {tool_input}\nOutput: {tool_response}"
+    return f"[category:agent] [{ts}] Tool: {tool_name}\nInput: {tool_input}\nOutput: {tool_response}"
 
 
 def _build_stop_text(payload: dict) -> str:
@@ -53,7 +53,7 @@ def _build_stop_text(payload: dict) -> str:
     if not msg or msg == "null":
         return ""
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    return f"[{ts}] Assistant response:\n{msg}"
+    return f"[category:agent] [{ts}] Assistant response:\n{msg}"
 
 
 async def _resolve_user(user_id: str):

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Store text into a Cognee session cache (lightweight, no cognify).
+
+Usage:
+    echo '{"tool_name":"Read","tool_input":{},"tool_output":"..."}' | python store-to-session.py
+    echo '{"assistant_message":"..."}' | python store-to-session.py --stop
+
+Configuration:
+    Uses resolved session ID from SessionStart hook (via ~/.cognee-plugin/resolved.json).
+    Falls back to COGNEE_SESSION_ID / COGNEE_PLUGIN_DATASET env vars.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Add scripts dir to path for config import
+sys.path.insert(0, os.path.dirname(__file__))
+from config import load_config, get_session_id, get_dataset
+
+
+_RESOLVED_CACHE = Path.home() / ".cognee-plugin" / "resolved.json"
+MAX_TEXT = 4000
+
+
+def _load_resolved() -> tuple:
+    """Load session ID, dataset, and user ID from resolved cache."""
+    if _RESOLVED_CACHE.exists():
+        try:
+            data = json.loads(_RESOLVED_CACHE.read_text(encoding="utf-8"))
+            return data.get("session_id", ""), data.get("dataset", ""), data.get("user_id", "")
+        except Exception:
+            pass
+    config = load_config()
+    return get_session_id(config), get_dataset(config), ""
+
+
+def _build_tool_text(payload: dict) -> str:
+    tool_name = payload.get("tool_name", "unknown")
+    tool_input = json.dumps(payload.get("tool_input", {}))[:MAX_TEXT]
+    tool_response = str(payload.get("tool_output") or payload.get("tool_response", ""))[:MAX_TEXT]
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return f"[{ts}] Tool: {tool_name}\nInput: {tool_input}\nOutput: {tool_response}"
+
+
+def _build_stop_text(payload: dict) -> str:
+    msg = str(payload.get("assistant_message") or payload.get("last_assistant_message", ""))[
+        :MAX_TEXT
+    ]
+    if not msg or msg == "null":
+        return ""
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return f"[{ts}] Assistant response:\n{msg}"
+
+
+async def _resolve_user(user_id: str):
+    """Resolve cached user ID to a User object, or fall back to default."""
+    if user_id:
+        try:
+            from uuid import UUID
+            from cognee.modules.users.methods import get_user
+            user = await get_user(UUID(user_id))
+            if user:
+                return user
+        except Exception:
+            pass
+    from cognee.modules.users.methods import get_default_user
+    return await get_default_user()
+
+
+async def _store(text: str, session_id: str, dataset: str, user_id: str):
+    """Call cognee.remember with session_id for lightweight session storage."""
+    import cognee
+
+    user = await _resolve_user(user_id)
+    result = await cognee.remember(
+        data=text,
+        dataset_name=dataset,
+        session_id=session_id,
+        user=user,
+    )
+
+    if not result:
+        status = getattr(result, "status", "unknown")
+        print(
+            f"cognee-session: store failed (status={status})",
+            file=sys.stderr,
+        )
+
+
+def main():
+    payload_raw = sys.stdin.read()
+    if not payload_raw.strip():
+        return
+
+    try:
+        payload = json.loads(payload_raw)
+    except json.JSONDecodeError:
+        return
+
+    is_stop = "--stop" in sys.argv
+
+    # Skip recursive cognee-cli / cognee calls
+    if not is_stop:
+        tool_name = payload.get("tool_name", "")
+        tool_input_str = json.dumps(payload.get("tool_input", {}))
+        if tool_name == "Bash" and "cognee" in tool_input_str:
+            return
+        text = _build_tool_text(payload)
+    else:
+        text = _build_stop_text(payload)
+
+    if not text:
+        return
+
+    session_id, dataset, user_id = _load_resolved()
+    asyncio.run(_store(text, session_id, dataset, user_id))
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Bridge session cache entries into the permanent knowledge graph on session end.
+
+Calls cognee.improve(session_ids=[...]) to run:
+  1. Apply feedback weights from session scores
+  2. Persist session Q&A into the permanent graph
+  3. Default enrichment (triplet embeddings)
+  4. Sync graph knowledge back into session cache
+
+Configuration:
+    Uses resolved session ID and dataset from SessionStart hook
+    (via ~/.cognee-plugin/resolved.json). Falls back to env vars.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+# Add scripts dir to path for config import
+sys.path.insert(0, os.path.dirname(__file__))
+from config import load_config, get_session_id, get_dataset
+
+
+_RESOLVED_CACHE = Path.home() / ".cognee-plugin" / "resolved.json"
+
+
+def _load_resolved() -> tuple:
+    """Load session ID, dataset, and user ID from resolved cache."""
+    if _RESOLVED_CACHE.exists():
+        try:
+            data = json.loads(_RESOLVED_CACHE.read_text(encoding="utf-8"))
+            return data.get("session_id", ""), data.get("dataset", ""), data.get("user_id", "")
+        except Exception:
+            pass
+    config = load_config()
+    return get_session_id(config), get_dataset(config), ""
+
+
+async def _resolve_user(user_id: str):
+    """Resolve cached user ID to a User object, or fall back to default."""
+    if user_id:
+        try:
+            from uuid import UUID
+            from cognee.modules.users.methods import get_user
+            user = await get_user(UUID(user_id))
+            if user:
+                return user
+        except Exception:
+            pass
+    from cognee.modules.users.methods import get_default_user
+    return await get_default_user()
+
+
+async def _sync():
+    import cognee
+
+    session_id, dataset, user_id = _load_resolved()
+    user = await _resolve_user(user_id)
+
+    result = await cognee.improve(
+        dataset=dataset,
+        session_ids=[session_id],
+        run_in_background=False,
+        user=user,
+    )
+
+    # Log summary to stderr (visible in hook output, not in Claude's context)
+    if result and isinstance(result, dict):
+        for ds_id, run_info in result.items():
+            status = getattr(run_info, "status", "unknown")
+            print(f"cognee-sync: dataset={ds_id} status={status}", file=sys.stderr)
+    else:
+        print(f"cognee-sync: dataset={dataset} session={session_id} completed", file=sys.stderr)
+
+
+def main():
+    # Read stdin (SessionEnd payload) but we only use config for IDs
+    sys.stdin.read()
+
+    try:
+        asyncio.run(_sync())
+    except Exception as exc:
+        # Non-fatal: session sync failure should not crash Claude Code
+        print(f"cognee-sync: failed ({exc})", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/claude-code/skills/cognee-remember/SKILL.md
+++ b/integrations/claude-code/skills/cognee-remember/SKILL.md
@@ -1,19 +1,42 @@
 ---
 name: cognee-remember
-description: Store data permanently in the Cognee knowledge graph via add + cognify. Use when the user explicitly wants to persist important information into the permanent graph (not just session cache).
+description: Store data permanently in the Cognee knowledge graph. Accepts a data category (user, project, or agent) to tag the data with the correct node_set for filtered retrieval.
 ---
 
 # Cognee Permanent Memory Storage
 
-Store data permanently in the Cognee knowledge graph.
+Store data permanently in the Cognee knowledge graph with category tagging.
+
+## Data categories
+
+Cognee organizes knowledge into three categories via `node_set` tagging:
+
+| Category | Node set | What belongs here |
+|----------|----------|-------------------|
+| **user** | `user_context` | User preferences, corrections, personal facts, communication style |
+| **project** | `project_docs` | Repository docs, code context, architecture decisions, company data |
+| **agent** | `agent_actions` | Tool call logs, reasoning traces, generated artifacts (auto-captured by hooks) |
 
 ## Instructions
 
-Run the cognee remember command with the data to store:
+Determine the category from the user's intent, then run:
 
+**User data** (preferences, corrections, personal context):
 ```bash
-cognee-cli remember "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}"
+cognee-cli remember "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set user_context
 ```
+
+**Project data** (docs, code, company knowledge):
+```bash
+cognee-cli remember "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set project_docs
+```
+
+**Agent data** (explicit agent notes — routine tool logs are automatic):
+```bash
+cognee-cli remember "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set agent_actions
+```
+
+If the category is unclear, default to **project**.
 
 The command outputs a summary after completion:
 
@@ -25,18 +48,23 @@ Data ingested and knowledge graph built successfully!
   Elapsed: 4.2s
 ```
 
-Use the dataset ID and content hash to track what was stored. If items_processed is 0 or the command errors, the data was not indexed and won't be searchable.
-
-**IMPORTANT**: Do NOT use the `-b` (background) flag. Running cognify in the background can result in data not being fully indexed and therefore not searchable. Always run in the foreground to ensure the full pipeline completes before returning.
+**IMPORTANT**: Do NOT use the `-b` (background) flag. Always run in the foreground to ensure the full pipeline completes.
 
 ## When to use
 
-- The user explicitly says to "remember this permanently" or "save this to the knowledge graph"
-- Important findings or conclusions that should persist beyond the current session
-- NOT for routine tool call logging (that uses session memory automatically)
+- User says "remember this" or "save this" → category **user**
+- User says "remember this about the project/codebase" → category **project**
+- You want to persist your own findings or conclusions → category **agent**
+- NOT for routine tool call logging (that's automatic via hooks with `agent_actions` tagging)
 
-## Note
+## Category routing guide
 
-This triggers the full add + cognify + improve pipeline, which builds entities and relationships in the knowledge graph, then enriches them with triplet embeddings. It is heavier than session storage. Routine tool call and response logging is handled automatically by the plugin hooks using the lightweight session cache path.
-
-After remembering, the graph knowledge is automatically synced back to the active session for fast retrieval during completions.
+| Signal | Category |
+|--------|----------|
+| "remember my preference for..." | user |
+| "I always want..." / "I prefer..." | user |
+| "remember this about the codebase" | project |
+| "save these docs" / "index this file" | project |
+| "note that this API works like..." | project |
+| "remember what we discovered" | agent |
+| Routine tool calls | agent (automatic, no action needed) |

--- a/integrations/claude-code/skills/cognee-remember/SKILL.md
+++ b/integrations/claude-code/skills/cognee-remember/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: cognee-remember
+description: Store data permanently in the Cognee knowledge graph via add + cognify. Use when the user explicitly wants to persist important information into the permanent graph (not just session cache).
+---
+
+# Cognee Permanent Memory Storage
+
+Store data permanently in the Cognee knowledge graph.
+
+## Instructions
+
+Run the cognee remember command with the data to store:
+
+```bash
+cognee-cli remember "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}"
+```
+
+The command outputs a summary after completion:
+
+```
+Data ingested and knowledge graph built successfully!
+  Dataset ID: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+  Items processed: 1
+  Content hash: a1b2c3d4...
+  Elapsed: 4.2s
+```
+
+Use the dataset ID and content hash to track what was stored. If items_processed is 0 or the command errors, the data was not indexed and won't be searchable.
+
+**IMPORTANT**: Do NOT use the `-b` (background) flag. Running cognify in the background can result in data not being fully indexed and therefore not searchable. Always run in the foreground to ensure the full pipeline completes before returning.
+
+## When to use
+
+- The user explicitly says to "remember this permanently" or "save this to the knowledge graph"
+- Important findings or conclusions that should persist beyond the current session
+- NOT for routine tool call logging (that uses session memory automatically)
+
+## Note
+
+This triggers the full add + cognify + improve pipeline, which builds entities and relationships in the knowledge graph, then enriches them with triplet embeddings. It is heavier than session storage. Routine tool call and response logging is handled automatically by the plugin hooks using the lightweight session cache path.
+
+After remembering, the graph knowledge is automatically synced back to the active session for fast retrieval during completions.

--- a/integrations/claude-code/skills/cognee-search/SKILL.md
+++ b/integrations/claude-code/skills/cognee-search/SKILL.md
@@ -1,22 +1,25 @@
 ---
 name: cognee-search
-description: Search Cognee memory. Session memory is automatically searched on every prompt via hooks. Use this skill explicitly for permanent knowledge graph search or when you need more results than the automatic lookup provides.
+description: Search Cognee memory. Session memory is automatically searched on every prompt via hooks. Use this skill explicitly for permanent knowledge graph search, filtered category search, or when you need more results than the automatic lookup provides.
 ---
 
 # Cognee Memory Search
 
-Search both session memory and the permanent knowledge graph.
+Search both session memory and the permanent knowledge graph, optionally filtered by data category.
 
 ## Automatic session search
 
-Session memory is searched **automatically on every user prompt** via the `UserPromptSubmit` hook. Relevant context from tool calls and responses in this session is injected into your context window without any manual action. You do not need to run this skill to access current-session context.
+Session memory is searched **automatically on every user prompt** via the `UserPromptSubmit` hook. You do not need to run this skill to access current-session context.
 
-## When to use this skill explicitly
+## Data categories
 
-Use this skill when you need to:
-- Search the **permanent knowledge graph** (cross-session, ingested data)
-- Get **more results** than the automatic lookup provides (auto returns top 3)
-- Search with a **different query** than the user's prompt
+Knowledge is organized into three categories via `node_set`:
+
+| Category | Node set | Contains |
+|----------|----------|----------|
+| **user** | `user_context` | User preferences, corrections, personal facts |
+| **project** | `project_docs` | Repository docs, code context, architecture decisions |
+| **agent** | `agent_actions` | Tool call logs, reasoning traces, generated artifacts |
 
 ## Instructions
 
@@ -26,10 +29,23 @@ Use this skill when you need to:
 cognee-cli recall "$ARGUMENTS" -s "${COGNEE_SESSION_ID:-claude_code_session}" -k 10 -f json
 ```
 
-### Search permanent graph (cross-session, ingested data)
+### Search permanent graph (all categories)
 
 ```bash
 cognee-cli recall "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" -k 5 -f json
+```
+
+### Search permanent graph (specific category)
+
+```bash
+# User data only
+cognee-cli recall "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set user_context -k 5 -f json
+
+# Project data only
+cognee-cli recall "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set project_docs -k 5 -f json
+
+# Agent data only
+cognee-cli recall "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set agent_actions -k 5 -f json
 ```
 
 ### Search both (session first, fallback to graph)
@@ -44,12 +60,15 @@ Results include a `_source` field:
 - `"session"` — from the session cache (current conversation)
 - `"graph"` — from the permanent knowledge graph
 
+Session entries tagged with `[category:agent]` are automatic tool call logs.
+
 ## Decision table
 
 | Signal | Action |
 |--------|--------|
 | Need current session context | Already automatic, no action needed |
-| "from last time" / "previous session" | Search permanent graph with `-d` |
-| "what do you know about X" | Try auto context first, then permanent graph |
-| User explicitly says "search cognee" | Search permanent graph with `-d` |
-| Auto context insufficient | Search session with `-s -k 10` for more results |
+| "what are my preferences" | Search graph with `--node-set user_context` |
+| "what does the codebase do" | Search graph with `--node-set project_docs` |
+| "what did we do last time" | Search graph (all categories) with `-d` |
+| User explicitly says "search cognee" | Search graph with `-d` |
+| Auto context insufficient | Search session with `-s -k 10` |

--- a/integrations/claude-code/skills/cognee-search/SKILL.md
+++ b/integrations/claude-code/skills/cognee-search/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: cognee-search
+description: Search Cognee memory. Session memory is automatically searched on every prompt via hooks. Use this skill explicitly for permanent knowledge graph search or when you need more results than the automatic lookup provides.
+---
+
+# Cognee Memory Search
+
+Search both session memory and the permanent knowledge graph.
+
+## Automatic session search
+
+Session memory is searched **automatically on every user prompt** via the `UserPromptSubmit` hook. Relevant context from tool calls and responses in this session is injected into your context window without any manual action. You do not need to run this skill to access current-session context.
+
+## When to use this skill explicitly
+
+Use this skill when you need to:
+- Search the **permanent knowledge graph** (cross-session, ingested data)
+- Get **more results** than the automatic lookup provides (auto returns top 3)
+- Search with a **different query** than the user's prompt
+
+## Instructions
+
+### Search session memory (current session, more results)
+
+```bash
+cognee-cli recall "$ARGUMENTS" -s "${COGNEE_SESSION_ID:-claude_code_session}" -k 10 -f json
+```
+
+### Search permanent graph (cross-session, ingested data)
+
+```bash
+cognee-cli recall "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" -k 5 -f json
+```
+
+### Search both (session first, fallback to graph)
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "$ARGUMENTS"
+```
+
+## Understanding results
+
+Results include a `_source` field:
+- `"session"` — from the session cache (current conversation)
+- `"graph"` — from the permanent knowledge graph
+
+## Decision table
+
+| Signal | Action |
+|--------|--------|
+| Need current session context | Already automatic, no action needed |
+| "from last time" / "previous session" | Search permanent graph with `-d` |
+| "what do you know about X" | Try auto context first, then permanent graph |
+| User explicitly says "search cognee" | Search permanent graph with `-d` |
+| Auto context insufficient | Search session with `-s -k 10` for more results |

--- a/integrations/claude-code/skills/cognee-sync/SKILL.md
+++ b/integrations/claude-code/skills/cognee-sync/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: cognee-sync
+description: Sync session cache entries into the permanent Cognee knowledge graph. Run this to make session memory searchable, or it runs automatically at session end.
+---
+
+# Sync Session to Permanent Graph
+
+Bridge session cache entries into the permanent knowledge graph.
+
+## Instructions
+
+Run the sync script:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/sync-session-to-graph.py
+```
+
+Or equivalently via CLI:
+
+```bash
+cognee-cli improve -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" -s "${COGNEE_SESSION_ID:-claude_code_session}"
+```
+
+## What this does
+
+1. **Apply feedback weights** -- session entries with feedback scores update graph node/edge weights
+2. **Persist session Q&A** -- cognifies session text into the permanent graph
+3. **Enrich triplets** -- extracts and indexes triplet embeddings for vector search
+4. **Sync graph to session** -- copies new graph relationships back into the session cache as a knowledge snapshot, so subsequent completions have instant access to the enriched graph context
+
+After this, session entries become searchable via `/cognee-memory:cognee-search`, and the graph knowledge is automatically included in session completion prompts.
+
+## When to use
+
+- Before searching for session content that hasn't been synced yet
+- When you want to force an early sync without waiting for session end
+- This runs automatically at session end via the SessionEnd hook

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -27,6 +27,17 @@ integrations:
     migration_status: done
     notes: "OpenClaw plugin with auto-recall/capture hooks"
 
+  - slug: claude-code
+    name: "Cognee Plugin for Claude Code"
+    owner: cognee
+    language: python
+    registry: none
+    package_name: null
+    cognee_dependency: sdk
+    current_version: "0.1.0"
+    migration_status: done
+    notes: "Claude Code plugin – session storage via hooks, recall via context lookup, session-to-graph sync"
+
   - slug: dify
     name: "Cognee Tool Plugin for Dify"
     owner: cognee


### PR DESCRIPTION
## Summary
- Migrate `cognee-claude-plugin` from cognee repo to `integrations/claude-code`
- Add shared config module with Cognee Cloud support (`cognee.serve()`)
- Add `SessionStart` hook (per-directory session ID, cloud init, `claude-code@cognee.local` identity)
- Add `PreCompact` hook (memory anchor before context window compaction)
- Update all scripts to use shared config and pass `user=` for proper UI separation
- Add to `inventory.yml`

## Test plan
- [ ] Verify all Python scripts parse: `python -c "import ast; ..."`
- [ ] Install plugin in Claude Code, verify SessionStart creates identity and resolved.json
- [ ] Verify PostToolUse captures tool calls to session cache
- [ ] Verify UserPromptSubmit injects session context
- [ ] Verify SessionEnd bridges session to permanent graph
- [ ] Test cloud mode with `COGNEE_SERVICE_URL`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)