### PR TITLE
fix(openclaw): remove process.env security block and fix autoSync startup

### DIFF
--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -341,29 +341,20 @@ const memoryCogneePlugin = {
         },
       });
 
-      // Fallback: poll for start() invocation. OpenClaw >= 2026.4.x does not call
-      // start() on services registered by memory-kind plugins (core bug). Poll every
-      // 500ms up to 10s so fast machines don't wait unnecessarily while slow ones
-      // still get coverage. The autoSyncStarted guard prevents double-execution if
-      // start() is called late or core fixes this.
-      let elapsed = 0;
-      const pollInterval = setInterval(() => {
-        elapsed += 500;
-        if (autoSyncStarted) {
-          clearInterval(pollInterval);
-          return;
-        }
-        if (elapsed >= 10_000) {
-          clearInterval(pollInterval);
-          const fallbackDir = process.env.OPENCLAW_WORKSPACE
-            || (api as any).runtime?.config?.loadConfig?.()?.agents?.defaults?.workspace
-            || `${process.env.HOME}/.openclaw/workspace`;
-          api.logger.info?.("cognee-openclaw: service start() not invoked, running auto-sync directly");
-          runAutoSync(fallbackDir).catch((e) => {
-            api.logger.warn?.(`cognee-openclaw: fallback auto-sync error: ${String(e)}`);
-          });
-        }
-      }, 500);
+      // Fallback: OpenClaw >= 2026.4.x does not call start() on services
+      // registered by memory-kind plugins (core bug). Instead of polling,
+      // schedule the auto-sync to run on the next tick. The autoSyncStarted
+      // guard prevents double-execution if start() is called later or the
+      // core bug is fixed.
+      setTimeout(() => {
+        if (autoSyncStarted) return;
+        const config = api.runtime?.config?.loadConfig?.();
+        const fallbackDir = config?.agents?.defaults?.workspace;
+        api.logger.info?.("cognee-openclaw: service start() not invoked, running auto-sync directly");
+        runAutoSync(fallbackDir).catch((e) => {
+          api.logger.warn?.(`cognee-openclaw: fallback auto-sync error: ${String(e)}`);
+        });
+      }, 2_000);
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes two issues reported by a user running OpenClaw >= 2026.4.9:

### 1. Security scanner blocks plugin installation
`plugin.ts` line 358 used `process.env.OPENCLAW_WORKSPACE` and `process.env.HOME` in the same execution context as HTTP calls to the Cognee API. OpenClaw's security scanner flagged this as:

> WARNING: Plugin "cognee-openclaw" contains dangerous code patterns: Environment variable access combined with network send — possible credential harvesting

**Fix**: Replaced `process.env` access with `api.runtime.config.loadConfig()?.agents?.defaults?.workspace` — reads the workspace path from OpenClaw's own config instead of raw env vars. `plugin.ts` now has zero `process.env` references.

### 2. autoSync not running at gateway startup
The `registerService({ start() })` call works on older OpenClaw but >= 2026.4.x doesn't invoke `start()` on memory-kind plugins. The 10-second polling fallback was unreliable because it depended on `setInterval` surviving across the gateway startup lifecycle.

**Fix**: Replaced the polling loop with a single `setTimeout(2000)` that fires once after activation. The 2s delay gives `registerService` a chance to invoke `start()` first; if it doesn't, the fallback triggers immediately. The `autoSyncStarted` guard prevents double-execution.

## Test plan
- [ ] Install the plugin on OpenClaw >= 2026.4.9 — no security warning
- [ ] Start the gateway — autoSync runs within 2s (check logs for `"running auto-sync directly"`)
- [ ] Verify `plugins list` still triggers sync (backward compat)
- [ ] Verify `registerService` path still works on older OpenClaw versions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)