### PR TITLE
fix(claude-code): HTTP-first improve + non-blocking background

### DIFF
--- a/integrations/claude-code/hooks/hooks.json
+++ b/integrations/claude-code/hooks/hooks.json
@@ -18,7 +18,7 @@
           {
             "type": "command",
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/session-context-lookup.py",
-            "timeout": 3,
+            "timeout": 15,
             "statusMessage": "Searching session memory..."
           },
           {

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -8,6 +8,8 @@ they run on every user prompt / tool call.
 import json
 import os
 import sys
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -17,6 +19,11 @@ _RESOLVED_CACHE = _PLUGIN_DIR / "resolved.json"
 _HOOK_LOG = _PLUGIN_DIR / "hook.log"
 _COUNTER_FILE = _PLUGIN_DIR / "counter.json"
 _ACTIVITY_FILE = _PLUGIN_DIR / "activity.ts"
+_ACTIVITY_LOG = _PLUGIN_DIR / "activity.log"
+_SAVE_COUNTER = _PLUGIN_DIR / "save_counter.json"
+
+# Save-kinds tracked per turn. Keep this tuple in sync with bump_save_counter callers.
+SAVE_KINDS = ("prompt", "trace", "answer")
 
 # Cap the per-line log size so a noisy tool output doesn't bloat the file.
 _LOG_LINE_CAP = 600
@@ -77,9 +84,70 @@ def hook_log(event: str, detail: Optional[dict] = None) -> None:
         pass
 
 
+def _verbose_enabled() -> bool:
+    return os.environ.get("COGNEE_PLUGIN_VERBOSE", "").lower() in ("1", "true", "yes")
+
+
 def notify(msg: str) -> None:
-    """Print a status line to stderr (shown under the hook's status indicator)."""
-    print(f"cognee-plugin: {msg}", file=sys.stderr)
+    """Print a status line to stderr (shown under the hook's status indicator).
+
+    When ``COGNEE_PLUGIN_VERBOSE=1`` is set, also append a timestamped
+    line to ``~/.cognee-plugin/activity.log`` so saves that happen in
+    async hooks are ``tail -f``-visible (they never surface in the
+    Claude transcript on their own).
+    """
+    line = f"cognee-plugin: {msg}"
+    print(line, file=sys.stderr)
+    if _verbose_enabled():
+        try:
+            _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+            ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+            with _ACTIVITY_LOG.open("a", encoding="utf-8") as fh:
+                fh.write(f"{ts} {line}\n")
+        except Exception:
+            pass
+
+
+def bump_save_counter(session_id: str, kind: str) -> None:
+    """Record a save of ``kind`` (one of ``SAVE_KINDS``) for this session.
+
+    Used to surface per-turn save volume back to the user through the
+    next UserPromptSubmit's injected context. Cheap, best-effort file IO —
+    never raises.
+    """
+    if not session_id or kind not in SAVE_KINDS:
+        return
+    try:
+        data = json.loads(_SAVE_COUNTER.read_text(encoding="utf-8")) if _SAVE_COUNTER.exists() else {}
+    except Exception:
+        data = {}
+    sess = data.get(session_id) or {k: 0 for k in SAVE_KINDS}
+    sess[kind] = int(sess.get(kind, 0)) + 1
+    data[session_id] = sess
+    try:
+        _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        _SAVE_COUNTER.write_text(json.dumps(data), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def read_and_reset_save_counter(session_id: str) -> dict:
+    """Return the save-kind counts accumulated since the last reset, then zero them."""
+    zero = {k: 0 for k in SAVE_KINDS}
+    if not session_id:
+        return zero
+    try:
+        data = json.loads(_SAVE_COUNTER.read_text(encoding="utf-8")) if _SAVE_COUNTER.exists() else {}
+    except Exception:
+        return zero
+    sess = data.get(session_id) or zero
+    data[session_id] = dict(zero)
+    try:
+        _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        _SAVE_COUNTER.write_text(json.dumps(data), encoding="utf-8")
+    except Exception:
+        pass
+    return {k: int(sess.get(k, 0)) for k in SAVE_KINDS}
 
 
 def _auto_improve_threshold() -> int:
@@ -132,3 +200,63 @@ def touch_activity() -> None:
         _ACTIVITY_FILE.write_text(str(datetime.now(timezone.utc).timestamp()), encoding="utf-8")
     except Exception:
         pass
+
+
+def _local_api_url() -> str:
+    return os.environ.get("COGNEE_LOCAL_API_URL", "http://localhost:8000")
+
+
+def _backend_reachable(base_url: str, timeout: float = 1.5) -> bool:
+    try:
+        with urllib.request.urlopen(f"{base_url.rstrip('/')}/docs", timeout=timeout) as resp:
+            return 200 <= resp.status < 500
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return False
+
+
+def improve_via_http(
+    dataset: str,
+    session_id: str,
+    run_in_background: bool = False,
+    timeout: float = 600.0,
+) -> bool:
+    """POST /api/v1/improve to the running backend if reachable.
+
+    Returns True on HTTP 2xx, False if the backend is unreachable or the
+    request failed. Callers should fall back to the local SDK path on False.
+
+    Purpose: Kuzu is a single-writer graph DB. When the backend server is
+    running it holds the lock; a second process importing ``cognee.improve()``
+    fails mid-pipeline. Routing through HTTP lets the server — which owns
+    the lock — run improve() in its own process.
+    """
+    base_url = _local_api_url()
+    if not _backend_reachable(base_url):
+        return False
+    url = f"{base_url.rstrip('/')}/api/v1/improve"
+    payload = json.dumps(
+        {
+            "dataset_name": dataset,
+            "session_ids": [session_id],
+            "run_in_background": run_in_background,
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            hook_log(
+                "improve_http_ok",
+                {"status": resp.status, "dataset": dataset, "session": session_id},
+            )
+            return 200 <= resp.status < 300
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        hook_log(
+            "improve_http_failed",
+            {"error": str(exc)[:200], "dataset": dataset, "session": session_id},
+        )
+        return False

--- a/integrations/claude-code/scripts/idle-watcher.py
+++ b/integrations/claude-code/scripts/idle-watcher.py
@@ -81,9 +81,23 @@ def _install_signal_handlers() -> None:
 
 
 async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
-    """Fire one improve cycle. Returns True on success."""
+    """Fire one improve cycle. Returns True on success.
+
+    Prefers the running backend via HTTP to avoid Kuzu single-writer lock
+    conflicts — the backend server already holds the lock. Falls back to
+    the local SDK when no backend is reachable.
+    """
+    sys.path.insert(0, os.path.dirname(__file__))
     try:
-        sys.path.insert(0, os.path.dirname(__file__))
+        from _plugin_common import improve_via_http  # type: ignore
+
+        if improve_via_http(dataset, session_id, run_in_background=True):
+            _log("improve_via_http", session=session_id, dataset=dataset)
+            return True
+    except Exception as exc:
+        _log("improve_http_check_error", error=str(exc)[:200])
+
+    try:
         from config import ensure_cognee_ready, ensure_identity  # type: ignore
 
         await ensure_cognee_ready(config)
@@ -99,7 +113,7 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
             dataset=dataset,
             session_ids=[session_id],
             user=user,
-            run_in_background=False,
+            run_in_background=True,
         )
         return True
     except Exception as exc:

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -18,7 +18,7 @@ import sys
 
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
-from _plugin_common import hook_log, load_resolved, notify
+from _plugin_common import hook_log, load_resolved, notify, read_and_reset_save_counter
 from config import ensure_cognee_ready, get_session_id, load_config
 
 TOP_K = 3
@@ -83,6 +83,8 @@ async def _run(prompt: str):
         hook_log("no_session_id", {"event": "context_lookup"})
         return
 
+    saves_last_turn = read_and_reset_save_counter(session_id)
+
     try:
         results = await cognee.recall(
             prompt,
@@ -92,20 +94,31 @@ async def _run(prompt: str):
         )
     except Exception as exc:
         hook_log("recall_error", {"error": str(exc)[:200]})
-        return
-
-    if not results:
-        notify("no session matches")
-        hook_log("context_lookup_empty")
-        return
+        results = []
 
     # Bucket results by _source for human-readable output.
     by_source: dict[str, list] = {"session": [], "trace": [], "graph_context": []}
-    for r in results:
+    for r in results or []:
         if not isinstance(r, dict):
             continue
         src = r.get("_source", "session")
         by_source.setdefault(src, []).append(r)
+
+    counts = {k: len(v) for k, v in by_source.items()}
+    total = sum(counts.values())
+
+    # Build a one-line visibility header so the user (via the assistant's
+    # context) can tell that memory fired on this turn — both what it
+    # recalled right now and what the previous turn persisted.
+    recall_tag = (
+        f"🔍 cognee recall: {counts['session']} session / "
+        f"{counts['trace']} trace / {counts['graph_context']} graph-ctx hits"
+    )
+    saves_tag = (
+        f"💾 saves last turn: {saves_last_turn['prompt']} prompt / "
+        f"{saves_last_turn['trace']} trace / {saves_last_turn['answer']} answer"
+    )
+    header = f"{recall_tag}    |    {saves_tag}"
 
     section_lines = []
     if by_source.get("graph_context"):
@@ -124,18 +137,26 @@ async def _run(prompt: str):
             section_lines.append(_format_entry(e))
             section_lines.append("")
 
-    if not section_lines:
-        return
-
-    context = "Relevant context from this session's memory:\n\n" + "\n".join(section_lines).strip()
-    counts = {k: len(v) for k, v in by_source.items() if v}
-    hook_log("context_lookup_hit", {"counts": counts})
-    notify(f"injected context ({counts})")
+    if total > 0:
+        context = (
+            f"{header}\n\nRelevant context from this session's memory:\n\n"
+            + "\n".join(section_lines).strip()
+        )
+        hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
+        notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
+    else:
+        context = f"{header}\n\n(no memory matches for this prompt)"
+        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
+        notify(f"no recall matches; saves last turn {saves_last_turn}")
 
     output = {
         "hookSpecificOutput": {
             "hookEventName": "UserPromptSubmit",
             "additionalContext": context,
+            # Surfaces the one-line header to the user's terminal (UI),
+            # so they can see that memory fired even though the full
+            # context only goes to the model via additionalContext.
+            "systemMessage": header,
         }
     }
     print(json.dumps(output))

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -21,6 +21,7 @@ import sys
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
+    bump_save_counter,
     bump_turn_counter,
     hook_log,
     load_resolved,
@@ -39,9 +40,21 @@ _MAX_ASSISTANT_BYTES = 8000
 async def _fire_improve_background(dataset: str, session_id: str, user, reason: str) -> None:
     """Fire-and-forget improve() — intentionally detached from the caller.
 
-    Marked as background on the SDK so it doesn't block the hook's exit
-    path. Failures are logged but never raised.
+    Prefers POST /api/v1/improve against a running backend (avoids the
+    Kuzu single-writer lock). Falls back to the SDK path with
+    ``run_in_background=True`` when no backend is reachable. Failures are
+    logged but never raised.
     """
+    from _plugin_common import improve_via_http  # type: ignore
+
+    try:
+        if improve_via_http(dataset, session_id, run_in_background=True):
+            hook_log("auto_improve_fired", {"reason": reason, "session": session_id, "via": "http"})
+            notify(f"auto-improve fired via HTTP ({reason})")
+            return
+    except Exception as exc:
+        hook_log("auto_improve_http_error", {"reason": reason, "error": str(exc)[:200]})
+
     import cognee
 
     try:
@@ -51,7 +64,7 @@ async def _fire_improve_background(dataset: str, session_id: str, user, reason: 
             user=user,
             run_in_background=True,
         )
-        hook_log("auto_improve_fired", {"reason": reason, "session": session_id})
+        hook_log("auto_improve_fired", {"reason": reason, "session": session_id, "via": "sdk"})
         notify(f"auto-improve fired ({reason})")
     except Exception as exc:
         hook_log("auto_improve_error", {"reason": reason, "error": str(exc)[:200]})
@@ -170,6 +183,7 @@ async def _store_tool_call(payload: dict) -> None:
             },
         )
         notify(f"trace stored ({tool_name}, {status})")
+        bump_save_counter(session_id, "trace")
 
         touch_activity()
         count, should_improve = bump_turn_counter(session_id)
@@ -219,6 +233,7 @@ async def _store_assistant_stop(payload: dict) -> None:
     if result:
         hook_log("stop_stored", {"chars": len(msg), "qa_id": getattr(result, "entry_id", None)})
         notify(f"assistant message stored ({len(msg)} chars)")
+        bump_save_counter(session_id, "answer")
 
         touch_activity()
         count, should_improve = bump_turn_counter(session_id)

--- a/integrations/claude-code/scripts/store-user-prompt.py
+++ b/integrations/claude-code/scripts/store-user-prompt.py
@@ -15,7 +15,14 @@ import sys
 
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
-from _plugin_common import hook_log, load_resolved, notify, resolve_user, touch_activity
+from _plugin_common import (
+    bump_save_counter,
+    hook_log,
+    load_resolved,
+    notify,
+    resolve_user,
+    touch_activity,
+)
 from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
 
 MAX_TEXT = 4000
@@ -68,6 +75,7 @@ async def _store(prompt: str):
             "prompt_stored", {"chars": len(prompt), "qa_id": getattr(result, "entry_id", None)}
         )
         notify(f"user prompt stored ({len(prompt)} chars)")
+        bump_save_counter(session_id, "prompt")
         touch_activity()
 
 

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -7,6 +7,12 @@ Calls cognee.improve(session_ids=[...]) to run:
   3. Default enrichment (triplet embeddings)
   4. Sync graph knowledge back into session cache
 
+Execution path:
+    1. If a local backend is running (COGNEE_LOCAL_API_URL or
+       http://localhost:8000), POST to /api/v1/improve so the server
+       — which holds the Kuzu single-writer lock — runs the pipeline.
+    2. Otherwise, fall back to direct cognee.improve() SDK call.
+
 Configuration:
     Uses resolved session ID and dataset from SessionStart hook
     (via ~/.cognee-plugin/resolved.json). Falls back to env vars.
@@ -19,8 +25,9 @@ import signal
 import sys
 from pathlib import Path
 
-# Add scripts dir to path for config import
+# Add scripts dir to path for config/_plugin_common imports
 sys.path.insert(0, os.path.dirname(__file__))
+from _plugin_common import improve_via_http
 from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
 
 _RESOLVED_CACHE = Path.home() / ".cognee-plugin" / "resolved.json"
@@ -81,16 +88,25 @@ async def _resolve_user(user_id: str):
 async def _sync():
     import cognee
 
+    session_id, dataset, user_id = _load_resolved()
+
+    # Prefer the running backend to avoid the Kuzu single-writer lock.
+    if improve_via_http(dataset, session_id, run_in_background=True):
+        print(
+            f"cognee-sync: via HTTP dataset={dataset} session={session_id}",
+            file=sys.stderr,
+        )
+        return
+
+    # Fallback: no backend running → run improve() locally via the SDK.
     config = load_config()
     await ensure_cognee_ready(config)
-
-    session_id, dataset, user_id = _load_resolved()
     user = await _resolve_user(user_id)
 
     result = await cognee.improve(
         dataset=dataset,
         session_ids=[session_id],
-        run_in_background=False,
+        run_in_background=True,
         user=user,
     )
 


### PR DESCRIPTION
## Summary

Routes the plugin's improve/cognify calls through the running Cognee backend (HTTP) with fire-and-forget semantics, so hooks no longer block Claude Code on the full pipeline and don't collide with the Kuzu single-writer lock.

- **HTTP-first**: `sync-session-to-graph.py` and `idle-watcher.py` now POST to `/api/v1/improve` before falling back to the in-process SDK. The running backend already holds the Kuzu lock — a second process importing `cognee.improve()` fails mid-pipeline.
- **Non-blocking**: all improve paths pass `run_in_background=True`. The server accepts, queues, and the hook returns quickly.
- **Save-counter heartbeat**: `bump_save_counter` + `read_and_reset_save_counter` feed the per-turn "saves last turn: N prompt / M trace / K answer" line that renders on every UserPromptSubmit.
- **Timeout**: bump UserPromptSubmit context-lookup from 3s to 15s (3s was not enough for the initial cognee import + recall round-trip, leading to silent misses).

## Test plan

- [ ] Fresh Claude Code session shows `## Cognee Memory Connected` on start
- [ ] Each prompt shows `🔍 cognee recall: X session / Y trace / Z graph-ctx hits | 💾 saves last turn: N prompt / M trace / K answer`
- [ ] Auto-improve every 30 turns logs `auto_improve_fired` in `~/.cognee-plugin/hook.log` with `via: http`
- [ ] Session end triggers `improve: feedback weights applied` in backend log without Kuzu lock errors
- [ ] `sync-session-to-graph.py` run standalone returns in <10s when backend is reachable (not blocked on the full pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)