### PR TITLE
feat: add Codex Cognee plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Each integration lives under `integrations/<name>/` and is an independently publ
 ```
 integrations/
   openclaw/           -> @openclaw/memory-cognee (npm)
+  claude-code/        -> Cognee plugin for Claude Code
+  codex/              -> Cognee plugin marketplace for Codex
 ```
 
 ## Adding a New Integration

--- a/integrations/codex/.agents/plugins/marketplace.json
+++ b/integrations/codex/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "cognee-local",
+  "interface": {
+    "displayName": "Cognee Local Plugins"
+  },
+  "plugins": [
+    {
+      "name": "cognee",
+      "source": {
+        "source": "local",
+        "path": "./plugins/cognee"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Engineering"
+    }
+  ]
+}

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,0 +1,35 @@
+# Cognee Plugin Marketplace for Codex
+
+This integration packages Cognee skills for Codex as a local Codex plugin
+marketplace. It exposes CLI-first workflows for Cognee setup, memory, codebase
+ingestion, and local UI launch.
+
+## Contents
+
+- `.agents/plugins/marketplace.json` - local Codex marketplace definition.
+- `plugins/cognee/.codex-plugin/plugin.json` - Cognee Codex plugin manifest.
+- `plugins/cognee/skills/` - reusable Codex skills for Cognee CLI workflows.
+- `plugins/cognee/scripts/cognee-cli.sh` - helper that runs `uv run cognee-cli`
+  from a Cognee repository root.
+
+## Local Install
+
+From this directory:
+
+```bash
+codex plugin marketplace add .
+```
+
+Restart Codex, open the plugin directory, select `Cognee Local Plugins`, and
+install `Cognee`.
+
+## CLI Baseline
+
+The skills assume Cognee is available through the repository environment:
+
+```bash
+uv run cognee-cli --help
+uv run cognee-cli remember "Cognee turns documents into AI memory." -d notes
+uv run cognee-cli recall "What does Cognee do?" -d notes
+uv run cognee-cli -ui
+```

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "cognee",
+  "version": "1.0.3-local",
+  "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
+  "author": {
+    "name": "Topoteretes",
+    "url": "https://github.com/topoteretes"
+  },
+  "homepage": "https://docs.cognee.ai",
+  "repository": "https://github.com/topoteretes/cognee",
+  "license": "Apache-2.0",
+  "keywords": [
+    "memory",
+    "knowledge-graph",
+    "rag",
+    "cli",
+    "agents"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Cognee",
+    "shortDescription": "Use Cognee from Codex through the cognee CLI.",
+    "longDescription": "Reusable Codex skills for running Cognee's CLI workflows: configure local or cloud Cognee, remember and recall knowledge, ingest codebases, manage datasets, and launch the local UI with cognee-cli -ui. This plugin intentionally does not configure MCP.",
+    "developerName": "Topoteretes",
+    "category": "Engineering",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://docs.cognee.ai",
+    "defaultPrompt": [
+      "Use Cognee CLI to remember the important context in this repo.",
+      "Use Cognee CLI to recall what we know about this feature.",
+      "Launch the local Cognee UI with the CLI and check its health."
+    ],
+    "brandColor": "#6510F4"
+  }
+}

--- a/integrations/codex/plugins/cognee/README.md
+++ b/integrations/codex/plugins/cognee/README.md
@@ -1,0 +1,34 @@
+# Cognee Codex Plugin
+
+This plugin packages CLI-first Cognee workflows for Codex. It lives alongside
+the Claude Code integration in `cognee-integrations`, uses the Codex plugin
+manifest format, and does not configure MCP.
+
+## Contents
+
+- `.codex-plugin/plugin.json` - Codex plugin manifest.
+- `skills/` - reusable Codex instructions for Cognee CLI workflows.
+- `scripts/cognee-cli.sh` - optional helper that runs `uv run cognee-cli` from a
+  Cognee repository root.
+
+## Local Install
+
+From the Codex marketplace root, `integrations/codex`:
+
+```bash
+codex plugin marketplace add .
+```
+
+Restart Codex, open the plugin directory, select `Cognee Local Plugins`, and
+install `Cognee`.
+
+## CLI Baseline
+
+The skills assume Cognee is available through the repository environment:
+
+```bash
+uv run cognee-cli --help
+uv run cognee-cli remember "Cognee turns documents into AI memory." -d notes
+uv run cognee-cli recall "What does Cognee do?" -d notes
+uv run cognee-cli -ui
+```

--- a/integrations/codex/plugins/cognee/scripts/cognee-cli.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-cli.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${COGNEE_REPO_ROOT:-}" ]]; then
+  cd "$COGNEE_REPO_ROOT"
+elif [[ -f pyproject.toml ]] && grep -q '^name = "cognee"$' pyproject.toml; then
+  :
+else
+  echo "Run this from the Cognee repository root or set COGNEE_REPO_ROOT." >&2
+  exit 64
+fi
+
+exec uv run cognee-cli "$@"

--- a/integrations/codex/plugins/cognee/skills/codebase/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/codebase/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: codebase
+description: Use when ingesting, cognifying, or querying a codebase with Cognee CLI from Codex.
+---
+
+# Cognee CLI Codebase Workflows
+
+Use this skill when the user asks Codex to build a Cognee memory of a repository,
+index code, query implementation details, or create a code-aware knowledge graph.
+
+## Rules
+
+- Use `uv run cognee-cli ...`; do not use MCP.
+- Start by defining the codebase scope and dataset name.
+- Never ingest `.env`, private keys, credentials, local database files, virtualenvs, dependency caches, or generated build output.
+- Prefer focused ingestion over sending an entire large repository at once.
+- Use `rg --files` first to inspect candidate paths.
+
+## Scope
+
+Create a dataset name that is stable and readable, such as:
+
+```text
+codebase-cognee
+codebase-frontend
+codebase-api
+```
+
+Inspect candidate files:
+
+```bash
+rg --files
+```
+
+Common exclusions include:
+
+```text
+.git/
+.venv/
+node_modules/
+dist/
+build/
+.next/
+coverage/
+.env
+*.sqlite
+*.db
+*.key
+*.pem
+```
+
+## Ingest
+
+For a focused set of source paths:
+
+```bash
+uv run cognee-cli add <path-1> <path-2> <path-3> -d <dataset-name>
+uv run cognee-cli cognify -d <dataset-name> --background
+```
+
+For small docs or architectural notes:
+
+```bash
+uv run cognee-cli remember <path-or-note> -d <dataset-name>
+```
+
+If command length becomes unwieldy, ingest in batches by directory or feature
+area, then run `cognify` once for the dataset.
+
+## Query
+
+For code-specific questions:
+
+```bash
+uv run cognee-cli search "<implementation question>" -d <dataset-name> -t CODE -k 10 -f pretty
+```
+
+For architecture and reasoning questions:
+
+```bash
+uv run cognee-cli recall "<architecture question>" -d <dataset-name> -t GRAPH_COMPLETION -f pretty
+```
+
+For citation-like output:
+
+```bash
+uv run cognee-cli search "<specific symbol or behavior>" -d <dataset-name> -t CHUNKS -k 10 -f json
+```
+
+Use results as supporting context. Verify important claims against the actual
+files before editing code.

--- a/integrations/codex/plugins/cognee/skills/local-ui/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/local-ui/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: local-ui
+description: Use when launching, checking, or reporting on the local Cognee UI/backend through cognee-cli -ui.
+---
+
+# Cognee CLI Local UI
+
+Use this skill when the user asks to launch the local Cognee UI, check whether
+Cognee is running, or report how well the UI/backend work.
+
+## Rules
+
+- Use `uv run cognee-cli -ui` as the primary launcher.
+- Do not use MCP for this plugin.
+- Keep the process running when the user wants the UI available.
+- If ports are already occupied, inspect the running services before starting another copy.
+- Do not kill user processes without explicit approval.
+
+## Launch
+
+From the Cognee repository root:
+
+```bash
+uv run cognee-cli -ui
+```
+
+Expected local surfaces:
+
+```text
+Backend: http://localhost:8000
+Frontend: http://localhost:3000
+```
+
+## Health Checks
+
+Backend:
+
+```bash
+curl -i http://localhost:8000/health
+```
+
+Frontend:
+
+```bash
+curl -i http://localhost:3000/
+```
+
+Useful route checks:
+
+```bash
+curl -i http://localhost:3000/dashboard
+curl -i http://localhost:3000/datasets
+curl -i http://localhost:3000/search
+curl -i http://localhost:3000/knowledge-graph
+```
+
+If authenticated checks are needed, use the repository's documented local test
+credentials only when appropriate and do not expose real user credentials.
+
+## Reporting Status
+
+Report:
+
+- which process or command is running;
+- backend health and any warnings;
+- frontend route availability;
+- working authenticated flows, if checked;
+- broken or suspicious behavior with file references when possible.

--- a/integrations/codex/plugins/cognee/skills/memory/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/memory/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: memory
+description: Use when Codex should remember, recall, search, improve, or forget information using the Cognee CLI.
+---
+
+# Cognee CLI Memory
+
+Use this skill when the user asks Codex to use Cognee as memory, add facts or
+documents, search a knowledge graph, recall prior context, or improve existing
+memory.
+
+## Rules
+
+- Use `uv run cognee-cli ...`; do not use MCP.
+- Prefer `remember` for one-step ingestion and graph construction.
+- Use `add` plus `cognify` when ingestion and processing should be staged.
+- Choose a clear dataset name with `-d` or `--dataset-name`; ask only if the dataset boundary is genuinely ambiguous.
+- Do not ingest secrets, credentials, `.env` files, private keys, token dumps, or unrelated generated artifacts.
+- Before destructive commands such as `forget`, `delete`, or `--everything`, get explicit user confirmation.
+
+## Add And Build
+
+One-step ingestion:
+
+```bash
+uv run cognee-cli remember <text-or-path> -d <dataset-name>
+```
+
+For larger or staged work:
+
+```bash
+uv run cognee-cli add <text-or-path> -d <dataset-name>
+uv run cognee-cli cognify -d <dataset-name>
+```
+
+For long processing:
+
+```bash
+uv run cognee-cli remember <text-or-path> -d <dataset-name> --background
+uv run cognee-cli cognify -d <dataset-name> --background
+```
+
+## Recall And Search
+
+Memory-oriented recall:
+
+```bash
+uv run cognee-cli recall "<question>" -d <dataset-name> -f pretty
+```
+
+Search modes:
+
+```bash
+uv run cognee-cli search "<question>" -d <dataset-name> -t GRAPH_COMPLETION -f pretty
+uv run cognee-cli search "<exact passage or citation need>" -d <dataset-name> -t CHUNKS -k 10 -f pretty
+uv run cognee-cli search "<code question>" -d <dataset-name> -t CODE -k 10 -f pretty
+```
+
+Use `-f json` when downstream parsing is needed.
+
+## Improve Memory
+
+Enrich an existing graph:
+
+```bash
+uv run cognee-cli improve -d <dataset-name>
+```
+
+Bridge session feedback or Q&A into the graph:
+
+```bash
+uv run cognee-cli improve -d <dataset-name> -s <session-id>
+```
+
+For targeted enrichment:
+
+```bash
+uv run cognee-cli improve -d <dataset-name> --node-name <entity-name>
+```
+
+## Forget
+
+Use the narrowest deletion command possible and confirm first:
+
+```bash
+uv run cognee-cli forget --dataset <dataset-name>
+uv run cognee-cli forget --dataset <dataset-name> --data-id <data-uuid>
+```
+
+Avoid `uv run cognee-cli forget --everything` unless the user explicitly asks
+to delete all Cognee data.

--- a/integrations/codex/plugins/cognee/skills/setup/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/setup/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: setup
+description: Use when setting up, checking, or connecting Cognee through the cognee CLI from Codex.
+---
+
+# Cognee CLI Setup
+
+Use this skill when the user asks to configure Cognee, check whether Cognee is
+ready, connect to a local or cloud Cognee instance, or inspect CLI capability.
+
+## Rules
+
+- Use `uv run cognee-cli ...` as the primary interface.
+- Do not use MCP for this plugin.
+- Work from the Cognee repository root when available.
+- Do not print secret values from `.env`, config files, shell history, or command output.
+- If a command may create, delete, or overwrite durable Cognee state, say what it will affect before running it.
+
+## Checks
+
+Start with the local command surface:
+
+```bash
+uv run cognee-cli --help
+uv run cognee-cli --version
+```
+
+If dependencies are missing, use the repository command:
+
+```bash
+uv sync --dev --all-extras --reinstall
+```
+
+Inspect configuration without exposing values:
+
+```bash
+uv run cognee-cli config list
+```
+
+Use `config get <KEY>` only for non-secret settings. For secret-like keys,
+report whether the key appears configured rather than showing the value.
+
+## Connect
+
+For a local backend:
+
+```bash
+uv run cognee-cli serve --url http://localhost:8000
+```
+
+For a hosted instance with an API key, do not paste the key into the transcript.
+Use an environment variable or an already configured credential.
+
+To disconnect:
+
+```bash
+uv run cognee-cli serve --logout
+```
+
+## Multi-Agent Or API Mode
+
+When the user wants concurrent or multi-agent use, prefer a running Cognee API
+server and pass:
+
+```bash
+uv run cognee-cli --api-url http://localhost:8000 <command>
+```
+
+For isolated session history and permissions, include:
+
+```bash
+uv run cognee-cli --user-id <uuid> <command>
+```

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -38,6 +38,17 @@ integrations:
     migration_status: done
     notes: "Claude Code plugin – session storage via hooks, recall via context lookup, session-to-graph sync"
 
+  - slug: codex
+    name: "Cognee Plugin for Codex"
+    owner: cognee
+    language: markdown
+    registry: codex-marketplace
+    package_name: null
+    cognee_dependency: cli
+    current_version: "1.0.3-local"
+    migration_status: done
+    notes: "Codex local plugin marketplace with Cognee CLI skills for setup, memory, codebase ingestion, and UI launch"
+
   - slug: dify
     name: "Cognee Tool Plugin for Dify"
     owner: cognee


### PR DESCRIPTION
Summary: Adds integrations/codex as a local Codex plugin marketplace with the Cognee plugin manifest, CLI skills, helper script, README, and inventory entry. Tests: jq empty on both JSON manifests. python3 scripts/check_version_pins.py. git diff --check.