### PR TITLE
(openclaw) Fix visualize endpoint typo + command output display

### DIFF
--- a/integrations/openclaw/package-lock.json
+++ b/integrations/openclaw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cognee/cognee-openclaw",
-  "version": "2026.3.6",
+  "version": "2026.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cognee/cognee-openclaw",
-      "version": "2026.3.6",
+      "version": "2026.4.12",
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^20.0.0",
@@ -916,6 +916,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3146,6 +3147,7 @@
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -3197,6 +3199,7 @@
       "integrity": "sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "e2e/*"
       ],
@@ -5193,6 +5196,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6423,6 +6427,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7346,6 +7351,7 @@
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7776,6 +7782,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -11187,6 +11194,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11731,6 +11739,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/integrations/openclaw/src/client.ts
+++ b/integrations/openclaw/src/client.ts
@@ -93,10 +93,11 @@ export class CogneeHttpClient {
     return {};
   }
 
-  async fetchJson<T>(
+  async fetchAPI<T>(
     path: string,
     init: RequestInit,
     timeoutMs = this.timeoutMs,
+    responseParser: (r: Response) => Promise<T> = async (r: Response) => (await r.json()) as T,
     retries = MAX_RETRIES,
   ): Promise<T> {
     await this.ensureAuth();
@@ -136,7 +137,7 @@ export class CogneeHttpClient {
               const errorText = await retryResponse.text();
               throw new Error(`Cognee request failed (${retryResponse.status}): ${errorText}`);
             }
-            return (await retryResponse.json()) as T;
+            return responseParser(response);
           } finally {
             clearTimeout(retryTimeout);
           }
@@ -202,7 +203,7 @@ export class CogneeHttpClient {
       formData.append("datasetId", params.datasetId);
     }
 
-    data = await this.fetchJson<CogneeAddResponse>(
+    data = await this.fetchAPI<CogneeAddResponse>(
       addPath,
       { method: "POST", body: formData },
       this.ingestionTimeoutMs,
@@ -243,7 +244,7 @@ export class CogneeHttpClient {
     const fileName = sanitizeFilePath(params.filePath);
     formData.append("data", new Blob([params.data], { type: "text/plain" }), fileName);
 
-    const data = await this.fetchJson<CogneeAddResponse>(
+    const data = await this.fetchAPI<CogneeAddResponse>(
       `/api/v1/update?${query.toString()}`,
       { method: "PATCH", body: formData },
       this.ingestionTimeoutMs,
@@ -261,7 +262,7 @@ export class CogneeHttpClient {
     try {
       const path = this.isCloud ? `/datasets/${datasetId}/data` : `/api/v1/datasets/${datasetId}/data`;
       type DataItem = { id: string; name: string };
-      const items = await this.fetchJson<DataItem[]>(path, { method: "GET" });
+      const items = await this.fetchAPI<DataItem[]>(path, { method: "GET" });
       if (!Array.isArray(items)) return undefined;
       const match = items.find((item) => item.name === fileName);
       return match?.id;
@@ -278,10 +279,10 @@ export class CogneeHttpClient {
     try {
       if (this.isCloud) {
         // Cloud: DELETE /datasets/{datasetId}/data/{dataId}
-        await this.fetchJson<unknown>(`/datasets/${params.datasetId}/data/${params.dataId}`, { method: "DELETE" });
+        await this.fetchAPI<unknown>(`/datasets/${params.datasetId}/data/${params.dataId}`, { method: "DELETE" });
       } else {
         const query = new URLSearchParams({ data_id: params.dataId, dataset_id: params.datasetId, mode: params.mode ?? "soft" });
-        await this.fetchJson<unknown>(`/api/v1/delete?${query.toString()}`, { method: "DELETE" });
+        await this.fetchAPI<unknown>(`/api/v1/delete?${query.toString()}`, { method: "DELETE" });
       }
       return { datasetId: params.datasetId, dataId: params.dataId, deleted: true };
     } catch (error) {
@@ -291,7 +292,7 @@ export class CogneeHttpClient {
 
   async cognify(params: { datasetIds?: string[] } = {}): Promise<{ status?: string }> {
     const path = this.isCloud ? "/cognify" : "/api/v1/cognify";
-    return this.fetchJson<{ status?: string }>(path, {
+    return this.fetchAPI<{ status?: string }>(path, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ datasetIds: params.datasetIds, runInBackground: true, temporal_cognify: true }),
@@ -300,7 +301,7 @@ export class CogneeHttpClient {
 
   async memify(params: { datasetIds?: string[] } = {}): Promise<{ status?: string }> {
     const datasetId = params.datasetIds?.[0];
-    return this.fetchJson<{ status?: string }>("/api/v1/memify", {
+    return this.fetchAPI<{ status?: string }>("/api/v1/memify", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ dataset_id: datasetId }),
@@ -316,7 +317,7 @@ export class CogneeHttpClient {
     sessionId?: string;
   }): Promise<CogneeSearchResult[]> {
     const searchPath = this.isCloud ? "/search" : "/api/v1/search";
-    const data = await this.fetchJson<unknown>(searchPath, {
+    const data = await this.fetchAPI<unknown>(searchPath, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -333,14 +334,19 @@ export class CogneeHttpClient {
 
   async listDatasets(): Promise<{ id: string; name: string }[]> {
     const path = this.isCloud ? "/datasets" : "/api/v1/datasets";
-    return this.fetchJson<{ id: string; name: string }[]>(path, { method: "GET" });
+    return this.fetchAPI<{ id: string; name: string }[]>(path, { method: "GET" });
   }
 
   async visualise(datasetId: string): Promise<unknown> {
     const path = this.isCloud
-      ? `/visualise?dataset_id=${datasetId}`
-      : `/api/v1/visualise?dataset_id=${datasetId}`;
-    return this.fetchJson<unknown>(path, { method: "GET" });
+      ? `/visualize?dataset_id=${datasetId}`
+      : `/api/v1/visualize?dataset_id=${datasetId}`;
+    return this.fetchAPI<unknown>(
+      path,
+      { method: "GET" },
+      this.timeoutMs,
+      async (r: Response) => (await r.text()),
+    );
   }
 
   /**
@@ -348,7 +354,7 @@ export class CogneeHttpClient {
    */
   async datasetStatus(datasetId: string): Promise<string> {
     const path = this.isCloud ? `/datasets/status?dataset_id=${datasetId}` : `/api/v1/datasets/status?dataset_id=${datasetId}`;
-    const resp = await this.fetchJson<Record<string, string>>(path, { method: "GET" });
+    const resp = await this.fetchAPI<Record<string, string>>(path, { method: "GET" });
     // Response is a dict keyed by dataset ID: { [datasetId]: "DATASET_PROCESSING_COMPLETED" }
     const status = resp[datasetId] ?? Object.values(resp)[0] ?? "unknown";
     return status.toLowerCase().replace("dataset_processing_", "");

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -233,7 +233,7 @@ const memoryCogneePlugin = {
           }
           try {
             const graph = await client.visualise(dsId);
-            console.log(JSON.stringify(graph, null, 2));
+            console.log(graph);
           } catch (error) {
             console.log(`Failed to visualise graph: ${error instanceof Error ? error.message : String(error)}`);
             process.exit(1);
@@ -525,7 +525,7 @@ const memoryCogneePlugin = {
 
             if (targetDatasetIds.length > 0) {
               // Call Cognee's session persistence endpoint via the generic fetchJson
-              await client.fetchJson("/api/v1/sessions/persist", {
+              await client.fetchAPI("/api/v1/sessions/persist", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({


### PR DESCRIPTION
## Changes in client.ts

* Fix typo in visualize endpoint
* Rename client fetchJson function to fetchAPI and add a new responseParser parameter that defaults to parse the HTTP response to JSON

* New responseParser parameter allows other API endpoints like visualize to parse the HTML response data as plain text

## Changes in plugin.ts

* Update calls to fetchAPI
* Print plain HTML graph data returned by the visualize endpoint to the console output

## Other updates
* Update package-lock.json