### PR TITLE
feat(claude-code): add cognee-graph-memory toolkit (cherry-pick friendly)

### DIFF
--- a/integrations/claude-code-cognee-graph-memory/CHANGELOG.md
+++ b/integrations/claude-code-cognee-graph-memory/CHANGELOG.md
@@ -1,0 +1,186 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.1] - 2026-05-04
+
+### Changed
+- Code style cleanup only — **no behavior changes**. v0.2.0 verification
+  results (UT 110 / IT 6 / ET 4 / ST 4 all passed; qwen2.5:14b matrix
+  verification 8 tools × 5 runs) remain valid because no logic was modified.
+- Applied Ruff lint fixes to comply with cognee-integrations coding
+  standards (`line-length = 100`, `select = ["E", "F", "I", "W"]`,
+  `target-version = "py310"`):
+  - `harness/hooks/auto_remember_completion.py`: F401 — unused
+    `import os` commented out and moved out of import block.
+  - `harness/hooks/auto_remember_user_message.py`: F401 — unused
+    `import os` and `import subprocess` commented out and moved out
+    of import block.
+  - `harness/hooks/cognee_remember_flusher.py`: F841 — `result =`
+    assignment commented out (function call retained); E501 — argparse
+    `--interval` line wrapped to fit 100-char limit.
+  - `src/knowledge_src/import_knowledge.py`: E501 — five logger and
+    argparse lines wrapped (one log message wording slightly shortened
+    while preserving meaning: "the failure" → "failure", "the cause"
+    → "cause").
+  - `src/main_src/import_to_graph.py`: I001 — `urllib.error` and
+    `urllib.request` imports reordered alphabetically; E501 — argparse
+    description and three help lines wrapped (one description shortened
+    while preserving meaning: "production runtime" → "runtime").
+
+### Why
+- Preparing the toolkit for potential cognee-integrations contribution
+  (per cognee co-founder Vasilije Markovic's invitation on X to send a
+  PR with toolkit features). The cognee-integrations CI enforces
+  Ruff lint rules above; passing those rules ahead of time avoids
+  CI rejections during the PR review process.
+
+## [0.2.0] - 2026-05-04
+
+### Added
+- New `knowledge/sample_knowledge/05_graph_memory_operations.md`: a sample
+  ingestion file documenting operational know-how for Cognee graph memory
+  (when to call cognify, remember vs. save_interaction, search-type choice,
+  recall auto-routing, and forget_memory/improve/prune usage). The bundled
+  sample count therefore increased from 4 to 5 files.
+
+### Changed
+- **Upgraded Cognee from 1.0.3 to 1.0.5**. Cognee 1.0.4 replaced the embedded graph
+  database from KuzuDB to **Ladybug DB**, and this distribution follows that change.
+  - Dependency: `kuzu==0.11.3` → `ladybug==0.16.0` (auto-replaced; backward-compatible aliases retained)
+  - Verified Cognee version: 1.0.5
+  - cognee-mcp version: 0.5.4 (no change)
+- Updated documentation to replace **"KuzuDB" with "Ladybug DB"** throughout:
+  - `README.md` (features and tech stack table)
+  - `config/.env.example` (COGNEE_DATA_PATH comments and storage description)
+  - `docs/SETUP.md` (verified versions and pinning examples)
+  - `docs/GETTING_STARTED.md` (verified Cognee version and measured response times)
+- Updated the bundled-sample file-count notation from 4 to 5:
+  - `README.md` (directory structure section)
+  - `docs/GETTING_STARTED.md` (including the `[N/M]` ingestion log examples)
+- Reorganized design-decision notes in
+  `knowledge/sample_knowledge/03_design_decisions.md`. KuzuDB/LanceDB/FastEmbed
+  are bundled with Cognee and used automatically, so they are not user-side
+  selections. The text was consolidated under "Why Cognee was adopted" and
+  notes that the graph DB is Ladybug DB in v0.2.0 / KuzuDB in v0.1.x.
+- Updated error-handling notes in
+  `knowledge/sample_knowledge/04_common_errors.md` so that local-LLM examples
+  use `qwen2.5:14b` (the only locally verified LLM for v0.2.0) instead of
+  `llama3.1:8b`.
+- Updated the recall failure-condition note in
+  `harness/rules/cognee_memory_usage.md` from "may fail when running on
+  `llama3.1:8b`" to "may fail when running on local LLMs other than
+  `qwen2.5:14b`".
+
+### Fixed (pre-existing source code defects from v0.1.10–v0.1.12)
+- `src/main_src/import_to_graph.py`:
+  - Removed a stale display line in `list_targets()` for the `comments` target
+    that was not defined in `TARGET_MAP` (a leftover from v0.1.10).
+  - `check_ollama()` now runs only when `LLM_PROVIDER=ollama`
+    (previously it failed unnecessarily when a cloud API was configured).
+  - `check_ollama()` is now skipped during `--dry-run`
+    (the dry-run mode only prints the file list and does not need Ollama).
+- `src/knowledge_src/import_knowledge.py`:
+  - Added the same `LLM_PROVIDER=ollama` guard to `check_ollama()`.
+- `harness/hooks/auto_remember_user_message.py`:
+  - Removed contradictory docstring lines that claimed "this sample provides the
+    simpler direct-call variant" while the actual implementation uses the queue
+    approach exclusively.
+- `harness/hooks/cognee_remember_flusher.py`:
+  - Fixed the `remaining` filter from `not line.strip()` to `line.strip()`
+    (an internal bug that caused failed entries to be silently dropped from
+    the queue; the data itself was still preserved in `failed.jsonl`, but
+    the queue — the source of retry attempts — held the wrong contents).
+  - Removed an unnecessary `sys.path.insert(main_src)` in `remember_via_mcp()`
+    (fastmcp is importable directly from the distribution's venv site-packages).
+
+### Verified (in v0.2.0)
+- **qwen2.5:14b (num_ctx=8192) × Ladybug DB: 35/40 ✅** verified
+  - remember 5/5 ✅, search(CHUNKS) 5/5 ✅, search(GRAPH_COMPLETION) 5/5 ✅, recall 5/5 ✅
+  - cognify 5/5 ✅, improve 5/5 ✅, forget_memory 5/5 ✅
+  - **save_interaction 0/5 ❌** (known limitation, see below)
+- **Ladybug DB (introduced in Cognee 1.0.4) accelerates graph traversal**, making
+  qwen2.5:14b practically usable (significant subjective improvement over the
+  v0.1.x KuzuDB environment).
+  - search(CHUNKS): avg 3.2s (deterministic, no LLM)
+  - search(GRAPH_COMPLETION): avg 14.6s (range 12-18s)
+  - recall (Q-A, TEMPORAL routing): 20-24s
+  - recall (Q-B, GRAPH_COMPLETION_COT routing): 154-156s
+  - improve / forget_memory: all immediate (under a few seconds)
+
+### Known Issues
+- **save_interaction is unavailable** (API mismatch between cognee-mcp 0.5.4 and cognee 1.0.5)
+  - Error: `add_rule_associations() got an unexpected keyword argument 'context'`
+  - Cause: cognee 1.0.5 renamed the `add_rule_associations` argument from `context` to `ctx`,
+    but cognee-mcp 0.5.4 has not been updated (upstream `topoteretes/cognee` main branch is
+    in the same state)
+  - Workaround: Use `remember` for immediate persistence of interaction text
+
+### Migration (from v0.1.x)
+- Existing graph DB data (KuzuDB) from Cognee 1.0.3 is automatically migrated to Ladybug
+  format on first startup of Cognee 1.0.4+.
+- To preserve existing data: `pip install -U "cognee[fastembed]==1.0.5"` and start Cognee
+  once → automatic migration runs.
+- To reset data: run `forget_memory(everything=True)` to clear all data, then re-cognify
+  in the Cognee 1.0.5 environment.
+
+## [0.1.12] - 2026-05-03
+
+### Fixed
+- Hardware notation in `README.md` and `docs/GETTING_STARTED.md` is now
+  expressed in terms of **VRAM capacity**, not GPU model name. Previous
+  text said "RTX 4070 12GB or higher", but the laptop variant of the
+  RTX 4070 has only 8GB of VRAM, which would mislead users into
+  thinking their laptop met the requirement when it does not. The
+  recommended threshold is now stated as "GPU with 12GB+ VRAM" with a
+  note about laptop variants. The verified-minimum entry is now
+  "NVIDIA GeForce RTX 4060 Laptop GPU (VRAM 8GB)" so the actual tested
+  device is named precisely.
+- `CHANGELOG.md` has been trimmed to keep only public-relevant
+  entries (v0.1.10 onward); the pre-public v0.1.0..v0.1.9 history was
+  internal development noise.
+
+## [0.1.11] - 2026-05-02
+
+### Changed
+- Switched the default local LLM in `config/.env.example` to
+  `qwen2.5:14b` (num_ctx=8192). Setup examples for Claude API and
+  OpenAI API are also included as comments.
+- Added a "Recommended LLM and Environment" section to
+  `docs/GETTING_STARTED.md`.
+  - Cloud APIs (Claude / OpenAI) are **strongly recommended** thanks
+    to their official structured-output support.
+  - Local LLM operation requires a GPU with **12GB+ VRAM** and
+    **qwen2.5:32b or larger** (14B is the practical minimum).
+- `src/main_src/import_to_graph.py` and
+  `src/knowledge_src/import_knowledge.py` now read `LLM_MODEL` from
+  `config/.env` dynamically (the previous `llama3.1:8b` hardcoding has
+  been removed).
+- Replaced `llama3.1:8b`-specific text in `docs/GETTING_STARTED.md`
+  with `qwen2.5:14b` / cloud-API guidance (sample-ingestion failure
+  fallback list, `recall` fallback notice, and the troubleshooting
+  section).
+
+## [0.1.10] - 2026-05-02
+
+### Added
+- Initial public release. A module that adds Cognee-based graph memory
+  to Claude Code.
+  - `src/main_src/start_cognee_mcp.py` — MCP server startup script
+  - `src/main_src/import_to_graph.py` — production ingestion
+  - `src/sample_src/load_sample.py` / `delete_sample.py` — bundled
+    sample handling
+  - `src/knowledge_src/split_knowledge.py` / `import_knowledge.py` —
+    user-knowledge ingestion pipeline
+  - `docs/SETUP.md` / `docs/GETTING_STARTED.md` /
+    `docs/HARNESS_GUIDE.md` — setup, usage, and harness installation
+    guides
+  - `knowledge/sample_knowledge/` — 4 bundled sample files for
+    end-to-end verification
+  - `harness/` — Claude Code × Cognee auto-accumulation harness
+    (optional)
+  - Fully local operation possible (Ollama + FastEmbed, no external
+    API keys required)

--- a/integrations/claude-code-cognee-graph-memory/LICENSE
+++ b/integrations/claude-code-cognee-graph-memory/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JapanNomu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHER FORM ACTION,
+ARISING FROM, IN CONNECTION WITH THE SOFTWARE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/integrations/claude-code-cognee-graph-memory/README.md
+++ b/integrations/claude-code-cognee-graph-memory/README.md
@@ -1,0 +1,172 @@
+# Claude Code + Cognee Graph Memory System
+
+**Version**: 0.2.1  
+**Verified Cognee version**: 1.0.5 (Ladybug DB)
+
+A module that adds graph-based memory to Claude Code. It accumulates work-related memory (rules, lessons learned, design decisions, incident records) across sessions, enabling retrieval in later sessions.
+
+---
+
+### [Claude Code × Cognee — Practical Know-How Accumulation Tool]
+
+**RAG gives you the answer. Cognee gives you the whole story.**
+Claude Code remembers why decisions were made.
+**Never say the same thing twice again.**
+
+With the auto-accumulation harness in `harness/`, the more you use Claude Code, the more your own personal know-how is recorded into Cognee graph memory — and decisions, context, and related facts come back to you in a connected chain. See `docs/HARNESS_GUIDE.md` for details.
+
+---
+
+## Why Cognee MCP alone is not sufficient
+
+1. **Cognee MCP only accepts file paths or text strings** — it has no built-in mechanism to automatically ingest Claude Code work logs or conversation text into graph memory
+2. **`import_to_graph.py` bridges this gap** — it can ingest files from `~/.claude/rules/` or any directory into Cognee
+3. **`start_cognee_mcp.py` connects Claude Code to Cognee** — without registering as an MCP server, Cognee cannot be used as a Claude Code tool
+
+---
+
+## Features
+
+- **Fully local** — Ollama + FastEmbed. No external API keys required, zero additional cost
+- **Cross-session** — Same graph memory accessible from any Claude Code session
+- **Graph + vector search** — High-precision recall powered by Ladybug DB (graph) + LanceDB (vector)
+- **Role-separated folders** — Production runtime, sample handling, and user knowledge ingestion are separated by folder
+
+---
+
+## Speed Improvements with Ladybug DB (v0.2.0 measured values)
+
+Ladybug DB (introduced in Cognee 1.0.4) accelerates graph traversal, making qwen2.5:14b (num_ctx=8192) practically usable (significant subjective improvement over the v0.1.x KuzuDB environment).
+
+| Tool | Response time | Notes |
+|---|---|---|
+| `search(CHUNKS)` | avg 3.2s (range 2-5s) | Deterministic, no LLM |
+| `search(GRAPH_COMPLETION)` | avg 14.6s (range 12-18s) | LLM inference, practical speed |
+| `recall` (Q-A, TEMPORAL routing) | 20-24s | Near-instant response class |
+| `recall` (Q-B, GRAPH_COMPLETION_COT routing) | 154-156s | Chain-of-Thought reasoning, slow but very accurate |
+| `improve` | All immediate (under a few seconds) | session_ids=None mode |
+| `forget_memory` | All immediate | Both `dataset` and `everything=True` modes |
+| `remember` (with synchronous cognify) | avg 92s (range 44-237s) | Includes entity extraction |
+| `cognify` (background processing) | avg 145s (range 99-232s) | For long documents; runs in background to avoid MCP timeout |
+
+Test environment: NVIDIA GeForce RTX 4060 Laptop GPU (VRAM 8GB) / RAM 32GB / qwen2.5:14b (num_ctx=8192) / Cognee 1.0.5 (Ladybug DB)
+
+---
+
+## Known Limitations (v0.2.0)
+
+- **`save_interaction` tool is unavailable**
+  - Error: `add_rule_associations() got an unexpected keyword argument 'context'`
+  - Cause: API mismatch between cognee-mcp 0.5.4 and cognee 1.0.5 (cognee 1.0.5 renamed the `context` argument to `ctx`, but cognee-mcp has not been updated)
+  - Workaround: To persist an interaction immediately, use `remember(data="User: ... / Assistant: ...")`
+
+All other tools (`remember`, `search`, `recall`, `cognify`, `improve`, `forget_memory`, etc.) have been verified to work correctly in v0.2.0.
+
+---
+
+## Reading order
+
+| Order | Document | Content |
+|---|---|---|
+| 1 | This `README.md` | Overview, prerequisites, directory structure |
+| 2 | `docs/SETUP.md` | Environment setup (venv creation, Ollama, MCP registration) |
+| 3 | `docs/GETTING_STARTED.md` | Operation verification, usage, ingestion of your own knowledge |
+| 4 | `docs/HARNESS_GUIDE.md` | Auto-accumulation harness setup (optional, strongly recommended) |
+
+---
+
+## Prerequisites
+
+### Verified environment
+
+| Item | Value |
+|------|---|
+| OS | Linux (Ubuntu 22.04 or later) / WSL2 |
+| Python | 3.12 or higher |
+| Ollama | Latest version (when using local LLM) |
+| LLM | qwen2.5:14b (num_ctx=8192) — local default. Cloud APIs (Claude / OpenAI) are strongly recommended for production. |
+| Claude Code | Latest version |
+
+### Recommended hardware
+
+| Use mode | GPU | RAM | LLM |
+|---------|-----|-----|-----|
+| **Cloud API (strongly recommended)** | Not required | 16GB+ | claude-sonnet-4-6 / gpt-4o, etc. |
+| Local LLM (recommended) | GPU with **12GB+ VRAM** (note: laptop RTX 4070 has only 8GB and does NOT qualify; desktop RTX 4070 / 4070 SUPER / 4070 Ti / 4080 etc. do) | 32GB+ | qwen2.5:32b or larger |
+| Local LLM (verified minimum) | NVIDIA GeForce RTX 4060 Laptop GPU (VRAM 8GB) | 32GB | qwen2.5:14b — practical speed on Ladybug DB (see "Speed Improvements with Ladybug DB" table above for measured response times) |
+
+See `docs/GETTING_STARTED.md` "Recommended LLM and Environment" for details.
+
+### Technology stack
+
+| Technology | Details |
+|------|------|
+| Graph memory engine | Cognee |
+| LLM (entity extraction) | qwen2.5:14b (default, local) / Claude API / OpenAI API |
+| LLM runtime | Ollama (local) or cloud API |
+| Graph DB | Ladybug DB (bundled with Cognee, replaced KuzuDB in 1.0.4) |
+| Vector DB | LanceDB (bundled with Cognee) |
+| Embedding model | FastEmbed all-MiniLM-L6-v2 |
+
+---
+
+## Directory structure
+
+```
+distribution root/
+├── README.md                     ← this file
+├── LICENSE                       MIT License
+│
+├── config/
+│   └── .env.example              Environment variable template (copy to config/.env)
+│
+├── docs/
+│   ├── SETUP.md                  Environment setup guide
+│   ├── GETTING_STARTED.md        Operation verification & usage
+│   └── HARNESS_GUIDE.md          Auto-accumulation harness setup
+│
+├── harness/                      Claude Code × Cognee auto-accumulation harness (optional, strongly recommended)
+│   ├── CLAUDE_md_sample.md       Snippet to append to your project's CLAUDE.md
+│   ├── rules/
+│   │   └── cognee_memory_usage.md   Long-form rule for ~/.claude/rules/
+│   ├── hooks/
+│   │   ├── auto_remember_user_message.py    UserPromptSubmit hook
+│   │   ├── auto_remember_completion.py      Stop hook
+│   │   └── cognee_remember_flusher.py       Queue drainer (cron recommended)
+│   └── settings.example.json     Merge into ~/.claude/settings.json
+│
+├── src/
+│   ├── main_src/                 Production runtime (active during Claude Code sessions)
+│   │   ├── start_cognee_mcp.py   MCP server startup script
+│   │   └── import_to_graph.py    Production ingestion (called from Claude Code)
+│   ├── sample_src/               Sample-related operations
+│   │   ├── load_sample.py        Load bundled samples
+│   │   └── delete_sample.py      Delete bundled samples
+│   └── knowledge_src/            Initial ingestion of your own knowledge (mitigates cognify failures, supports batched execution)
+│       ├── split_knowledge.py    Split files (by H2 heading)
+│       └── import_knowledge.py   Ingest with retry support
+│
+└── knowledge/
+    ├── sample_knowledge/         Bundled sample data (5 files)
+    ├── user_knowledge/           Place your knowledge source files here (see folder README)
+    └── user_chunks/              Auto-generated split files for ingestion
+```
+
+---
+
+## Quick start
+
+1. Follow `docs/SETUP.md` to set up your environment
+2. Run `src/venv/bin/python3 src/sample_src/load_sample.py` to load sample data
+3. Try the example queries in `docs/GETTING_STARTED.md`
+4. Follow `docs/HARNESS_GUIDE.md` to enable the harness (**strongly recommended** — this is what makes your know-how accumulate automatically)
+
+To ingest your own knowledge, see "Step 4: Ingest your own knowledge" in `docs/GETTING_STARTED.md`.
+
+---
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+Copyright (c) 2026 JapanNomu

--- a/integrations/claude-code-cognee-graph-memory/config/.env.example
+++ b/integrations/claude-code-cognee-graph-memory/config/.env.example
@@ -1,0 +1,64 @@
+# ============================================================
+# Cognee settings (no changes required by default)
+# ============================================================
+
+# Cognee data root (where Ladybug DB and LanceDB files are stored)
+COGNEE_DATA_PATH=./data/cognee
+
+# LLM settings
+# Default is qwen2.5:14b (num_ctx=8192) — verified on RTX 4060 8GB with 20/20 feature success.
+# Cloud APIs (Claude / OpenAI) are strongly recommended. See docs/GETTING_STARTED.md "Recommended LLM and Environment".
+#
+# To use Claude API:
+#   LLM_PROVIDER=anthropic
+#   LLM_MODEL=claude-sonnet-4-6
+#   LLM_ENDPOINT=https://api.anthropic.com
+#   LLM_API_KEY=<your_anthropic_api_key>
+#
+# To use OpenAI API:
+#   LLM_PROVIDER=openai
+#   LLM_MODEL=gpt-4o
+#   LLM_ENDPOINT=https://api.openai.com/v1
+#   LLM_API_KEY=<your_openai_api_key>
+#
+# To use local Ollama (default):
+LLM_PROVIDER=ollama
+LLM_MODEL=qwen2.5:14b
+LLM_ENDPOINT=http://localhost:11434/v1
+LLM_API_KEY=ollama
+
+# Embedding model settings (leave as-is when using FastEmbed)
+EMBEDDING_PROVIDER=fastembed
+EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
+EMBEDDING_DIMENSIONS=384
+HUGGINGFACE_TOKENIZER=sentence-transformers/all-MiniLM-L6-v2
+
+
+# ============================================================
+# Data persistence paths (REQUIRED: set absolute paths for your environment)
+# ============================================================
+#
+# This system stores Cognee's graph DB (Ladybug DB) and vector DB (LanceDB)
+# in local directories. The settings below specify those locations as absolute paths.
+#
+# How to configure:
+#   1. `cd` into this distribution directory in your terminal
+#   2. Run `pwd` to obtain the absolute path
+#   3. Substitute that path into the values below
+#
+# Example: distribution placed at `/home/yourname/cognee-system/`:
+#   SYSTEM_ROOT_DIRECTORY=/home/yourname/cognee-system/data/cognee/system
+#   DATA_ROOT_DIRECTORY=/home/yourname/cognee-system/data/cognee/data
+#
+# Example: WSL2 (Windows) at `/home/yourname/projects/cognee/`:
+#   SYSTEM_ROOT_DIRECTORY=/home/yourname/projects/cognee/data/cognee/system
+#   DATA_ROOT_DIRECTORY=/home/yourname/projects/cognee/data/cognee/data
+#
+# Important:
+# - Relative paths (e.g. `./data/cognee/...`) are NOT supported
+# - Always use absolute paths (starting with `/`)
+# - The directories `data/cognee/system` and `data/cognee/data` are created automatically
+#   (no need to create them manually)
+#
+SYSTEM_ROOT_DIRECTORY=/your/absolute/path/to/project/data/cognee/system
+DATA_ROOT_DIRECTORY=/your/absolute/path/to/project/data/cognee/data

--- a/integrations/claude-code-cognee-graph-memory/docs/GETTING_STARTED.md
+++ b/integrations/claude-code-cognee-graph-memory/docs/GETTING_STARTED.md
@@ -1,0 +1,315 @@
+# GETTING STARTED — Claude Code + Cognee Graph Memory: Operation Verification & Usage
+
+This document explains how to verify the system after setup and how to ingest your own knowledge.
+
+If you have not completed setup yet, please refer to `docs/SETUP.md` first.
+
+---
+
+## Recommended LLM and Environment
+
+### Recommended LLM (strongly recommended)
+
+To use all features (especially `recall` and `search(GRAPH_COMPLETION)`) **reliably**, we strongly recommend using a **cloud LLM API** that handles Cognee's structured output requirements consistently.
+
+| Tier | LLM | Recommendation |
+|------|-----|------|
+| Cloud API (**strongly recommended**) | **Anthropic Claude API** (claude-sonnet-4-6, etc.) / **OpenAI API** (gpt-4o, etc.) | ★★★ Near-100% reliability with official structured-output support |
+| Local LLM (conditionally OK) | qwen2.5:14b / qwen2.5:32b / qwen2.5:72b / llama3.3:70b — 14B or larger | ★★ Acceptable if your GPU has enough memory |
+| Local LLM (**not recommended**) | Models smaller than qwen2.5:14b (llama3.1:8b / llama3.2:3b / gemma4:e4b, etc.) | ★ Frequent JSON Schema violations in structured output |
+
+Local LLM operation avoids API billing, but its structured-output reliability is clearly inferior to cloud APIs. For production use or stable operation, choose a cloud API.
+
+### Recommended Environment
+
+| Item | Cloud API mode | Local LLM mode |
+|------|---------------|---------------|
+| GPU | Not required | **GPU with 12GB+ VRAM** recommended (note: laptop RTX 4070 has only 8GB and does NOT qualify; desktop RTX 4070 / 4070 SUPER / 4070 Ti / 4080 etc. do) |
+| RAM | 16GB+ | **32GB+** |
+| LLM | claude-sonnet-4-6 / gpt-4o, etc. | **qwen2.5:32b or higher** (14B+ is the minimum) |
+
+Local LLM operation becomes practical with **a GPU that has 12GB+ VRAM**. With less VRAM (e.g. NVIDIA GeForce RTX 4060 Laptop GPU with 8GB VRAM), 14B-class models can still run, but model weights spill out of GPU memory and partially offload to CPU.
+
+### Verification Record (reference)
+
+This distribution's full feature set has been verified in the following environment:
+
+- Test environment: GPU **NVIDIA GeForce RTX 4060 Laptop GPU (VRAM 8GB)** / RAM 32GB
+- Test LLM: **qwen2.5:14b** (num_ctx=8192)
+- Verified Cognee version: **1.0.5 (Ladybug DB)**
+- Result: **35/40 success** (remember 5/5 ✅, search(CHUNKS) 5/5 ✅, search(GRAPH_COMPLETION) 5/5 ✅, recall 5/5 ✅, cognify 5/5 ✅, improve 5/5 ✅, forget_memory 5/5 ✅, **save_interaction 0/5 ❌** = known limitation, see below)
+- Response time (measured on Ladybug DB):
+  - search(CHUNKS): avg 3.2s (deterministic, no LLM)
+  - search(GRAPH_COMPLETION): avg 14.6s (range 12-18s)
+  - recall (Q-A, TEMPORAL routing): 20-24s
+  - recall (Q-B, GRAPH_COMPLETION_COT routing): 154-156s (Chain-of-Thought reasoning)
+  - improve / forget_memory: all immediate (under a few seconds)
+
+**Ladybug DB (introduced in Cognee 1.0.4) accelerates graph traversal**, making GRAPH_COMPLETION and recall practically usable even with qwen2.5:14b (significant subjective improvement over the v0.1.x KuzuDB environment).
+
+In other words, the distribution **runs all major features at practical speed on an 8GB-VRAM laptop GPU (RTX 4060 Laptop GPU) with qwen2.5:14b + Ladybug DB**.
+
+### Default Configuration
+
+The default `config/.env.example` ships with **qwen2.5:14b** (num_ctx=8192). If you want to use a cloud API, edit `LLM_PROVIDER` / `LLM_MODEL` / `LLM_API_KEY` / `LLM_ENDPOINT` (see `docs/SETUP.md` for details).
+
+---
+
+## Step 1: Verify operation with bundled samples
+
+Run the following in your terminal.
+
+```bash
+cd <cloned directory>
+src/venv/bin/python3 src/sample_src/load_sample.py
+```
+
+The five files under `knowledge/sample_knowledge/` will be ingested into Cognee one by one.
+
+```
+2026-04-29 10:00:00 [INFO] [1/5] 01_claude_code_tips.md → dataset=sample_knowledge
+2026-04-29 10:00:30 [INFO] [2/5] 02_software_dev_lessons.md → dataset=sample_knowledge
+...
+```
+
+Time estimate: 2-5 minutes (includes Ollama graph processing).
+
+### If sample ingestion fails
+
+When running on a local LLM, the model sometimes returns unstable responses that cause structured-output validation errors. After 5 retries the script may abort with errors such as `InstructorRetryException` or `Field required`. If this happens, clean up and retry:
+
+```bash
+# Remove any partially-ingested sample data
+src/venv/bin/python3 src/sample_src/delete_sample.py
+
+# Re-ingest the samples
+src/venv/bin/python3 src/sample_src/load_sample.py
+```
+
+If the failure persists, check that Ollama is reachable (`ollama list` should show the model), try a larger local LLM (e.g. `qwen2.5:32b` / `qwen2.5:72b` / `llama3.3:70b`) by changing `LLM_MODEL` in `config/.env`, or **switch to a cloud API (Claude / OpenAI)** — this error rarely happens with cloud APIs.
+
+---
+
+## Step 2: Launch Claude Code and call MCP tools
+
+Open a new Claude Code session (it can be a different session from the ingestion).
+
+Try the following queries in the chat to retrieve knowledge from graph memory.
+
+---
+
+### Scenario A: Ask about Claude Code usage
+
+**Your input:**
+
+```
+search("Tell me about the timing of git push", search_type="CHUNKS")
+```
+
+Or in natural language:
+
+```
+recall("When can I run git push?")
+```
+
+> ⚠️ With local LLMs (especially models 8B and below), `recall` may fail with an "LLM format error". If it fails, use `search(query, search_type="CHUNKS")` as a fallback (see Troubleshooting at the bottom of this file). Cloud APIs and qwen2.5:14b or larger handle `recall` reliably.
+
+**Expected response:**
+
+> "Run `git push` only when the user explicitly instructs to. Task or phase completion is not a reason to push."
+
+---
+
+### Scenario B: Look up past errors
+
+```
+search("How to handle errors when Ollama is unreachable", search_type="CHUNKS")
+```
+
+**Expected response:**
+
+> "Run `ollama serve` and retry. Also check whether the configured local LLM (default: qwen2.5:14b) is downloaded with `ollama list`."
+
+---
+
+### Scenario C: Retrieve design rationale
+
+```
+search("Why KuzuDB is used", search_type="CHUNKS")
+```
+
+**Expected response:**
+
+> "Python-native, in-process execution, bundled with Cognee (no extra installation). It was the only choice that satisfied the local-only and zero-cost requirements."
+
+---
+
+### Scenario D: Retrieve development lessons
+
+```
+search("Where to derive test expected values from", search_type="CHUNKS")
+```
+
+**Expected response:**
+
+> "Unit-test expected values must be derived from the IF specification. Reading the implementation code to determine expected values is forbidden."
+
+---
+
+## Step 3: Register your own knowledge ad hoc (single record)
+
+You can register knowledge gained on the fly by calling the `remember` tool from Claude Code.
+
+```
+remember("Today's lesson: Always take a backup before running Django migrate. There was a non-rollback-capable table change.", dataset_name="my_lessons")
+```
+
+In a later session:
+
+```
+recall("What should I watch out for with Django migrate?")
+```
+
+Returns the knowledge you registered.
+
+> ⚠️ If `recall` fails with an "LLM format error", use `search("Django migrate", search_type="CHUNKS")` as a fallback.
+
+---
+
+## Step 4: Ingest your own knowledge in bulk
+
+Steps to ingest existing knowledge files (`.md`).
+
+### Step 4-1: Delete sample data (optional)
+
+If you no longer need the bundled samples:
+
+```bash
+src/venv/bin/python3 src/sample_src/delete_sample.py
+```
+
+Only the `sample_knowledge` dataset is removed.
+
+### Step 4-2: Place your knowledge under user_knowledge/
+
+Place `.md` files under `knowledge/user_knowledge/`. You can use sub-folders by category.
+
+```
+knowledge/user_knowledge/
+├── project-management/
+│   └── task-management.md
+├── design/
+│   └── db-design.md
+└── lessons/
+    └── past-incidents.md
+```
+
+### Step 4-3: Split the knowledge
+
+```bash
+src/venv/bin/python3 src/knowledge_src/split_knowledge.py
+```
+
+Each `.md` under `user_knowledge/` is split by H2 heading and written to `knowledge/user_chunks/`.
+
+### Step 4-4: Ingest the chunks
+
+```bash
+src/venv/bin/python3 src/knowledge_src/import_knowledge.py
+```
+
+Files in `user_chunks/` are ingested into Cognee one at a time, with retries on cognify failure.
+
+Time estimate: tens of seconds to a few minutes per file. For 100 files, roughly tens of minutes to several hours.
+
+### Step 4-5: Preview the ingestion list
+
+```bash
+src/venv/bin/python3 src/knowledge_src/import_knowledge.py --dry-run
+```
+
+A dry-run shows the file list that would be ingested.
+
+---
+
+## Tool reference
+
+| Tool | Purpose | Example |
+|-------|------|---|
+| `remember(data, dataset_name)` | Register knowledge / decisions / lessons | `remember("...", dataset_name="lessons")` |
+| `recall(query)` | Semantic search using graph + LLM (fallback to `search` on failure) | `recall("What were past incidents?")` |
+| `search(search_query, search_type="CHUNKS")` | Retrieve text directly via vector search | `search("How to handle errors", search_type="CHUNKS")` |
+| `list_data()` | Show registered datasets | `list_data()` |
+| `prune()` | Reset all data | `prune()` |
+
+---
+
+## Troubleshooting
+
+**`save_interaction` fails with `add_rule_associations() got an unexpected keyword argument 'context'`**
+→ This is a **known limitation in v0.2.0**. API mismatch between cognee-mcp 0.5.4 and cognee 1.0.5
+(cognee 1.0.5 renamed the `add_rule_associations` argument from `context` to `ctx`, but cognee-mcp
+has not been updated yet).
+As a workaround, use `remember(data="User: question\nAssistant: answer")` instead — this persists
+the interaction text immediately into the permanent memory.
+
+**SearchPreconditionError**
+→ No data has been ingested yet. Run Step 1 first.
+
+**`recall` returns empty results**
+→ Graph processing might still be running. Check completion with `cognify_status()` and retry.
+
+**LLM format error during `recall`**
+→ Local LLMs (especially models 8B and below) sometimes do not respond in the JSON format Cognee expects. Use `search(query, search_type="CHUNKS")` as a fallback, or switch to a larger local LLM (qwen2.5:14b or above) or a **cloud API (Claude / OpenAI)**.
+
+**Knowledge ingestion shows `status=errored`**
+→ The file may be too large. Run `split_knowledge.py` to split it before ingesting. `import_knowledge.py` retries up to 3 times on failure.
+
+---
+
+## Appendix: v0.1.x (Cognee 1.0.3 / KuzuDB) Local LLM Comparison Data (Reference)
+
+> This section is a reference record of the local-LLM comparison verification data from v0.1.x (KuzuDB environment). In v0.2.0, the graph DB has been replaced with Ladybug DB, and only qwen2.5:14b has been re-verified (see "Verification Results" near the top of this file). Use this section as background information when choosing a local LLM.
+
+### Verification environment (v0.1.x)
+
+- Cognee 1.0.3 / KuzuDB 0.11.3
+- GPU: NVIDIA GeForce RTX 4060 Laptop GPU (VRAM 8GB) / RAM 32GB
+- Verification date: 2026-05-02
+- Runs per LLM: 4 tools × 5 runs = 20 runs
+
+### LLM × Tool result summary
+
+| LLM (num_ctx) | remember×5 | search(CHUNKS)×5 | search(GRAPH_COMPLETION)×5 | recall×5 | Total |
+|---|---|---|---|---|---|
+| llama3.1:8b (2048, initial) | 5/5 ✅ | 5/5 ✅ | 4/5 ⚠️ (#1: JSON Schema violation) | 1/5 ✅ + 2/5 ⚠️ + 2/5 ❌ (Q-B 2/2 fail) | 14/20 |
+| llama3.1:8b (65536, retest) | 5/5 ✅ | 5/5 ✅ | 2/5 ✅ + 3/5 ❌ (pydantic ValidationError) | 2/5 ✅ + 3/5 ❌ (Q-B 2/2 fail continued) | 14/20 |
+| llama3.2:3b (2048 default) | 0/5 ❌ Timeout | (skipped) | (skipped) | (skipped) | 0/20 |
+| gemma4:e4b (16384) | 5/5 ✅ | 5/5 ✅ | **5/5 ✅** | 3/5 ✅ + 2/5 ❌ (Q-B 2/2 JSON Schema violation) | 18/20 |
+| **qwen2.5:14b (8192)** | **5/5 ✅** | **5/5 ✅** | **5/5 ✅** | **5/5 ✅** (Q-A/Q-B all correct) | **20/20** |
+| claude-sonnet-4-6 | (not run, to avoid API cost) | - | - | - | - |
+
+### Key observations (v0.1.x)
+
+- **qwen2.5:14b (num_ctx=8192) was the only LLM with a perfect score** (20/20). The only local LLM that fully answered recall Q-B (reasoning that includes background and rationale)
+- **llama3.1:8b** did not improve with larger num_ctx; recall Q-B failed 2/2
+- **llama3.2:3b** timed out at the connection test stage (too lightweight to complete entity extraction)
+- **gemma4:e4b** scored full marks on GRAPH_COMPLETION but failed recall Q-B with JSON Schema violations
+- This is the basis for shipping **qwen2.5:14b** as the default in this distribution
+
+### Verification queries (v0.1.x)
+
+- Q-A: `When can I run git push?` (simple fact retrieval)
+- Q-B: `Why is KuzuDB used in this project?` (reasoning that requires background and rationale)
+
+### num_ctx settings rationale
+
+| Model | num_ctx | Rationale |
+|---|---|---|
+| llama3.1:8b | 65536 | 8B model weights 4.7GB + KV cache (FP16, 64K) ~4.0GB = 8.7GB total. Some offload on 8GB GPU but mostly GPU-resident. Plenty of headroom for Cognee cognify long-text processing |
+| qwen2.5:14b | 8192 | Model weights 9GB are already in CPU offload. Increasing num_ctx slows it down further, so capped at 8K (sufficient for Cognee's short-prompt structured-output use case) |
+| gemma4:e4b | 16384 | Model weights 5GB + KV cache 1GB = 6GB total, fully GPU-resident. Wider context favors Cognee cognify (long-document chunked processing) |
+
+### v0.2.0 scope
+
+In v0.2.0, only **qwen2.5:14b** has been re-verified across all features (8 tools) on Cognee 1.0.5 / Ladybug DB (35/40 ✅; see "Verification Results" near the top of this file). Re-verification of other LLMs on Ladybug DB has been left as future work.

--- a/integrations/claude-code-cognee-graph-memory/docs/HARNESS_GUIDE.md
+++ b/integrations/claude-code-cognee-graph-memory/docs/HARNESS_GUIDE.md
@@ -1,0 +1,208 @@
+# HARNESS_GUIDE — Claude Code × Cognee Auto-Accumulation Harness
+
+## [Claude Code × Cognee — Practical Know-How Accumulation Tool]
+
+**RAG gives you the answer. Cognee gives you the whole story.**
+Claude Code remembers why decisions were made.
+**Never say the same thing twice again.**
+
+## What is this harness?
+
+**A mechanism that accumulates your own, personal know-how into Cognee graph memory
+the more you use Claude Code.**
+
+- User messages and AI responses are automatically recorded into the graph by hooks
+- From the next session onward, the AI is required to search graph memory before
+  starting any work
+- The same mistakes are not repeated; past decisions, context, and related facts
+  come back to you in a connected chain
+
+Plain vector search (RAG) returns only the matching chunk. With graph structure on
+top, Cognee returns the rationale, the timeline, and related facts as well — so you
+can recover **why** something was decided, **when**, and **what else relates to it**.
+
+---
+
+## How it works
+
+```
+┌────────────────────────────────────────────────────────┐
+│ Claude Code session                                     │
+│                                                         │
+│  User message ─────► UserPromptSubmit hook ────┐       │
+│                                                ▼        │
+│                                  ~/.claude/             │
+│                                  cognee_pending_        │
+│                                  remembers.jsonl        │
+│                                  (queue)                │
+│                                                ▲        │
+│  AI response done ───► Stop hook ──────────────┘        │
+│                                                         │
+│  AI runs                                                │
+│  search(CHUNKS) ◄─── enforced via CLAUDE.md / rules     │
+└────────────────────────┬────────────────────────────────┘
+                         │
+                         │ flusher drains the queue periodically
+                         ▼
+                ┌─────────────────────┐
+                │ Cognee graph memory │
+                │ (persistent)        │
+                └─────────────────────┘
+```
+
+---
+
+## Installation (5 steps)
+
+### Prerequisites
+
+- The base distribution setup (`docs/SETUP.md`) is complete
+- `claude mcp list` shows `cognee` as registered
+- `src/sample_src/load_sample.py` has run successfully
+
+### Step 1: Copy harness files into ~/.claude/
+
+```bash
+# Run from the distribution root
+cp harness/rules/cognee_memory_usage.md ~/.claude/rules/
+cp harness/hooks/auto_remember_user_message.py ~/.claude/hooks/
+cp harness/hooks/auto_remember_completion.py ~/.claude/hooks/
+cp harness/hooks/cognee_remember_flusher.py ~/.claude/hooks/
+chmod +x ~/.claude/hooks/auto_remember_user_message.py
+chmod +x ~/.claude/hooks/auto_remember_completion.py
+chmod +x ~/.claude/hooks/cognee_remember_flusher.py
+```
+
+### Step 2: Merge ~/.claude/settings.json
+
+Manually merge the contents of `harness/settings.example.json` into your existing
+`~/.claude/settings.json`.
+
+**Important keys to merge**:
+- `hooks.UserPromptSubmit` — record user messages
+- `hooks.Stop` — record AI response summaries
+- `permissions.allow` — auto-approve Cognee MCP tools (`search`, `remember`, etc.)
+
+Append to the existing `hooks` and `permissions` rather than overwriting them.
+
+### Step 3: Append the snippet to your project's CLAUDE.md
+
+Append the contents of `harness/CLAUDE_md_sample.md` to the end of the `CLAUDE.md`
+of any project where you want the harness to be active.
+
+This ensures that the AI **always searches Cognee graph memory before starting
+any work** in that project.
+
+### Step 4: Schedule the flusher (cron recommended)
+
+The hooks only append to a queue file; the flusher actually performs the
+`remember` calls.
+
+**Cron example (every 5 minutes)**:
+
+```bash
+crontab -e
+# Add the following line:
+*/5 * * * * /usr/bin/python3 $HOME/.claude/hooks/cognee_remember_flusher.py >> $HOME/.claude/cognee_flusher.log 2>&1
+```
+
+**Or run as a daemon**:
+
+```bash
+nohup python3 ~/.claude/hooks/cognee_remember_flusher.py --daemon --interval 60 &
+```
+
+### Step 5: Restart Claude Code
+
+Changes to `settings.json` and to the hook files are not picked up by an already
+running Claude Code session.
+
+- VSCode Claude Code extension: `Reload Window`
+- Terminal `claude` command: exit and re-launch
+
+Verify the connection:
+```bash
+claude mcp list
+# cognee should appear with ✓ Connected
+```
+
+---
+
+## Verifying the harness
+
+### Is the harness recording?
+
+1. Send any message to Claude Code
+2. `cat ~/.claude/cognee_pending_remembers.jsonl` — your message should appear
+3. Run the flusher manually: `python3 ~/.claude/hooks/cognee_remember_flusher.py`
+4. Check the log: `cat ~/.claude/cognee_flusher.log` — you should see `OK: dataset=user_messages`
+5. From Claude Code, run `search("a keyword from your message", search_type="CHUNKS")`
+   — the message should appear in the results
+
+### Is the AI calling search?
+
+Compare the AI's behaviour for the same kind of task before and after enabling the
+harness:
+
+- Before: jumps straight into Edit / Bash
+- After: first calls `mcp__cognee__search(...)` and only then proceeds
+
+If the after-behaviour does not happen, the snippet may not have made it into your
+project's CLAUDE.md.
+
+---
+
+## Troubleshooting
+
+### Hooks aren't running (queue file is not updated)
+
+- Verify the structure of `hooks.UserPromptSubmit` / `hooks.Stop` in `~/.claude/settings.json`
+- Did you restart Claude Code? Hook changes require a restart
+- Try running `python3 ~/.claude/hooks/auto_remember_user_message.py < /dev/null` standalone
+
+### Flusher fails
+
+- Check `~/.claude/cognee_flusher.log`
+- Failed entries are kept in `~/.claude/cognee_failed_remembers.jsonl` for inspection
+- If the project root cannot be located, set `COGNEE_GRAPH_MEMORY_ROOT`:
+  ```bash
+  export COGNEE_GRAPH_MEMORY_ROOT=/path/to/claude-code-cognee-graph-memory
+  ```
+
+### The AI doesn't call search
+
+- Confirm the `harness/CLAUDE_md_sample.md` content is in your project's `CLAUDE.md`
+- `CLAUDE.md` is read every turn, so a Claude Code restart is not required, but a
+  new session may be needed to pick up the change
+- For a stronger rule, place `harness/rules/cognee_memory_usage.md` under
+  `~/.claude/rules/`
+
+### The queue is filling up faster than it drains
+
+- The flusher is probably not running. Check your cron schedule or the daemon process
+- Each entry takes a few seconds to a few tens of seconds to ingest, so the queue
+  may be populated on first start
+- Drain manually: `python3 ~/.claude/hooks/cognee_remember_flusher.py`
+
+---
+
+## Files in this harness
+
+| File | Purpose |
+|---|---|
+| `harness/CLAUDE_md_sample.md` | Snippet to append to a project's CLAUDE.md |
+| `harness/rules/cognee_memory_usage.md` | Long-form rule for `~/.claude/rules/` |
+| `harness/hooks/auto_remember_user_message.py` | UserPromptSubmit hook (queue user messages) |
+| `harness/hooks/auto_remember_completion.py` | Stop hook (queue AI response summaries) |
+| `harness/hooks/cognee_remember_flusher.py` | Drain the queue (cron / daemon) |
+| `harness/settings.example.json` | Example for merging into ~/.claude/settings.json |
+
+---
+
+## Outcome (the longer you use it, the more you accumulate)
+
+- After 1 day: dozens of entries
+- After 1 week: hundreds of entries (you can already retrieve past corrections and decisions)
+- After 1 month: thousands of entries — your own personal AI knowledge base
+
+**The more you use Claude Code, the more your AI grows into yours.**

--- a/integrations/claude-code-cognee-graph-memory/docs/SETUP.md
+++ b/integrations/claude-code-cognee-graph-memory/docs/SETUP.md
@@ -1,0 +1,157 @@
+# Environment Setup Guide
+
+---
+
+## 1. Prerequisites
+
+### 1-1. Verified environment
+
+| Item | Value |
+|------|---|
+| OS | Linux (Ubuntu 22.04 or later) / WSL2 |
+| Python | 3.12 or higher |
+| Ollama | Latest version (https://ollama.com) |
+| LLM model | qwen2.5:14b (`ollama pull qwen2.5:14b`) |
+| Claude Code | Latest version |
+
+### 1-2. Ollama startup check
+
+```bash
+ollama serve             # Start in background
+ollama list              # Show available models
+ollama pull qwen2.5:14b  # Download model if not yet pulled
+```
+
+---
+
+## 2. Setup steps
+
+### 2-1. Overview
+
+| Step | Action | Time estimate |
+|---------|------|------------|
+| 1 | Clone the repository | 1 min |
+| 2 | Create `.env` and configure paths | 2 min |
+| 3 | Build venv and `pip install` | 5–15 min (includes FastEmbed model download) |
+| 4 | Add execute permission to startup script | 1 min |
+| 5 | Register MCP with Claude Code | 1 min |
+
+### 2-2. Step details
+
+**Step 1: Clone the repository**
+```bash
+git clone https://github.com/JapanNomu/tools.git
+cd tools/claude-code-tools/claude-code-cognee-graph-memory
+```
+
+**Step 2: Create `.env` and configure paths**
+
+```bash
+cp config/.env.example config/.env
+```
+
+Open `config/.env` and replace the following two values with absolute paths in your environment.
+
+**(1) How to obtain the absolute path**
+
+Run `pwd` inside the cloned directory; it prints the absolute path.
+
+```bash
+pwd
+# Example output: /home/yourname/tools/claude-code-tools/claude-code-cognee-graph-memory
+```
+
+**(2) Values to configure in `config/.env`**
+
+Use the absolute path obtained from `pwd` to fill in the following.
+
+| Setting | Example value |
+|---------|-----------|
+| `SYSTEM_ROOT_DIRECTORY` | `<pwd output>/data/cognee/system` |
+| `DATA_ROOT_DIRECTORY` | `<pwd output>/data/cognee/data` |
+
+For example, if `pwd` returned `/home/yourname/tools/claude-code-tools/claude-code-cognee-graph-memory`:
+
+```bash
+SYSTEM_ROOT_DIRECTORY=/home/yourname/tools/claude-code-tools/claude-code-cognee-graph-memory/data/cognee/system
+DATA_ROOT_DIRECTORY=/home/yourname/tools/claude-code-tools/claude-code-cognee-graph-memory/data/cognee/data
+```
+
+**(3) Notes**
+
+- Relative paths (e.g. `./data/cognee/...`) are not supported. **Always use absolute paths (starting with `/`)**.
+- The `data/cognee/system` and `data/cognee/data` directories are created automatically (no manual creation required).
+- `COGNEE_DATA_PATH` can be left at its default value (`./data/cognee`) unless you need to change it.
+
+**Step 3: Build venv**
+```bash
+cd src
+python3 -m venv venv
+source venv/bin/activate
+pip install cognee-mcp "cognee[fastembed]"
+deactivate
+cd ..
+```
+
+**Step 4: Add execute permission**
+```bash
+chmod +x src/main_src/start_cognee_mcp.py
+```
+
+**Step 5: Register MCP**
+
+Register the script with an **absolute path** to the location you cloned to. Reuse the `pwd` output from Step 2.
+
+For example, if `pwd` returned `/home/yourname/tools/claude-code-tools/claude-code-cognee-graph-memory`, run:
+
+```bash
+claude mcp add cognee --scope user /home/yourname/tools/claude-code-tools/claude-code-cognee-graph-memory/src/main_src/start_cognee_mcp.py
+claude mcp list  # Setup is complete when "cognee" shows ✓ Connected
+```
+
+Replace the path above with **your own absolute path** (the `pwd` output from Step 2 + `/src/main_src/start_cognee_mcp.py`).
+
+> **Why an absolute path is required:** `--scope user` registers the server globally for all your projects. If you register it with a relative path (e.g. `src/main_src/start_cognee_mcp.py`), Claude Code resolves the path against the current working directory at launch time — so it only connects when you start `claude` from this cloned directory and fails everywhere else.
+
+### 2-3. Verifying the setup
+
+**Important: Restart Claude Code if it is already running**
+
+The settings registered with `claude mcp add` are **not picked up by Claude Code sessions that are already running**. Restart your session as follows:
+
+| Environment | How to restart |
+|---|---|
+| VSCode extension | Command Palette (`Ctrl+Shift+P`) → `Developer: Reload Window` |
+| Terminal `claude` command | Exit the session (`Ctrl+D` or `/exit`) and start `claude` again |
+
+**Three ways to verify the connection**
+
+- Terminal: run `claude mcp list` and check that `cognee: ✓ Connected` is shown
+- VSCode: open the "MCP servers" panel and check that `cognee: ✓ Connected` is shown
+- Inside a session: run `/mcp` and check that `cognee: connected` is shown
+
+---
+
+## 3. Dependency version policy
+
+| Item | Description |
+|------|------|
+| Install method | `pip install cognee-mcp "cognee[fastembed]"` (latest version) |
+| Pinned version file | `src/requirements.txt` (not yet provided; future work) |
+| Verified versions | Cognee 1.0.5, cognee-mcp 0.5.4, ladybug 0.16.0 (as of 2026-05-04) |
+| Pinning specific versions | Use e.g. `pip install "cognee-mcp==0.5.4" "cognee[fastembed]==1.0.5"` |
+
+---
+
+## 4. Settings to update when relocating
+
+| Target | Change | Required/Optional |
+|---------|---------|---------|
+| `config/.env` `SYSTEM_ROOT_DIRECTORY` | Absolute path in your environment | **Required** |
+| `config/.env` `DATA_ROOT_DIRECTORY` | Absolute path in your environment | **Required** |
+| `config/.env` `COGNEE_DATA_PATH` | Leave at default (`./data/cognee`) unless you need to change it | Optional |
+| `config/.env` `LLM_MODEL` | When using a different Ollama model | Optional |
+| `config/.env` `LLM_ENDPOINT` | When Ollama runs on a different host | Optional |
+| `config/.env` `EMBEDDING_MODEL` / `EMBEDDING_DIMENSIONS` | When using a different embedding model | Optional |
+
+**No change needed:** `src/main_src/start_cognee_mcp.py` (resolves the project root automatically via `Path(__file__)`)

--- a/integrations/claude-code-cognee-graph-memory/harness/CLAUDE_md_sample.md
+++ b/integrations/claude-code-cognee-graph-memory/harness/CLAUDE_md_sample.md
@@ -1,0 +1,77 @@
+# CLAUDE.md Snippet — Rules to make Claude Code use Cognee graph memory automatically
+
+Append the contents of this file to the end of your project's `CLAUDE.md`.
+Claude Code reads `CLAUDE.md` every turn, so the rules below are always
+in effect.
+
+---
+
+The following block is the part to copy and paste into your `CLAUDE.md`:
+
+```markdown
+## 🔴 Knowledge search order (mandatory rule)
+
+Before starting any work, always investigate related knowledge in this order. No exceptions.
+
+### Search order
+
+1. **Search Cognee graph memory first**
+   Call `mcp__cognee__search(query, search_type="CHUNKS")` to retrieve user-specific
+   experiences, lessons, and decisions accumulated across past sessions.
+2. **If Cognee yields nothing, read `~/.claude/skills/`**
+   Read the relevant `reference.md` of the matching skill.
+3. **Only if both fail, ask the user**
+
+### When to apply (search is mandatory)
+
+- Any response that edits, creates, or deletes files
+- Any response that runs commands (Bash etc.)
+- Design decisions, policy choices, presenting options
+- Suggestions for handling incidents or solving problems
+
+### When not to apply (search is not required)
+
+- Simple yes/no answers
+- Clarifying the user's intent
+- Echoing what the user just said
+
+### Why this order?
+
+- Cognee holds the most recent, user-specific experience. Skills are static, generic, shared knowledge.
+  Prioritising the more concrete and more recent source prevents repeating past mistakes.
+- The cases where you "obviously already know it" are the very cases where you have
+  made the same mistake before. Search costs seconds. A repeated mistake costs hours or days.
+- The act of judging "I can skip this search" is itself the source of mistakes.
+  Eliminate that judgment by always searching.
+
+### Crafting search queries
+
+- Pick 1–3 keywords from the user's request and pass them in
+  - Example: "What should I watch out for with Django migrate?"
+    → `search("Django migrate caution", search_type="CHUNKS")`
+- File names, function names, and error strings can be passed in as-is
+- If a query yields nothing, retry 2–3 times with different wordings before
+  falling through to skills
+
+### Recording is handled by hooks (you do not have to call remember)
+
+The hooks in `harness/hooks/` automatically record user messages and AI response
+summaries via `mcp__cognee__remember`. The AI does not need to call `remember`
+explicitly (calling it manually is also fine; duplicates are tolerated).
+```
+
+---
+
+## What this snippet is
+
+- This file is part of the distribution and is intended to be **copy-pasted as-is into your `CLAUDE.md`**
+- You may trim parts to suit your own project, but **do not remove "Search order" or "When to apply"** — they are the core of this harness
+- Together with `harness/rules/cognee_memory_usage.md` placed under `~/.claude/rules/`, you also get the long-form rule (with rationale and provenance) that the AI can refer to
+
+## Related files
+
+- `harness/rules/cognee_memory_usage.md` — Long-form rule (Why / provenance / shared agreement)
+- `harness/hooks/auto_remember_user_message.py` — User message → Cognee
+- `harness/hooks/auto_remember_completion.py` — AI response → Cognee
+- `harness/settings.example.json` — Example settings to enable the hooks
+- `docs/HARNESS_GUIDE.md` — End-to-end installation guide

--- a/integrations/claude-code-cognee-graph-memory/harness/hooks/auto_remember_completion.py
+++ b/integrations/claude-code-cognee-graph-memory/harness/hooks/auto_remember_completion.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Stop hook: queue AI response summaries for Cognee graph memory
+
+When Claude Code finishes a turn, capture the gist of the AI's last
+response and enqueue it for Cognee graph memory. This makes "what
+did the AI do" traceable across sessions.
+
+The Stop hook fires at the end of an AI turn. We pull the last
+assistant message from the transcript, truncate it if needed, and
+push it onto the queue.
+
+Same queue mechanism as auto_remember_user_message.py:
+- Read transcript_path from stdin (JSON)
+- Extract the last assistant message
+- Append to ~/.claude/cognee_pending_remembers.jsonl
+- A separate flusher process drains the queue and calls `remember`
+
+Input: JSON on stdin: {"transcript_path": "...", "session_id": "..."}
+Output: exit 0 (always allowed; failure to record must never block turn end)
+
+Design notes:
+- An assistant response can be very long. We keep the head and the tail
+  (up to 1000 + 1000 chars), with an ellipsis in between, instead of
+  recording the entire message.
+- Dataset name: "ai_responses" (separated from user_messages)
+- For finer-grained capture you could add separate hooks that record
+  into "incidents" or "decisions" datasets when files change. This
+  sample writes everything into "ai_responses".
+
+Setup:
+  1. Copy this file into ~/.claude/hooks/
+  2. Register it under hooks.Stop in ~/.claude/settings.json
+     (see settings.example.json)
+"""
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# import os
+
+# Target dataset name for AI response summaries
+DATASET_NAME = "ai_responses"
+
+# Truncation thresholds for long responses (head + tail)
+MAX_HEAD_CHARS = 1000
+MAX_TAIL_CHARS = 1000
+
+
+def extract_last_assistant_message(transcript_path: str) -> str:
+    """
+    Extract the text of the last assistant message from a Claude Code
+    transcript (JSONL: one JSON object per line). Concatenate the
+    `content[].text` segments of the assistant turn.
+    """
+    path = Path(transcript_path)
+    if not path.exists():
+        return ""
+
+    last_assistant_text = ""
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                # Only assistant turns
+                role = entry.get("role") or entry.get("type", "")
+                if role != "assistant":
+                    continue
+
+                content = entry.get("content") or entry.get("message", {}).get("content", [])
+                if isinstance(content, str):
+                    last_assistant_text = content
+                elif isinstance(content, list):
+                    parts = []
+                    for c in content:
+                        if isinstance(c, dict) and c.get("type") == "text":
+                            parts.append(c.get("text", ""))
+                    if parts:
+                        last_assistant_text = "\n".join(parts)
+    except Exception:
+        return ""
+
+    return last_assistant_text
+
+
+def truncate(text: str) -> str:
+    """Keep head + tail of long responses with an ellipsis in between."""
+    if len(text) <= MAX_HEAD_CHARS + MAX_TAIL_CHARS:
+        return text
+    head = text[:MAX_HEAD_CHARS]
+    tail = text[-MAX_TAIL_CHARS:]
+    return f"{head}\n\n... (truncated) ...\n\n{tail}"
+
+
+def queue_remember(message: str, session_id: str) -> None:
+    queue_path = Path.home() / ".claude" / "cognee_pending_remembers.jsonl"
+    queue_path.parent.mkdir(parents=True, exist_ok=True)
+
+    entry = {
+        "timestamp": datetime.now().isoformat(),
+        "session_id": session_id,
+        "dataset_name": DATASET_NAME,
+        "data": f"[ai response {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {message}",
+    }
+
+    with queue_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        data = json.loads(raw) if raw.strip() else {}
+        transcript_path = data.get("transcript_path", "")
+        session_id = data.get("session_id", "unknown")
+
+        if not transcript_path:
+            sys.exit(0)
+
+        text = extract_last_assistant_message(transcript_path)
+        if not text:
+            sys.exit(0)
+
+        truncated = truncate(text)
+        queue_remember(truncated, session_id)
+
+    except Exception:
+        # Recording failures must never block the turn end
+        pass
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/claude-code-cognee-graph-memory/harness/hooks/auto_remember_user_message.py
+++ b/integrations/claude-code-cognee-graph-memory/harness/hooks/auto_remember_user_message.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+UserPromptSubmit hook: queue user messages for Cognee graph memory
+
+Captures the prompt the user submits, and enqueues it so that it can
+be persisted into Cognee graph memory via the cognee MCP `remember`
+tool. This is what enables cross-session context retrieval.
+
+How it works:
+- The UserPromptSubmit hook reads the prompt from stdin
+- The prompt is appended to ~/.claude/cognee_pending_remembers.jsonl
+- A separate process (cognee_remember_flusher.py) drains the queue and
+  actually calls `remember` on the cognee MCP server
+
+Calling MCP directly from inside the hook would delay the start of the
+AI turn, so this implementation uses an asynchronous file-queue approach.
+
+Input: JSON on stdin: {"prompt": "...", "session_id": "..."}
+Output: exit 0 (always allowed; failure to record must never block the prompt)
+
+Setup:
+  1. Copy this file into ~/.claude/hooks/
+  2. Register it under hooks.UserPromptSubmit in ~/.claude/settings.json
+     (see settings.example.json)
+  3. Make sure the cognee MCP server is registered (`claude mcp list`)
+
+Design notes:
+- Every user message is recorded (no filtering).
+  Rationale: filtering at write time means anything you didn't think
+  was important right now is lost. Graph memory is designed for
+  large accumulation; search can extract what is needed later.
+- Dataset name: "user_messages" (separated by purpose)
+- Failure to record must never block the prompt (exit 0 always)
+"""
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# import os
+# import subprocess
+
+# Skip very short messages (acknowledgements, single-word replies)
+MIN_LENGTH = 5
+
+# Target dataset name for user messages
+DATASET_NAME = "user_messages"
+
+# The cognee MCP server is expected to be registered via
+# `claude mcp add cognee --scope user <PROJECT_ROOT>/src/main_src/start_cognee_mcp.py`
+
+
+def queue_remember(message: str, session_id: str) -> None:
+    """
+    Append the message to ~/.claude/cognee_pending_remembers.jsonl.
+    A flusher process picks up entries from this file and calls
+    `remember` against the cognee MCP server.
+    """
+    queue_path = Path.home() / ".claude" / "cognee_pending_remembers.jsonl"
+    queue_path.parent.mkdir(parents=True, exist_ok=True)
+
+    entry = {
+        "timestamp": datetime.now().isoformat(),
+        "session_id": session_id,
+        "dataset_name": DATASET_NAME,
+        "data": f"[user message {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {message}",
+    }
+
+    with queue_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        data = json.loads(raw) if raw.strip() else {}
+        message = data.get("prompt", data.get("message", "")).strip()
+        session_id = data.get("session_id", "unknown")
+
+        if not message:
+            sys.exit(0)
+
+        if len(message) < MIN_LENGTH:
+            sys.exit(0)
+
+        queue_remember(message, session_id)
+
+    except Exception:
+        # Recording failures must never block the user's prompt
+        pass
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/claude-code-cognee-graph-memory/harness/hooks/cognee_remember_flusher.py
+++ b/integrations/claude-code-cognee-graph-memory/harness/hooks/cognee_remember_flusher.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+Cognee remember queue flusher
+
+Drains entries appended by auto_remember_user_message.py and
+auto_remember_completion.py into ~/.claude/cognee_pending_remembers.jsonl,
+and persists each one into Cognee graph memory by calling `remember`
+on the cognee MCP server.
+
+Calling MCP directly from inside the UserPromptSubmit/Stop hooks
+would delay the AI turn, so the hooks only append to a queue file
+and this flusher runs separately to process them.
+
+How to run:
+- One-shot:  python3 cognee_remember_flusher.py
+- Daemon:    nohup python3 cognee_remember_flusher.py --daemon &
+- Cron (every 5 minutes):
+    */5 * * * * /usr/bin/python3 /home/<youruser>/.claude/hooks/cognee_remember_flusher.py
+
+Dependencies:
+- The base distribution must be set up
+- Either set COGNEE_GRAPH_MEMORY_ROOT to the distribution root, or
+  place it at ~/tools/claude-code-tools/claude-code-cognee-graph-memory
+
+Design notes:
+- Read the queue line by line; on success the line is removed
+- Failed entries are moved to ~/.claude/cognee_failed_remembers.jsonl
+  for later inspection / re-injection
+- Concurrent runs are prevented via flock
+"""
+import argparse
+import asyncio
+import fcntl
+import json
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+QUEUE_PATH = Path.home() / ".claude" / "cognee_pending_remembers.jsonl"
+FAILED_PATH = Path.home() / ".claude" / "cognee_failed_remembers.jsonl"
+LOCK_PATH = Path.home() / ".claude" / "cognee_flusher.lock"
+LOG_PATH = Path.home() / ".claude" / "cognee_flusher.log"
+
+# Distribution root candidates (env var takes precedence)
+DEFAULT_ROOT_CANDIDATES = [
+    Path(os.environ.get("COGNEE_GRAPH_MEMORY_ROOT", "")),
+    Path.home() / "tools" / "claude-code-tools" / "claude-code-cognee-graph-memory",
+]
+
+
+def find_project_root() -> Path | None:
+    for p in DEFAULT_ROOT_CANDIDATES:
+        if p and p.exists() and (p / "src" / "main_src" / "import_to_graph.py").exists():
+            return p
+    return None
+
+
+def log(msg: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(f"[{timestamp}] {msg}\n")
+
+
+async def remember_via_mcp(project_root: Path, data: str, dataset_name: str) -> bool:
+    """
+    Call `remember` on the cognee MCP server via fastmcp StdioTransport.
+    Returns True on success, False on failure.
+    """
+    try:
+        # fastmcp lives in the distribution's venv
+        from fastmcp import Client
+        from fastmcp.client.transports import StdioTransport
+
+        env = os.environ.copy()
+        env_path = project_root / "config" / ".env"
+        if env_path.exists():
+            for line in env_path.read_text().splitlines():
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    k, v = line.split("=", 1)
+                    env[k.strip()] = v.strip()
+
+        transport = StdioTransport(
+            command=str(project_root / "src" / "venv" / "bin" / "python3"),
+            args=[str(project_root / "src" / "main_src" / "start_cognee_mcp.py")],
+            env=env,
+        )
+
+        async with Client(transport) as client:
+            # result =
+            await client.call_tool(
+                "remember",
+                {"data": data, "dataset_name": dataset_name},
+            )
+            log(f"OK: dataset={dataset_name} len={len(data)}")
+            return True
+    except Exception as e:
+        log(f"FAIL: {type(e).__name__}: {e}")
+        return False
+
+
+def acquire_lock():
+    LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    fp = LOCK_PATH.open("w")
+    try:
+        fcntl.flock(fp.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return fp
+    except BlockingIOError:
+        return None
+
+
+def append_failed(entry: dict) -> None:
+    FAILED_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with FAILED_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+async def flush_once() -> None:
+    if not QUEUE_PATH.exists():
+        return
+
+    project_root = find_project_root()
+    if not project_root:
+        log("ERROR: claude-code-cognee-graph-memory project root not found")
+        return
+
+    # Read queue, attempt every entry, drop succeeded ones
+    lines = QUEUE_PATH.read_text(encoding="utf-8").splitlines()
+    if not lines:
+        return
+
+    succeeded_indices = set()
+    for i, line in enumerate(lines):
+        line = line.strip()
+        if not line:
+            succeeded_indices.add(i)
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            log(f"SKIP malformed line: {line[:80]}")
+            succeeded_indices.add(i)
+            continue
+
+        ok = await remember_via_mcp(
+            project_root,
+            entry["data"],
+            entry.get("dataset_name", "main_dataset"),
+        )
+        if ok:
+            succeeded_indices.add(i)
+        else:
+            append_failed(entry)
+
+    # Keep failed valid-data entries in the queue (drop succeeded and blank lines;
+    # failed entries are also saved to failed.jsonl for reference)
+    remaining = [
+        line for i, line in enumerate(lines)
+        if i not in succeeded_indices and line.strip()
+    ]
+    if remaining:
+        QUEUE_PATH.write_text("\n".join(remaining) + "\n", encoding="utf-8")
+    else:
+        QUEUE_PATH.unlink(missing_ok=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--daemon", action="store_true", help="run continuously at fixed intervals")
+    parser.add_argument(
+        "--interval", type=int, default=60,
+        help="seconds between runs in --daemon mode (default: 60)"
+    )
+    args = parser.parse_args()
+
+    lock = acquire_lock()
+    if not lock:
+        log("Another flusher is already running. Exit.")
+        sys.exit(0)
+
+    if args.daemon:
+        while True:
+            asyncio.run(flush_once())
+            time.sleep(args.interval)
+    else:
+        asyncio.run(flush_once())
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/claude-code-cognee-graph-memory/harness/rules/cognee_memory_usage.md
+++ b/integrations/claude-code-cognee-graph-memory/harness/rules/cognee_memory_usage.md
@@ -1,0 +1,136 @@
+# Cognee Graph Memory Usage Rule (Mandatory)
+
+Place this file under `~/.claude/rules/` so it applies across all projects.
+
+## 1. Search order (mandatory, no exceptions)
+
+Before starting any work, always investigate related knowledge in this order:
+
+```
+1. Cognee graph memory: mcp__cognee__search(query, search_type="CHUNKS")
+   ↓ if nothing found
+2. Read the relevant reference.md under ~/.claude/skills/
+   ↓ if nothing found
+3. Ask the user
+```
+
+## 2. When to apply (search is mandatory)
+
+The following situations require a search before responding:
+
+- Editing, creating, or deleting files (Edit / Write / NotebookEdit)
+- Running commands (Bash)
+- Design decisions, policy choices
+- Suggestions for handling incidents or solving problems
+- Presenting options or recommendations to the user
+
+## 3. When not to apply (search not required)
+
+- Simple yes/no answers
+- Clarifying the user's intent
+- Echoing what the user just said
+
+## 4. Why this order, and why no exceptions
+
+### Why Cognee comes first
+
+- Cognee accumulates **the user's own most recent experience, lessons, and decisions**
+- Skills are generic, static, shared across all projects
+- Prioritising "specific and recent and user-owned" knowledge prevents repeating
+  past mistakes. Skills are the fall-back when Cognee has nothing on this topic.
+
+### Why "no exceptions"
+
+- The cases where you think "I obviously know this" are the cases where you have
+  already made the same mistake before
+- The act of judging "I can skip the search this time" is itself the source of mistakes
+- A search takes seconds. Recovering from a repeated mistake takes hours or days
+- "I'll be careful" does not work. Mechanically searching every time does.
+
+### Why "before any work" rather than "every response"
+
+- Searching before every textual reply (chit-chat, intent clarification) would be excessive
+- File edits, command execution, and design decisions, however, are **irreversible**
+- Therefore: always search before any potentially irreversible action
+
+## 5. How to craft a search query
+
+### Basic
+
+Take 1–3 keywords from the user's request and pass them in directly.
+
+| User request | Example query |
+|---|---|
+| "What should I watch out for with Django migrate?" | `search("Django migrate caution", search_type="CHUNKS")` |
+| "This test is failing, what's wrong?" | `search("test failure cause", search_type="CHUNKS")` |
+| "Is it OK to git push?" | `search("git push timing", search_type="CHUNKS")` |
+
+### Variations
+
+- 1st try: only keywords (e.g. `Django migrate`)
+- 2nd try: closer to the user's wording (e.g. `What should I watch out for with Django migrate`)
+- 3rd try: add related terms (e.g. `Django migrate rollback backup`)
+
+If three tries yield nothing, fall through to skills.
+
+### When handling errors
+
+Pass the error string itself (the most distinctive part) as the query.
+
+```
+search("LLMAPIKeyNotSetError Status 422", search_type="CHUNKS")
+search("ModuleNotFoundError pydantic", search_type="CHUNKS")
+```
+
+## 6. Recording is handled by hooks (you don't have to call remember)
+
+The hooks in `harness/hooks/` automatically register user messages and AI response
+summaries into Cognee via `mcp__cognee__remember`.
+
+- The AI does not need to call `remember` explicitly (it is fine to do so; duplicates
+  are tolerated)
+- When the AI judges that something is particularly important, it may call `remember`
+  proactively
+- Use these dataset names according to purpose:
+  - `feedback` — user-facing corrections / preferences
+  - `incidents` — failures, mishandling, error recovery
+  - `decisions` — design / policy decisions
+  - `lessons` — project-wide takeaways
+  - default: `main_dataset`
+
+## 7. Use search(CHUNKS) instead of recall
+
+`mcp__cognee__recall` may fail with an LLM format error when running on
+local LLMs other than qwen2.5:14b. The distribution's verification flow
+recommends `search(CHUNKS)`.
+
+- For lookups, use `search(query, search_type="CHUNKS")` by default
+- Even when `recall` would have been a natural choice, try `search(CHUNKS)` first
+
+## 8. Provenance (how this rule came about)
+
+- 2026-05-02 user instruction: "Cognee first, then fall back to skills"
+- Same day: "Always search before any work"
+- Same day: "If you skip the search, that's the very moment mistakes happen"
+- Same day: when the AI proposed "only record important things to Cognee", the user
+  pushed back: "Even if the graph grows huge, you can pull what you need with the
+  right query — that's literally the point of graph memory."
+  → AI corrected its position: "Record liberally, search before acting."
+
+## 9. Shared agreement
+
+- AI (Claude Code): initially proposed "register only important items to Cognee"
+- User: "Even if the graph grows huge, you can extract what you need by searching.
+  That's the whole point of graph memory."
+- AI: revised stance — "Record liberally is the right operation"
+- Both agreed: **record when in doubt; always search before acting**
+
+---
+
+## Related files
+
+- `harness/CLAUDE_md_sample.md` — Snippet to append to your project's CLAUDE.md
+- `harness/hooks/auto_remember_user_message.py` — UserPromptSubmit hook
+- `harness/hooks/auto_remember_completion.py` — Stop hook
+- `harness/settings.example.json` — Example settings.json merge
+- `docs/HARNESS_GUIDE.md` — End-to-end installation guide

--- a/integrations/claude-code-cognee-graph-memory/harness/settings.example.json
+++ b/integrations/claude-code-cognee-graph-memory/harness/settings.example.json
@@ -1,0 +1,42 @@
+{
+  "_comment": "Sample to merge into ~/.claude/settings.json to enable the Cognee graph-memory harness. Merge manually with your existing settings.json. See docs/HARNESS_GUIDE.md for the meaning of each value.",
+
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/auto_remember_user_message.py"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/auto_remember_completion.py"
+          }
+        ]
+      }
+    ]
+  },
+
+  "permissions": {
+    "_comment_permissions": "Auto-allow the main Cognee MCP tools so you are not prompted on every call.",
+    "allow": [
+      "mcp__cognee__search",
+      "mcp__cognee__recall",
+      "mcp__cognee__remember",
+      "mcp__cognee__cognify",
+      "mcp__cognee__cognify_status",
+      "mcp__cognee__list_data",
+      "Bash(python3 ~/.claude/hooks/cognee_remember_flusher.py*)"
+    ]
+  },
+
+  "_comment_cron": "Run cognee_remember_flusher.py periodically (cron recommended). Example (every 5 minutes):",
+  "_comment_cron_example": "*/5 * * * * /usr/bin/python3 /home/youruser/.claude/hooks/cognee_remember_flusher.py >> /home/youruser/.claude/cognee_flusher.log 2>&1"
+}

--- a/integrations/claude-code-cognee-graph-memory/knowledge/sample_knowledge/01_claude_code_tips.md
+++ b/integrations/claude-code-cognee-graph-memory/knowledge/sample_knowledge/01_claude_code_tips.md
@@ -1,0 +1,38 @@
+# Claude Code know-how
+
+## Session management
+
+When a Claude Code session ends, the conversation context is lost. Register
+key decisions, rules, and incident records during the session via `remember`,
+and the next session can pull them back via `recall`.
+
+## Commit granularity
+
+Run `git commit` immediately after finishing each task. Bundling several tasks
+into one commit makes it unclear which change belongs to which task and leaves
+the rollback unit ambiguous. One task = one commit is the rule.
+
+## Task management
+
+Before starting work, append the task to the task management table and mark it
+in-progress. Editing files without an entry in the table is blocked by a hook.
+Register first, work second.
+
+## How to receive feedback
+
+When the user gives feedback, record it immediately, then turn it into a task.
+If you start working before recording, you will receive the same feedback
+repeatedly. Always follow record -> task -> work.
+
+## git push
+
+Run `git push` only when the user explicitly instructs to. "Please commit"
+does not include push. Task completion, phase completion, or project
+completion are not reasons to push.
+
+## Full coverage checks
+
+Verification work for testing, review, and audits is exhaustive by default.
+Even with many files, do not narrow the scope. Checking only representative
+files or only deep-diving into "the important ones" is abandoning quality
+assurance.

--- a/integrations/claude-code-cognee-graph-memory/knowledge/sample_knowledge/02_software_dev_lessons.md
+++ b/integrations/claude-code-cognee-graph-memory/knowledge/sample_knowledge/02_software_dev_lessons.md
@@ -1,0 +1,38 @@
+# Software development lessons
+
+## Principles of test design
+
+Unit-test expected values must be derived from the IF (interface) specification.
+Reading the implementation code to determine expected values is forbidden. A
+test driven by the implementation cannot detect bugs.
+
+## V-model: design and test pairing
+
+Requirements <-> system test. High-level design <-> external integration
+test. Detailed design <-> internal integration test. Implementation <-> unit
+test. Expected values must always come from the matching design document.
+
+## Aligning test and production environments
+
+If ports, protocols, or configuration differ between test and production,
+tests can pass while production fails. HTTP/HTTPS mixing and port mismatches
+in particular cause false PASSED results in integration tests.
+
+## Separating design from procedure
+
+Design documents describe what to build and how it is structured. Procedure
+documents describe how to set it up. Mixing the two in one document buries the
+design intent inside operational instructions.
+
+## Order of consistency checks
+
+When you find a problem during a check, do not fix it on the spot. Finish the
+full check, transcribe the issues into the unresolved list, then address them
+one by one in list order. Fix-on-discovery breeds oversights and chaos.
+
+## Where to store documents
+
+Each artifact's location is fixed by its phase and role. In-phase check records
+go to the check folder. Cross-phase review results go to the review folder.
+Re-investigations after issues go to the quality cross-check folder. The wrong
+location makes the artifact unfindable later.

--- a/integrations/claude-code-cognee-graph-memory/knowledge/sample_knowledge/03_design_decisions.md
+++ b/integrations/claude-code-cognee-graph-memory/knowledge/sample_knowledge/03_design_decisions.md
@@ -1,0 +1,28 @@
+# Design decisions
+
+## Why Cognee for the graph memory engine
+
+Cognee was chosen because the graph DB (Ladybug DB since Cognee 1.0.4, KuzuDB up
+to 1.0.3), vector DB (LanceDB), and embedding model (FastEmbed) are all bundled
+with no extra installation, and everything runs fully locally. This satisfies
+the no-external-API-key and zero-additional-cost requirements.
+
+## Why MCP scope=user
+
+The Cognee MCP server is registered with `scope=user`. With `scope=project`,
+only that one project's Claude Code session could access it. Cross-project
+access is the whole point of this graph memory system.
+
+## Why Ollama + qwen2.5:14b for the LLM
+
+Ollama with qwen2.5:14b runs fully locally, needs no external API key, and
+reuses an existing Ollama installation. It is accurate enough for entity
+extraction and incurs no additional cost. Among local LLMs, qwen2.5:14b is the
+only one verified to satisfy Cognee's structured-output requirements (perfect
+20/20 score in the v0.1.x verification matrix).
+
+## Why stdio mode for transport
+
+stdio mode is used to communicate with Claude Code because it does not consume
+a port (no clashes with other services), and Claude Code launches the MCP
+server directly as a child process — no separate HTTP server required.

--- a/integrations/claude-code-cognee-graph-memory/knowledge/sample_knowledge/04_common_errors.md
+++ b/integrations/claude-code-cognee-graph-memory/knowledge/sample_knowledge/04_common_errors.md
@@ -1,0 +1,38 @@
+# Common errors and how to handle them
+
+## Cognee: SearchPreconditionError
+
+Calling `recall` / `search` right after `prune` (or before any data has been
+ingested) raises SearchPreconditionError. You must register data with
+`remember` first, then call `recall` / `search`.
+
+## Cognee: DatabaseNotCreatedError
+
+Calling `list_data` after `prune` raises DatabaseNotCreatedError. Because
+`prune` deletes the database completely, you must run at least one `remember`
+before `list_data` to re-initialize the database.
+
+## Ollama connection error
+
+If `import_to_graph.py` reports "Cannot reach Ollama," the Ollama service is
+not running. Run `ollama serve` and retry. Also check whether `qwen2.5:14b`
+(or the configured local LLM) has been downloaded with `ollama list`.
+
+## recall returns empty results
+
+If `recall` returns an empty result (`search_result: ['']`), the graph
+construction may still be running. `remember` builds the graph asynchronously
+in the background, so right after a large bulk ingest, check completion with
+`cognify_status` before calling `recall`.
+
+## LLM format error (recall failure)
+
+`recall` can fail with an LLM JSON-format error when local LLMs smaller than
+qwen2.5:14b do not respond in the JSON shape Cognee expects. As a workaround,
+use `search(search_type="CHUNKS")` to retrieve text directly via vector search.
+
+## LLM_ENDPOINT in .env requires /v1
+
+When using Ollama as the LLM, `LLM_ENDPOINT` must be set to
+`http://localhost:11434/v1` — not `http://localhost:11434`. Without `/v1`,
+Cognee cannot find the OpenAI-compatible endpoint and errors out.

--- a/integrations/claude-code-cognee-graph-memory/knowledge/sample_knowledge/05_graph_memory_operations.md
+++ b/integrations/claude-code-cognee-graph-memory/knowledge/sample_knowledge/05_graph_memory_operations.md
@@ -1,0 +1,54 @@
+# Graph memory operations know-how
+
+## When to call cognify
+
+`cognify` runs entity extraction and graph construction over the input text.
+Run it after a batch of `remember` calls, or directly on a long document, to
+materialize new entities and relationships into the graph. Without `cognify`,
+`search(GRAPH_COMPLETION)` and `recall` cannot reason over freshly added data.
+
+## remember vs save_interaction
+
+`remember` stores arbitrary text in the permanent memory. Use it for documents,
+rules, decisions, and incident records. `save_interaction` stores a Q-A pair
+into the session cache, optimized for short conversational turns. Use
+`save_interaction` when capturing a single exchange, and `remember` for any
+content that must survive into the permanent graph immediately.
+
+## search type selection
+
+Use `search(CHUNKS)` to retrieve the raw matching passages without LLM cost.
+Use `search(GRAPH_COMPLETION)` when the question requires reasoning across
+multiple entities or summarizing relationships. CHUNKS is deterministic and
+cheap; GRAPH_COMPLETION involves the configured LLM and may fail when the
+local model returns malformed structured output.
+
+## recall auto-routing
+
+`recall` chooses a search strategy automatically. It can fall back to keyword
+matching against session caches before hitting the permanent graph. Prefer
+`search(CHUNKS)` for predictable retrieval and reserve `recall` for cases
+where a session-aware shortcut is acceptable.
+
+## forget_memory and graph_only
+
+`forget_memory` removes data from the relational, graph, and vector stores.
+The `graph_only=True` flag erases graph edges while preserving the underlying
+chunks and embeddings, which is useful when graph quality degrades but the
+raw text should remain searchable. Use the default (full delete) when the
+content itself is no longer needed.
+
+## improve usage
+
+`improve` enriches the graph with triplet embeddings. Call it without
+`session_ids` to run only the enrichment stage. Pass comma-separated session
+IDs to additionally bridge session-cached Q-A pairs into the permanent graph.
+Run `improve` periodically when many new sessions accumulate to keep the
+graph aligned with recent activity.
+
+## prune as reset
+
+`prune` deletes both the data layer and the system metadata. It is the only
+way to fully reset the local Cognee state during development. After `prune`,
+the next `search` or `recall` will fail until at least one `remember` and
+`cognify` cycle has run again.

--- a/integrations/claude-code-cognee-graph-memory/knowledge/user_chunks/README.md
+++ b/integrations/claude-code-cognee-graph-memory/knowledge/user_chunks/README.md
@@ -1,0 +1,22 @@
+# user_chunks/
+
+This folder receives the **intermediate files split by H2 heading** from
+`user_knowledge/`.
+
+## Auto-generated content
+
+- Running `src/knowledge_src/split_knowledge.py` generates the split files here.
+- `src/knowledge_src/import_knowledge.py` ingests the files here into Cognee.
+- You **do not need to edit** anything here (auto-generated, auto-cleared).
+
+## Do not place files here manually
+
+Each run of `split_knowledge.py` clears this folder's contents (except
+README.md) and regenerates them. Place your source files under
+`user_knowledge/` instead.
+
+## Why this folder exists
+
+Cognee's cognify step can fail on large files, so splitting is required before
+ingestion. Separating the source folder (`user_knowledge/`) from the ingestion
+folder (`user_chunks/`) keeps editing and ingestion concerns apart.

--- a/integrations/claude-code-cognee-graph-memory/knowledge/user_knowledge/README.md
+++ b/integrations/claude-code-cognee-graph-memory/knowledge/user_knowledge/README.md
@@ -1,0 +1,33 @@
+# user_knowledge/
+
+This folder is **where you place your own knowledge files (.md)**.
+
+## How to use
+
+1. Drop `.md` files into this folder (sub-folders by category are fine).
+2. Run `src/venv/bin/python3 src/knowledge_src/split_knowledge.py`.
+   - Each `.md` is split by H2 heading and written to `knowledge/user_chunks/`.
+3. Run `src/venv/bin/python3 src/knowledge_src/import_knowledge.py`.
+   - The split files under `user_chunks/` are ingested into Cognee.
+
+## Recommended file format
+
+- Markdown (`.md`)
+- Use H1 (`# title`) to indicate the file's overall theme.
+- Use H2 (`## section`) to delimit chapters (this is the split boundary).
+- H3 and below: free-form.
+
+## Why split
+
+Cognee's cognify step (LLM-based summarization and graph construction) sometimes
+**fails (status=errored) on large files (hundreds of lines)** because the LLM
+cannot keep up. To avoid this, files are split by H2 heading before ingestion.
+
+Each split file is prefixed with reference metadata pointing back to the
+original file, so when knowledge is recalled from graph memory you can still
+trace the source document.
+
+## Notes
+
+- This README.md is excluded from ingestion (auto-skipped at split and import).
+- The folder layout is free-form, but flat per-category folders are preferred over deep nesting.

--- a/integrations/claude-code-cognee-graph-memory/src/knowledge_src/import_knowledge.py
+++ b/integrations/claude-code-cognee-graph-memory/src/knowledge_src/import_knowledge.py
@@ -1,0 +1,207 @@
+"""
+Ingest pre-split knowledge files (user_chunks/) into Cognee graph memory.
+
+Files split by split_knowledge.py are ingested one at a time via the Cognee MCP
+server. After each file, the cognify result is checked; if status=errored, the
+ingestion is retried up to 3 times.
+
+Usage:
+    cd <distribution root directory>
+    src/venv/bin/python3 src/knowledge_src/import_knowledge.py
+    src/venv/bin/python3 src/knowledge_src/import_knowledge.py --dry-run
+
+Input:  .md files under knowledge/user_chunks/
+Output: Cognee user_knowledge dataset
+"""
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from fastmcp import Client
+from fastmcp.client.transports import StdioTransport
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parent.parent
+ENV_PATH = PROJECT_ROOT / "config" / ".env"
+MCP_COMMAND = str(PROJECT_ROOT / "src" / "main_src" / "start_cognee_mcp.py")
+INPUT_DIR = PROJECT_ROOT / "knowledge" / "user_chunks"
+DATASET_NAME = "user_knowledge"
+MAX_RETRY = 3
+
+
+def check_ollama() -> None:
+    """Verify Ollama is running and the LLM model specified in config/.env is available."""
+    env = _load_env()
+    llm_provider = env.get("LLM_PROVIDER", "").strip().lower()
+    if llm_provider != "ollama":
+        logger.info("LLM_PROVIDER=%s; skipping Ollama connectivity check",
+                    llm_provider or "(unset)")
+        return
+
+    llm_model = env.get("LLM_MODEL", "").strip()
+    if not llm_model:
+        logger.error("LLM_MODEL is not set in config/.env")
+        sys.exit(1)
+
+    url = "http://localhost:11434/api/tags"
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            data = json.loads(resp.read().decode())
+    except urllib.error.URLError as e:
+        logger.error("Cannot reach Ollama: %s", e)
+        logger.error("Run 'ollama serve' and try again")
+        sys.exit(1)
+    except Exception as e:
+        logger.error("Unexpected error during Ollama check: %s", e)
+        sys.exit(1)
+
+    model_names = [m.get("name", "") for m in data.get("models", [])]
+    if not any(llm_model in name for name in model_names):
+        logger.error("%s not found. Available models: %s", llm_model, model_names)
+        logger.error("Run 'ollama pull %s' and try again", llm_model)
+        sys.exit(1)
+
+    logger.info("Ollama check OK: %s is available", llm_model)
+
+
+def _load_env() -> dict[str, str]:
+    """Load config/.env and return the resulting environment dict."""
+    env = os.environ.copy()
+    if ENV_PATH.exists():
+        try:
+            for line in ENV_PATH.read_text().splitlines():
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    k, v = line.split("=", 1)
+                    env[k.strip()] = v.strip()
+        except OSError as e:
+            logger.warning("Failed to read .env (skipping): %s", e)
+    return env
+
+
+def make_transport() -> StdioTransport:
+    """Build the StdioTransport for connecting to the Cognee MCP server."""
+    return StdioTransport(
+        command=str(PROJECT_ROOT / "src" / "venv" / "bin" / "python3"),
+        args=[MCP_COMMAND],
+        env=_load_env(),
+    )
+
+
+async def import_one(client: Client, file_path: Path, idx: int, total: int) -> bool:
+    """Ingest one file. Returns True on success, False on failure."""
+    rel = file_path.relative_to(INPUT_DIR)
+    content = file_path.read_text(encoding="utf-8")
+
+    for attempt in range(1, MAX_RETRY + 1):
+        try:
+            result = await client.call_tool("remember", {
+                "data": content,
+                "dataset_name": DATASET_NAME,
+            })
+            text = result.content[0].text if result and result.content else ""
+
+            if "status=completed" in text:
+                logger.info("[%d/%d] OK %s (attempt %d)", idx, total, rel, attempt)
+                return True
+
+            if "status=errored" in text:
+                logger.warning("[%d/%d] FAIL %s (attempt %d/%d): errored",
+                               idx, total, rel, attempt, MAX_RETRY)
+                if attempt < MAX_RETRY:
+                    await asyncio.sleep(2)
+                    continue
+                return False
+
+            # Unexpected status
+            logger.warning("[%d/%d] Unexpected response: %s", idx, total, text[:120])
+            return False
+        except Exception as e:
+            logger.warning("[%d/%d] Exception (attempt %d/%d): %s",
+                           idx, total, attempt, MAX_RETRY, e)
+            if attempt < MAX_RETRY:
+                await asyncio.sleep(2)
+                continue
+            return False
+
+    return False
+
+
+async def import_all(files: list[Path], dry_run: bool) -> tuple[int, int]:
+    """Ingest all files. Returns (success_count, failure_count)."""
+    success = 0
+    failed = 0
+    total = len(files)
+
+    if dry_run:
+        for idx, f in enumerate(files, 1):
+            rel = f.relative_to(INPUT_DIR)
+            logger.info("[%d/%d] (dry-run) %s", idx, total, rel)
+        return total, 0
+
+    async with Client(make_transport()) as client:
+        for idx, f in enumerate(files, 1):
+            ok = await import_one(client, f, idx, total)
+            if ok:
+                success += 1
+            else:
+                failed += 1
+                logger.error("3 failures, stopping: %s", f.relative_to(INPUT_DIR))
+                logger.error(
+                    "Halting so failure is not silently ignored. Investigate cause and rerun."
+                )
+                break
+
+    return success, failed
+
+
+def main() -> None:
+    """Entry point."""
+    parser = argparse.ArgumentParser(description="Ingest user_chunks/ into Cognee")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print the file list without ingesting")
+    args = parser.parse_args()
+
+    if not INPUT_DIR.exists():
+        logger.error("Input folder not found: %s", INPUT_DIR)
+        logger.error("Run split_knowledge.py first")
+        sys.exit(1)
+
+    md_files = sorted(INPUT_DIR.glob("**/*.md"))
+    # README.md is excluded from ingestion
+    md_files = [f for f in md_files if f.name != "README.md"]
+
+    if not md_files:
+        logger.warning("No .md files to ingest under: %s", INPUT_DIR)
+        logger.warning("Run split_knowledge.py first")
+        sys.exit(1)
+
+    if not args.dry_run:
+        check_ollama()
+
+    logger.info("Files to ingest: %d -> dataset=%s", len(md_files), DATASET_NAME)
+    success, failed = asyncio.run(import_all(md_files, args.dry_run))
+
+    logger.info("=" * 50)
+    logger.info("Succeeded: %d", success)
+    logger.info("Failed: %d", failed)
+
+    if failed > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/claude-code-cognee-graph-memory/src/knowledge_src/split_knowledge.py
+++ b/integrations/claude-code-cognee-graph-memory/src/knowledge_src/split_knowledge.py
@@ -1,0 +1,166 @@
+"""
+Split knowledge files (.md) by H2 heading.
+
+Cognee's cognify step occasionally fails to summarize large files (hundreds of
+lines) because the LLM cannot keep up. To avoid this, split each file by H2
+(`## heading`) into smaller chunks before ingesting. Each chunk is prefixed
+with reference metadata pointing back to the original file.
+
+Usage:
+    cd <distribution root directory>
+    src/venv/bin/python3 src/knowledge_src/split_knowledge.py
+
+Input:  .md files under knowledge/user_knowledge/
+Output: split files under knowledge/user_chunks/
+"""
+import logging
+import re
+import shutil
+import sys
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parent.parent
+INPUT_DIR = PROJECT_ROOT / "knowledge" / "user_knowledge"
+OUTPUT_DIR = PROJECT_ROOT / "knowledge" / "user_chunks"
+
+
+def sanitize_filename(name: str) -> str:
+    """Remove or replace characters that are illegal in filenames."""
+    name = re.sub(r"[/\\:*?\"<>|]", "", name)
+    name = re.sub(r"\s+", "_", name.strip())
+    if len(name) > 60:
+        name = name[:60]
+    return name
+
+
+def split_md_by_h2(content: str) -> tuple[list[tuple[str, str]], str]:
+    """Split markdown by H2 heading.
+
+    Returns:
+        (sections, h1_title)
+        sections: [(section title, section body), ...]
+        h1_title: text of the H1 heading (empty if none)
+    """
+    lines = content.split("\n")
+    sections: list[tuple[str, str]] = []
+
+    h1_title = ""
+    i = 0
+    # Skip the preamble before H1 / H2
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("# "):
+            h1_title = line[2:].strip()
+            i += 1
+            continue
+        if line.startswith("## "):
+            break
+        i += 1
+
+    # Split per H2 heading
+    current_section_title = ""
+    current_lines: list[str] = []
+
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("## "):
+            if current_section_title:
+                sections.append((current_section_title, "\n".join(current_lines).strip()))
+            current_section_title = line[3:].strip()
+            current_lines = [line]
+        else:
+            current_lines.append(line)
+        i += 1
+
+    if current_section_title:
+        sections.append((current_section_title, "\n".join(current_lines).strip()))
+
+    return sections, h1_title
+
+
+def process_file(md_path: Path) -> int:
+    """Split a single file and write the chunks under user_chunks/. Returns the chunk count."""
+    rel = md_path.relative_to(INPUT_DIR)
+    content = md_path.read_text(encoding="utf-8")
+    sections, h1_title = split_md_by_h2(content)
+
+    out_dir = OUTPUT_DIR / rel.parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Files with no H2 are emitted as a single chunk
+    if not sections:
+        out_path = out_dir / (md_path.stem + "_00_full.md")
+        out_path.write_text(content, encoding="utf-8")
+        return 1
+
+    base_name = md_path.stem
+    chunk_count = 0
+    for idx, (section_title, section_body) in enumerate(sections, 1):
+        # Prepend reference metadata pointing back to the source file
+        header = (
+            f"# {h1_title} - {section_title}\n\n"
+            f"> This file is the section `{section_title}` extracted from `user_knowledge/{rel}`.\n"
+            f"> Source document: `user_knowledge/{rel}`\n\n"
+        )
+        chunk_content = header + section_body
+
+        section_clean = sanitize_filename(section_title)
+        chunk_filename = f"{base_name}_{idx:02d}_{section_clean}.md"
+        out_path = out_dir / chunk_filename
+        out_path.write_text(chunk_content, encoding="utf-8")
+        chunk_count += 1
+
+    return chunk_count
+
+
+def main() -> None:
+    """Entry point."""
+    if not INPUT_DIR.exists():
+        logger.error("Input folder not found: %s", INPUT_DIR)
+        sys.exit(1)
+
+    md_files = sorted(INPUT_DIR.glob("**/*.md"))
+    # README.md is excluded (folder description, not knowledge content)
+    md_files = [f for f in md_files if f.name != "README.md"]
+
+    if not md_files:
+        logger.warning("No .md files to split under: %s", INPUT_DIR)
+        logger.warning("Place your knowledge files under user_knowledge/ and rerun")
+        sys.exit(1)
+
+    # Clear any existing chunks before regenerating
+    if OUTPUT_DIR.exists():
+        # Keep README.md
+        for item in OUTPUT_DIR.iterdir():
+            if item.name == "README.md":
+                continue
+            if item.is_dir():
+                shutil.rmtree(item)
+            else:
+                item.unlink()
+        logger.info("Cleared existing chunks: %s", OUTPUT_DIR)
+    else:
+        OUTPUT_DIR.mkdir(parents=True)
+
+    logger.info("Files to split: %d", len(md_files))
+    total_chunks = 0
+    for md_path in md_files:
+        rel = md_path.relative_to(INPUT_DIR)
+        n = process_file(md_path)
+        total_chunks += n
+        logger.info("  %s: %d chunks", rel, n)
+
+    logger.info("Split complete: %d chunks generated", total_chunks)
+    logger.info("Output: %s", OUTPUT_DIR)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/claude-code-cognee-graph-memory/src/main_src/import_to_graph.py
+++ b/integrations/claude-code-cognee-graph-memory/src/main_src/import_to_graph.py
@@ -1,0 +1,200 @@
+"""
+Production-time MD file ingestion script.
+
+Used during production runtime (while Claude Code is running) to ingest
+knowledge into Cognee graph memory. Besides loading the bundled samples,
+this is also the production path called from Claude Code on demand.
+
+Usage:
+  cd <distribution root directory>
+  src/venv/bin/python3 src/main_src/import_to_graph.py --target sample
+  src/venv/bin/python3 src/main_src/import_to_graph.py --list-targets
+
+Targets:
+  - sample: bundled samples (knowledge/sample_knowledge/)
+
+Note:
+  - For initial bulk ingestion, use src/knowledge_src/import_knowledge.py
+    (it supports retries on cognify failure and batched execution).
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from fastmcp import Client
+from fastmcp.client.transports import StdioTransport
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parent.parent  # src/main_src -> src -> distribution root
+WORKSPACE = PROJECT_ROOT.parent
+ENV_PATH = PROJECT_ROOT / "config" / ".env"
+MCP_COMMAND = str(PROJECT_ROOT / "src" / "main_src" / "start_cognee_mcp.py")
+
+
+def check_ollama() -> None:
+    """Verify Ollama is running and the LLM model specified in config/.env is available."""
+    env = _load_env()
+    llm_provider = env.get("LLM_PROVIDER", "").strip().lower()
+    if llm_provider != "ollama":
+        logger.info("LLM_PROVIDER=%s; skipping Ollama connectivity check",
+                    llm_provider or "(unset)")
+        return
+
+    llm_model = env.get("LLM_MODEL", "").strip()
+    if not llm_model:
+        logger.error("LLM_MODEL is not set in config/.env")
+        sys.exit(1)
+
+    url = "http://localhost:11434/api/tags"
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            data = json.loads(resp.read().decode())
+    except urllib.error.URLError as e:
+        logger.error("Cannot reach Ollama: %s", e)
+        logger.error("Run 'ollama serve' and try again")
+        sys.exit(1)
+    except Exception as e:
+        logger.error("Unexpected error during Ollama check: %s", e)
+        sys.exit(1)
+
+    model_names = [m.get("name", "") for m in data.get("models", [])]
+    if not any(llm_model in name for name in model_names):
+        logger.error("%s not found. Available models: %s", llm_model, model_names)
+        logger.error("Run 'ollama pull %s' and try again", llm_model)
+        sys.exit(1)
+
+    logger.info("Ollama check OK: %s is available", llm_model)
+
+
+def _load_env() -> dict[str, str]:
+    env = os.environ.copy()
+    if ENV_PATH.exists():
+        try:
+            for line in ENV_PATH.read_text().splitlines():
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    k, v = line.split("=", 1)
+                    env[k.strip()] = v.strip()
+        except OSError as e:
+            logger.warning("Failed to read .env (skipping): %s", e)
+    return env
+
+
+def make_transport() -> StdioTransport:
+    return StdioTransport(
+        command=str(PROJECT_ROOT / "src" / "venv" / "bin" / "python3"),
+        args=[MCP_COMMAND],
+        env=_load_env(),
+    )
+
+
+TARGET_MAP = {
+    "sample": {
+        "path": PROJECT_ROOT / "knowledge" / "sample_knowledge",
+        "dataset_name": "sample_knowledge",
+        "description": "Bundled sample knowledge data (for verification)",
+        "glob": "*.md",
+    },
+}
+
+
+def collect_files(target_key: str) -> list[tuple[Path, str]]:
+    """Return a list of (file, dataset_name) pairs."""
+    if target_key not in TARGET_MAP:
+        logger.error("Unknown target: %s", target_key)
+        sys.exit(1)
+
+    cfg = TARGET_MAP[target_key]
+    base_path = cfg["path"]
+    if not base_path.exists():
+        logger.warning("Path does not exist: %s", base_path)
+        return []
+
+    try:
+        files = sorted(base_path.glob(cfg["glob"]))
+    except Exception as e:
+        logger.error("Failed to enumerate files (%s): %s", base_path, e)
+        sys.exit(1)
+
+    return [(f, cfg["dataset_name"]) for f in files if f.is_file()]
+
+
+async def import_files(files: list[tuple[Path, str]], dry_run: bool = False) -> None:
+    """Ingest files into Cognee one by one."""
+    if not files:
+        logger.info("No files to ingest.")
+        return
+
+    logger.info("Ingestion target: %d files", len(files))
+
+    async with Client(make_transport()) as client:
+        for i, (file_path, dataset_name) in enumerate(files, 1):
+            logger.info("[%d/%d] %s -> dataset=%s", i, len(files), file_path.name, dataset_name)
+            if dry_run:
+                logger.info("  (dry-run: skipped)")
+                continue
+            try:
+                content = file_path.read_text(encoding="utf-8")
+                result = await client.call_tool("remember", {
+                    "data": content,
+                    "dataset_name": dataset_name,
+                })
+                text = result.content[0].text if result and result.content else ""
+                logger.info("  -> %s...", text[:80])
+            except Exception as e:
+                logger.error("  Ingestion failed (%s): %s", file_path.name, e)
+
+
+def list_targets() -> None:
+    """Print the list of available targets."""
+    logger.info("Available targets:")
+    for key, cfg in TARGET_MAP.items():
+        path = cfg["path"]
+        exists = "OK" if path.exists() else "MISSING (path not found)"
+        logger.info("  %s: %s [%s]", key, cfg["description"], exists)
+        logger.info("         Path: %s", path)
+
+
+def main() -> None:
+    """Entry point."""
+    parser = argparse.ArgumentParser(
+        description="Ingest MD files into Cognee graph memory (called from Claude Code at runtime)"
+    )
+    parser.add_argument("--target", help="Ingestion target (sample)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print the file list without ingesting")
+    parser.add_argument("--list-targets", action="store_true",
+                        help="Print the list of available targets")
+    args = parser.parse_args()
+
+    if args.list_targets:
+        list_targets()
+        return
+
+    if not args.target:
+        parser.print_help()
+        sys.exit(1)
+
+    if not args.dry_run:
+        check_ollama()
+
+    files = collect_files(args.target)
+    asyncio.run(import_files(files, dry_run=args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/claude-code-cognee-graph-memory/src/main_src/start_cognee_mcp.py
+++ b/integrations/claude-code-cognee-graph-memory/src/main_src/start_cognee_mcp.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Cognee MCP server startup script.
+
+Invoked from Claude Code's MCP configuration.
+Resolves the distribution root automatically, loads config/.env into the
+environment, and launches `cognee-mcp` from the venv.
+
+Registration command:
+  claude mcp add cognee --scope user src/main_src/start_cognee_mcp.py
+"""
+import logging
+import os
+import sys
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# Resolve the distribution root from this file's location.
+# src/main_src/start_cognee_mcp.py -> src/main_src -> src -> distribution root
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parent.parent
+ENV_FILE = PROJECT_ROOT / "config" / ".env"
+VENV_BIN = PROJECT_ROOT / "src" / "venv" / "bin"
+COGNEE_MCP = VENV_BIN / "cognee-mcp"
+
+
+def load_env_file(path: Path) -> None:
+    """Load KEY=VALUE pairs from .env into os.environ.
+
+    The cognee-mcp child process inherits os.environ via execv, so the
+    LLM_API_KEY / LLM_ENDPOINT / SYSTEM_ROOT_DIRECTORY etc. configured in
+    config/.env are made visible to the cognee runtime regardless of cwd.
+    Existing environment variables take precedence over .env values.
+    """
+    if not path.exists():
+        logger.warning(".env not found at %s (continuing without it)", path)
+        return
+
+    with path.open("r", encoding="utf-8") as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            if key and key not in os.environ:
+                os.environ[key] = value
+
+
+def main() -> None:
+    # Verify the cognee-mcp binary exists
+    if not COGNEE_MCP.exists():
+        logger.error("cognee-mcp not found: %s", COGNEE_MCP)
+        logger.error("Please create the venv following the setup guide")
+        sys.exit(1)
+
+    # Load config/.env into the current environment so that the spawned
+    # cognee-mcp process inherits LLM credentials and storage paths.
+    load_env_file(ENV_FILE)
+
+    # Change to the project root (some Cognee internals resolve relative
+    # paths against cwd).
+    os.chdir(PROJECT_ROOT)
+    logger.info("Starting: %s", COGNEE_MCP)
+
+    try:
+        # Replace the current process with cognee-mcp (using execv for memory efficiency)
+        os.execv(str(COGNEE_MCP), [str(COGNEE_MCP)])
+    except OSError as e:
+        logger.error("Failed to launch cognee-mcp: %s", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/claude-code-cognee-graph-memory/src/sample_src/delete_sample.py
+++ b/integrations/claude-code-cognee-graph-memory/src/sample_src/delete_sample.py
@@ -1,0 +1,81 @@
+"""
+Delete the sample_knowledge dataset from Cognee graph memory.
+
+Use this once you have finished verifying with the bundled samples and want
+to start clean with only your own knowledge. Other datasets (e.g. user_knowledge)
+are not affected.
+
+Usage:
+    cd <distribution root directory>
+    src/venv/bin/python3 src/sample_src/delete_sample.py
+"""
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+from fastmcp import Client
+from fastmcp.client.transports import StdioTransport
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+# Resolve the distribution root from this file's location.
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parent.parent
+ENV_PATH = PROJECT_ROOT / "config" / ".env"
+MCP_COMMAND = str(PROJECT_ROOT / "src" / "main_src" / "start_cognee_mcp.py")
+DATASET_NAME = "sample_knowledge"
+
+
+def _load_env() -> dict[str, str]:
+    """Load config/.env and return the resulting environment dict."""
+    env = os.environ.copy()
+    if ENV_PATH.exists():
+        try:
+            for line in ENV_PATH.read_text().splitlines():
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    k, v = line.split("=", 1)
+                    env[k.strip()] = v.strip()
+        except OSError as e:
+            logger.warning("Failed to read .env (skipping): %s", e)
+    return env
+
+
+def make_transport() -> StdioTransport:
+    """Build the StdioTransport for connecting to the Cognee MCP server."""
+    return StdioTransport(
+        command=str(PROJECT_ROOT / "src" / "venv" / "bin" / "python3"),
+        args=[MCP_COMMAND],
+        env=_load_env(),
+    )
+
+
+async def delete_sample_dataset() -> None:
+    """Delete the sample_knowledge dataset."""
+    logger.info("Dataset to delete: %s", DATASET_NAME)
+    async with Client(make_transport()) as client:
+        try:
+            result = await client.call_tool("delete_dataset", {
+                "dataset_name": DATASET_NAME,
+            })
+            text = result.content[0].text if result and result.content else ""
+            logger.info("Delete result: %s", text)
+        except Exception as e:
+            logger.error("Delete failed: %s", e)
+            sys.exit(1)
+
+
+def main() -> None:
+    """Entry point."""
+    asyncio.run(delete_sample_dataset())
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/claude-code-cognee-graph-memory/src/sample_src/load_sample.py
+++ b/integrations/claude-code-cognee-graph-memory/src/sample_src/load_sample.py
@@ -1,0 +1,41 @@
+"""
+Load bundled sample knowledge into Cognee graph memory.
+
+For post-setup verification. This is a thin wrapper that internally calls
+`src/main_src/import_to_graph.py --target sample`.
+
+Usage:
+    cd <distribution root directory>
+    src/venv/bin/python3 src/sample_src/load_sample.py
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parent.parent  # src/sample_src -> src -> distribution root
+IMPORT_SCRIPT = PROJECT_ROOT / "src" / "main_src" / "import_to_graph.py"
+PYTHON = PROJECT_ROOT / "src" / "venv" / "bin" / "python3"
+
+
+def main() -> None:
+    """Invoke src/main_src/import_to_graph.py --target sample"""
+    if not IMPORT_SCRIPT.exists():
+        print(f"Error: {IMPORT_SCRIPT} not found", file=sys.stderr)
+        sys.exit(1)
+
+    if not PYTHON.exists():
+        print(f"Error: venv Python not found: {PYTHON}", file=sys.stderr)
+        print("Please create the venv following docs/SETUP.md", file=sys.stderr)
+        sys.exit(1)
+
+    # Delegate to import_to_graph.py
+    result = subprocess.run(
+        [str(PYTHON), str(IMPORT_SCRIPT), "--target", "sample"],
+        cwd=str(PROJECT_ROOT),
+    )
+    sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR contributes the cognee-graph-memory toolkit from
[JapanNomu/tools](https://github.com/JapanNomu/tools) (MIT License),
following the invitation by @tricalt on X
(https://x.com/tricalt/status/2050962347527749967).

## Cherry-pick friendly

The toolkit is provided as a complete unit, but each commit is
logically independent. Please feel free to cherry-pick only the
commits that fit cognee's roadmap, and close the rest.

## Per-commit assessment

| Commit | Feature | Overlap with existing official plugin |
|--------|---------|---------------------------------------|
| 1 | MCP server startup wrapper + graph importer | Different focus — official plugin targets cloud APIs, this targets local LLM (Ollama qwen2.5:14b) |
| 2 | Sample knowledge corpus + sample loaders | None — useful for learning and verification |
| 3 | Knowledge ingestion utilities (split + retry) | None — complementary feature for bulk ingestion |
| 4 | Auto-accumulation harness (hooks) | **Significant overlap** — official `integrations/claude-code/` has more hooks (6 vs 2) and slash commands. Consider this commit as reference only. |
| 5 | Documentation, config, and license | Partial — covers local-LLM setup, usage, and harness configuration |

## License

This contribution is licensed under the MIT License,
Copyright (c) 2026 JapanNomu. The original LICENSE file is included
in this PR.

Per MIT license terms, the copyright notice and license text
**must be retained** in all copies or substantial portions of
the included files. Please ensure the LICENSE file (or equivalent
attribution in file headers / NOTICE / LICENSE-3RD-PARTY file)
is preserved in this integration directory.

## Maintenance

This is a one-time contribution.
The original repository at JapanNomu/tools will continue to evolve
independently. I won't be able to commit to long-term maintenance
of this code within cognee, but feel free to take, modify, or
remove as needed.

## Related articles

A comparison between cognee's official Claude Code plugin and this
toolkit (which prompted Vasilije's invitation):
- [Zenn article (Japanese): cognee official vs toolkit](https://zenn.dev/japannomu/articles/20260503_cognee-official-vs-toolkit)
- [Zenn article (Japanese): toolkit introduction](https://zenn.dev/japannomu/articles/20260502_cognee-graph-memory-toolkit)

## Source snapshot

- Source repo: https://github.com/JapanNomu/tools
- Source version: v0.2.1 (cognee 1.0.5 verified, lint-clean)
- Source commit SHA: c6e7e036cfcc8766ea576cb84ae7ff4613e9629c (v0.2.1 lint cleanup)



## DCO

I affirm that all code in every commit of this pull request
conforms to the terms of the Topoteretes Developer Certificate
of Origin.