### PR TITLE
Changes hooks flow + fixes persistence issues (compaction, background, onexit) + fixes background mode flow

### DIFF
--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -10,6 +10,7 @@ import os
 import sys
 import urllib.error
 import urllib.request
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -21,6 +22,7 @@ _COUNTER_FILE = _PLUGIN_DIR / "counter.json"
 _ACTIVITY_FILE = _PLUGIN_DIR / "activity.ts"
 _ACTIVITY_LOG = _PLUGIN_DIR / "activity.log"
 _SAVE_COUNTER = _PLUGIN_DIR / "save_counter.json"
+_SYNC_LOCK = _PLUGIN_DIR / "sync.lock"
 
 # Save-kinds tracked per turn. Keep this tuple in sync with bump_save_counter callers.
 SAVE_KINDS = ("prompt", "trace", "answer")
@@ -30,6 +32,7 @@ _LOG_LINE_CAP = 600
 
 # Default auto-improve threshold (tool calls + stops). Env override.
 AUTO_IMPROVE_EVERY_DEFAULT = 30
+SYNC_LOCK_STALE_SECONDS = 15 * 60
 
 
 def load_resolved() -> dict:
@@ -206,6 +209,52 @@ def touch_activity() -> None:
         pass
 
 
+@contextmanager
+def sync_lock(owner: str):
+    """Best-effort cross-hook lock for graph sync/improve work."""
+    acquired = False
+    try:
+        _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        now = datetime.now(timezone.utc).timestamp()
+        if _SYNC_LOCK.exists():
+            try:
+                current = json.loads(_SYNC_LOCK.read_text(encoding="utf-8"))
+                created_at = float(current.get("created_at", 0))
+                pid = int(current.get("pid", 0))
+            except Exception:
+                created_at = 0
+                pid = 0
+            pid_alive = False
+            if pid > 0:
+                try:
+                    os.kill(pid, 0)
+                    pid_alive = True
+                except PermissionError:
+                    pid_alive = True
+                except OSError:
+                    pid_alive = False
+            if not pid_alive or now - created_at > SYNC_LOCK_STALE_SECONDS:
+                try:
+                    _SYNC_LOCK.unlink()
+                except Exception:
+                    pass
+        try:
+            fd = os.open(str(_SYNC_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump({"owner": owner, "pid": os.getpid(), "created_at": now}, fh)
+            acquired = True
+            yield True
+        except FileExistsError:
+            hook_log("sync_lock_busy", {"owner": owner})
+            yield False
+    finally:
+        if acquired:
+            try:
+                _SYNC_LOCK.unlink()
+            except Exception:
+                pass
+
+
 def _local_api_url() -> str:
     return os.environ.get("COGNEE_LOCAL_API_URL", "http://localhost:8000")
 
@@ -226,8 +275,9 @@ def improve_via_http(
 ) -> bool:
     """POST /api/v1/improve to the running backend if reachable.
 
-    Returns True on HTTP 2xx, False if the backend is unreachable or the
-    request failed. Callers should fall back to the local SDK path on False.
+    Returns True on HTTP 2xx, False if the backend is unreachable, the
+    plugin has no cached agent API key, or the request failed. Callers
+    should fall back to the local SDK path on False.
 
     Purpose: Kuzu is a single-writer graph DB. When the backend server is
     running it holds the lock; a second process importing ``cognee.improve()``
@@ -236,6 +286,13 @@ def improve_via_http(
     """
     base_url = _local_api_url()
     if not _backend_reachable(base_url):
+        return False
+    api_key = load_resolved().get("api_key", "") or os.environ.get("COGNEE_API_KEY", "")
+    if not api_key:
+        hook_log(
+            "improve_http_skipped_no_api_key",
+            {"dataset": dataset, "session": session_id},
+        )
         return False
     url = f"{base_url.rstrip('/')}/api/v1/improve"
     payload = json.dumps(
@@ -248,7 +305,10 @@ def improve_via_http(
     req = urllib.request.Request(
         url,
         data=payload,
-        headers={"Content-Type": "application/json"},
+        headers={
+            "Content-Type": "application/json",
+            "X-Api-Key": api_key,
+        },
         method="POST",
     )
     try:

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -5,11 +5,13 @@ single log-to-disk helper. Hook scripts shouldn't grow heavy because
 they run on every user prompt / tool call.
 """
 
+import hashlib
 import json
 import os
 import sys
 import urllib.error
 import urllib.request
+import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -23,6 +25,8 @@ _ACTIVITY_FILE = _PLUGIN_DIR / "activity.ts"
 _ACTIVITY_LOG = _PLUGIN_DIR / "activity.log"
 _SAVE_COUNTER = _PLUGIN_DIR / "save_counter.json"
 _SYNC_LOCK = _PLUGIN_DIR / "sync.lock"
+_HTTP_BRIDGE_CACHE = _PLUGIN_DIR / "http_bridge_cache.json"
+_HTTP_BRIDGE_STATE = _PLUGIN_DIR / "http_bridge_state.json"
 
 # Save-kinds tracked per turn. Keep this tuple in sync with bump_save_counter callers.
 SAVE_KINDS = ("prompt", "trace", "answer")
@@ -43,6 +47,57 @@ def load_resolved() -> dict:
         except Exception:
             pass
     return {}
+
+
+def _load_json_file(path: Path) -> dict:
+    if path.exists():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    return {}
+
+
+def _write_json_file(path: Path, data: dict) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def _bridge_cache_key(dataset: str, session_id: str) -> str:
+    user_id = load_resolved().get("user_id", "")
+    return f"{user_id}:{dataset}:{session_id}"
+
+
+def append_http_bridge_entry(
+    dataset: str,
+    session_id: str,
+    *,
+    question: str = "",
+    answer: str = "",
+    trace: str = "",
+) -> None:
+    """Keep a tiny local shadow of API-mode session text for graph bridging.
+
+    Local SDK mode already reads Cognee's session cache directly. In API
+    mode the cache lives behind the server, so this mirrors the same text
+    locally without affecting local mode.
+    """
+    if not dataset or not session_id:
+        return
+    if not (question or answer or trace):
+        return
+
+    cache = _load_json_file(_HTTP_BRIDGE_CACHE)
+    key = _bridge_cache_key(dataset, session_id)
+    session_cache = cache.setdefault(key, {"qa": [], "trace": []})
+    if question or answer:
+        session_cache.setdefault("qa", []).append({"question": question, "answer": answer})
+    if trace:
+        session_cache.setdefault("trace", []).append(trace)
+    _write_json_file(_HTTP_BRIDGE_CACHE, cache)
 
 
 async def resolve_user(user_id: str):
@@ -256,7 +311,93 @@ def sync_lock(owner: str):
 
 
 def _local_api_url() -> str:
-    return os.environ.get("COGNEE_LOCAL_API_URL", "http://localhost:8000")
+    return (
+        os.environ.get("COGNEE_LOCAL_API_URL")
+        or os.environ.get("COGNEE_SERVICE_URL")
+        or "http://localhost:8000"
+    )
+
+
+def _api_key() -> str:
+    return load_resolved().get("api_key", "") or os.environ.get("COGNEE_API_KEY", "")
+
+
+def _json_http_request(
+    path: str,
+    payload: dict | None = None,
+    *,
+    method: str = "POST",
+    timeout: float = 30.0,
+):
+    base_url = _local_api_url().rstrip("/")
+    api_key = _api_key()
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["X-Api-Key"] = api_key
+
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+
+    req = urllib.request.Request(
+        f"{base_url}{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        body = resp.read().decode("utf-8")
+        if not body:
+            return None
+        return json.loads(body)
+
+
+def remember_entry_via_http(
+    dataset: str,
+    session_id: str,
+    entry: dict,
+    *,
+    timeout: float = 30.0,
+) -> dict | None:
+    """Store a typed QA/trace entry through the backend API.
+
+    API-mode hooks use this instead of importing Cognee's Python client,
+    so they don't initialize local databases while talking to a backend.
+    """
+    if not dataset or not session_id:
+        return None
+    return _json_http_request(
+        "/api/v1/remember/entry",
+        {
+            "entry": entry,
+            "dataset_name": dataset,
+            "session_id": session_id,
+        },
+        timeout=timeout,
+    )
+
+
+def recall_via_http(
+    query: str,
+    *,
+    session_id: str,
+    top_k: int,
+    scope: list[str],
+    only_context: bool = True,
+    search_type: str | None = None,
+    timeout: float = 60.0,
+) -> list:
+    payload = {
+        "query": query,
+        "session_id": session_id,
+        "top_k": top_k,
+        "scope": scope,
+        "only_context": only_context,
+    }
+    if search_type:
+        payload["search_type"] = search_type
+    result = _json_http_request("/api/v1/recall", payload, timeout=timeout)
+    return result if isinstance(result, list) else []
 
 
 def _backend_reachable(base_url: str, timeout: float = 1.5) -> bool:
@@ -267,60 +408,138 @@ def _backend_reachable(base_url: str, timeout: float = 1.5) -> bool:
         return False
 
 
-def improve_via_http(
-    dataset: str,
-    session_id: str,
-    run_in_background: bool = False,
-    timeout: float = 600.0,
-) -> bool:
-    """POST /api/v1/improve to the running backend if reachable.
-
-    Returns True on HTTP 2xx, False if the backend is unreachable, the
-    plugin has no cached agent API key, or the request failed. Callers
-    should fall back to the local SDK path on False.
-
-    Purpose: Kuzu is a single-writer graph DB. When the backend server is
-    running it holds the lock; a second process importing ``cognee.improve()``
-    fails mid-pipeline. Routing through HTTP lets the server — which owns
-    the lock — run improve() in its own process.
-    """
-    base_url = _local_api_url()
-    if not _backend_reachable(base_url):
-        return False
-    api_key = load_resolved().get("api_key", "") or os.environ.get("COGNEE_API_KEY", "")
-    if not api_key:
-        hook_log(
-            "improve_http_skipped_no_api_key",
-            {"dataset": dataset, "session": session_id},
+def _multipart_body(
+    fields: dict[str, str], files: list[tuple[str, str, bytes]]
+) -> tuple[bytes, str]:
+    boundary = f"----cogneePlugin{uuid.uuid4().hex}"
+    chunks: list[bytes] = []
+    for name, value in fields.items():
+        chunks.append(f"--{boundary}\r\n".encode("utf-8"))
+        chunks.append(f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode("utf-8"))
+        chunks.append(str(value).encode("utf-8"))
+        chunks.append(b"\r\n")
+    for field_name, filename, content in files:
+        chunks.append(f"--{boundary}\r\n".encode("utf-8"))
+        chunks.append(
+            (
+                f'Content-Disposition: form-data; name="{field_name}"; filename="{filename}"\r\n'
+                "Content-Type: text/plain; charset=utf-8\r\n\r\n"
+            ).encode("utf-8")
         )
-        return False
-    url = f"{base_url.rstrip('/')}/api/v1/improve"
-    payload = json.dumps(
+        chunks.append(content)
+        chunks.append(b"\r\n")
+    chunks.append(f"--{boundary}--\r\n".encode("utf-8"))
+    return b"".join(chunks), boundary
+
+
+def _format_cached_bridge_document(dataset: str, session_id: str) -> tuple[str, str]:
+    cache = _load_json_file(_HTTP_BRIDGE_CACHE)
+    key = _bridge_cache_key(dataset, session_id)
+    session_cache = cache.get(key, {})
+
+    qa_lines: list[str] = []
+    for entry in session_cache.get("qa", []) or []:
+        question = str(entry.get("question") or "").strip()
+        answer = str(entry.get("answer") or "").strip()
+        if question:
+            qa_lines.append(f"Question: {question}")
+        if answer:
+            qa_lines.append(f"Answer: {answer}")
+        if question or answer:
+            qa_lines.append("")
+
+    trace_lines = [str(value).strip() for value in session_cache.get("trace", []) or []]
+    trace_lines = [value for value in trace_lines if value]
+
+    qa_doc = "\n".join(qa_lines).strip()
+    trace_doc = "\n\n".join(trace_lines).strip()
+    if qa_doc:
+        qa_doc = f"Session ID: {session_id}\n\n{qa_doc}"
+    if trace_doc:
+        trace_doc = f"Session ID: {session_id}\n\n{trace_doc}"
+    return qa_doc, trace_doc
+
+
+def _post_remember_document(
+    base_url: str,
+    api_key: str,
+    dataset: str,
+    document: str,
+    node_set: str,
+    timeout: float,
+) -> bool:
+    body, boundary = _multipart_body(
         {
-            "dataset_name": dataset,
-            "session_ids": [session_id],
-            "run_in_background": run_in_background,
-        }
-    ).encode("utf-8")
+            "datasetName": dataset,
+            "node_set": node_set,
+            "run_in_background": "false",
+        },
+        [("data", f"{node_set}.txt", document.encode("utf-8"))],
+    )
     req = urllib.request.Request(
-        url,
-        data=payload,
+        f"{base_url.rstrip('/')}/api/v1/remember",
+        data=body,
         headers={
-            "Content-Type": "application/json",
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
             "X-Api-Key": api_key,
         },
         method="POST",
     )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return 200 <= resp.status < 300
+
+
+def persist_session_cache_to_graph_via_http(
+    dataset: str,
+    session_id: str,
+    timeout: float = 600.0,
+) -> bool:
+    """API-mode equivalent of the local SDK session-cache bridge.
+
+    Local mode reads Cognee's in-process session cache and calls
+    ``cognee.remember(..., self_improvement=False)``. API mode cannot
+    read the server cache directly, so the hooks maintain a small local
+    shadow and this function posts that text to the backend remember
+    endpoint as permanent graph data.
+    """
+    base_url = _local_api_url()
+    if not _backend_reachable(base_url):
+        return False
+    api_key = _api_key()
+    if not api_key:
+        hook_log("http_bridge_skipped_no_api_key", {"dataset": dataset, "session": session_id})
+        return False
+
+    qa_doc, trace_doc = _format_cached_bridge_document(dataset, session_id)
+    if not qa_doc and not trace_doc:
+        hook_log("http_bridge_skipped_empty_cache", {"dataset": dataset, "session": session_id})
+        return False
+
+    state = _load_json_file(_HTTP_BRIDGE_STATE)
+    wrote = False
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            hook_log(
-                "improve_http_ok",
-                {"status": resp.status, "dataset": dataset, "session": session_id},
-            )
-            return 200 <= resp.status < 300
+        for kind, node_set, document in (
+            ("qa", "user_sessions_from_cache", qa_doc),
+            ("trace", "agent_trace_feedbacks", trace_doc),
+        ):
+            if not document:
+                continue
+            state_key = f"{_bridge_cache_key(dataset, session_id)}:{kind}"
+            digest = hashlib.sha256(document.encode("utf-8")).hexdigest()
+            if state.get(state_key) == digest:
+                continue
+            if _post_remember_document(base_url, api_key, dataset, document, node_set, timeout):
+                state[state_key] = digest
+                wrote = True
+        _write_json_file(_HTTP_BRIDGE_STATE, state)
+        hook_log(
+            "http_bridge_done",
+            {"dataset": dataset, "session": session_id, "wrote": wrote},
+        )
+        return wrote
     except (urllib.error.URLError, TimeoutError, OSError) as exc:
         hook_log(
-            "improve_http_failed",
+            "http_bridge_failed",
             {"error": str(exc)[:200], "dataset": dataset, "session": session_id},
         )
         return False

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -360,6 +360,109 @@ async def ensure_cognee_ready(config: dict) -> None:
     print("cognee-plugin: local databases ready", file=sys.stderr)
 
 
+async def ensure_dataset_ready(dataset: str, user) -> None:
+    """Ensure the user can write to the dataset before session improve().
+
+    Cognee's improve(session_ids=[...]) bridges cached session entries
+    before the default enrichment stage. On a fresh local install, that
+    bridge can run before the dataset has been created, causing the
+    session persistence stages to no-op with permission errors. Use
+    Cognee's own pipeline resolver so dataset creation and ACL grants
+    follow the SDK's normal path.
+
+    Cognee 1.0.8's session/trace persistence pipelines call memify()
+    without forwarding their user argument. In local plugin processes,
+    make the resolved agent the process-local default user too, so those
+    nested calls resolve the same write permissions.
+    """
+    from cognee.base_config import get_base_config
+    from cognee.modules.pipelines.layers.resolve_authorized_user_datasets import (
+        resolve_authorized_user_datasets,
+    )
+
+    email = getattr(user, "email", "")
+    if email:
+        get_base_config().default_user_email = email
+
+    await resolve_authorized_user_datasets(dataset, user=user)
+
+
+def _read_field(entry, field: str) -> str:
+    if isinstance(entry, dict):
+        return str(entry.get(field) or "")
+    return str(getattr(entry, field, "") or "")
+
+
+async def persist_session_cache_to_graph(dataset: str, session_id: str, user) -> bool:
+    """Persist cached session QA/trace text to the permanent graph.
+
+    This is a local-mode compatibility bridge for Cognee 1.0.8. The SDK's
+    built-in session persistence can complete without extracting entries
+    from the file-system cache in the Claude plugin setup. Reading the same
+    cache directly here keeps the integration useful while still using
+    cognee.remember() for the actual add+cognify pipeline.
+    """
+    if not session_id or not user:
+        return False
+
+    import cognee
+    from cognee.infrastructure.session.get_session_manager import get_session_manager
+
+    await ensure_dataset_ready(dataset, user)
+
+    user_id = str(user.id)
+    session_manager = get_session_manager()
+    if not session_manager.is_available:
+        return False
+
+    wrote = False
+
+    qa_entries = await session_manager.get_session(
+        user_id=user_id,
+        session_id=session_id,
+        formatted=False,
+    )
+    qa_lines: list[str] = []
+    for entry in qa_entries or []:
+        question = _read_field(entry, "question").strip()
+        answer = _read_field(entry, "answer").strip()
+        if question:
+            qa_lines.append(f"Question: {question}")
+        if answer:
+            qa_lines.append(f"Answer: {answer}")
+        if question or answer:
+            qa_lines.append("")
+    qa_text = "\n".join(qa_lines).strip()
+    if qa_text:
+        await cognee.remember(
+            f"Session ID: {session_id}\n\n{qa_text}",
+            dataset_name=dataset,
+            node_set=["user_sessions_from_cache"],
+            self_improvement=False,
+            run_in_background=False,
+            user=user,
+        )
+        wrote = True
+
+    trace_values = await session_manager.get_agent_trace_feedback(
+        user_id=user_id,
+        session_id=session_id,
+    )
+    trace_text = "\n".join(str(value).strip() for value in trace_values or [] if str(value).strip())
+    if trace_text:
+        await cognee.remember(
+            f"Session ID: {session_id}\n\n{trace_text}",
+            dataset_name=dataset,
+            node_set=["agent_trace_feedbacks"],
+            self_improvement=False,
+            run_in_background=False,
+            user=user,
+        )
+        wrote = True
+
+    return wrote
+
+
 def _get_git_branch(cwd: str) -> str:
     """Get current git branch, or empty string if not a git repo."""
     try:

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -223,11 +223,6 @@ async def _ensure_identity_via_api(service_url: str, config: dict) -> tuple:
                     if keys:
                         agent_key = keys[0].get("key", "")
                         if agent_key:
-                            # Reconnect serve() with agent's own API key
-                            import cognee
-
-                            await cognee.disconnect()
-                            await cognee.serve(url=service_url, api_key=agent_key)
                             print(
                                 f"cognee-plugin: connected as agent (key={agent_key[:8]}...)",
                                 file=sys.stderr,
@@ -246,11 +241,6 @@ async def _ensure_identity_via_api(service_url: str, config: dict) -> tuple:
                 if resp.status == 200:
                     key_data = await resp.json()
                     agent_key = key_data["key"]
-                    # Reconnect serve() with agent's own API key
-                    import cognee
-
-                    await cognee.disconnect()
-                    await cognee.serve(url=service_url, api_key=agent_key)
                     print(
                         f"cognee-plugin: created agent API key (key={agent_key[:8]}...)",
                         file=sys.stderr,
@@ -266,6 +256,27 @@ async def _ensure_identity_via_api(service_url: str, config: dict) -> tuple:
             print(f"cognee-plugin: API key creation failed ({e})", file=sys.stderr)
 
     return "", ""
+
+
+async def ensure_dataset_ready_via_api(service_url: str, api_key: str, dataset: str) -> None:
+    """Ensure the remote backend has the dataset for the authenticated agent.
+
+    This mirrors local SDK mode's ``ensure_dataset_ready(dataset, user)``:
+    the backend creates or returns the dataset and grants permissions to
+    the API-key user.
+    """
+    if not service_url or not api_key or not dataset:
+        return
+
+    import aiohttp
+
+    base = service_url.rstrip("/")
+    async with aiohttp.ClientSession(headers={"X-Api-Key": api_key}) as session:
+        async with session.post(f"{base}/api/v1/datasets", json={"name": dataset}) as resp:
+            if resp.status in (200, 201):
+                return
+            text = await resp.text()
+            raise RuntimeError(f"remote dataset ensure failed ({resp.status}: {text[:200]})")
 
 
 def _get_user_id_from_jwt(jwt: str) -> str:
@@ -333,24 +344,19 @@ async def ensure_cognee_ready(config: dict) -> None:
     fresh virtualenv has its databases/tables before identity, recall, or
     session writes touch them.
     """
-    import cognee
-
     if is_cloud_mode(config):
         url = config["service_url"]
-        # Try config first, then fall back to cached key from SessionStart
-        api_key = config.get("api_key", "")
-        if not api_key and _RESOLVED_CACHE_PATH.exists():
-            try:
-                resolved = json.loads(_RESOLVED_CACHE_PATH.read_text(encoding="utf-8"))
-                api_key = resolved.get("api_key", "")
-            except Exception:
-                pass
-        kwargs = {"url": url}
-        if api_key:
-            kwargs["api_key"] = api_key
-        await cognee.serve(**kwargs)
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"{url.rstrip('/')}/health") as resp:
+                if resp.status >= 400:
+                    text = await resp.text()
+                    raise RuntimeError(f"backend health check failed ({resp.status}: {text[:200]})")
         print(f"cognee-plugin: connected to {url}", file=sys.stderr)
         return
+
+    import cognee
 
     if config.get("llm_api_key"):
         cognee.config.set_llm_api_key(config["llm_api_key"])

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -23,6 +23,7 @@ from typing import Optional
 
 _CONFIG_DIR = Path.home() / ".cognee-plugin"
 _CONFIG_FILE = _CONFIG_DIR / "config.json"
+_BRIDGE_STATE_FILE = _CONFIG_DIR / "bridge_state.json"
 
 _DEFAULTS = {
     "dataset": "claude_sessions",
@@ -361,14 +362,12 @@ async def ensure_cognee_ready(config: dict) -> None:
 
 
 async def ensure_dataset_ready(dataset: str, user) -> None:
-    """Ensure the user can write to the dataset before session improve().
+    """Ensure the user can write to the dataset before session bridging.
 
-    Cognee's improve(session_ids=[...]) bridges cached session entries
-    before the default enrichment stage. On a fresh local install, that
-    bridge can run before the dataset has been created, causing the
-    session persistence stages to no-op with permission errors. Use
-    Cognee's own pipeline resolver so dataset creation and ACL grants
-    follow the SDK's normal path.
+    On a fresh local install, session bridging can run before the dataset
+    has been created, causing persistence to no-op with permission
+    errors. Use Cognee's own pipeline resolver so dataset creation and
+    ACL grants follow the SDK's normal path.
 
     Cognee 1.0.8's session/trace persistence pipelines call memify()
     without forwarding their user argument. In local plugin processes,
@@ -387,10 +386,62 @@ async def ensure_dataset_ready(dataset: str, user) -> None:
     await resolve_authorized_user_datasets(dataset, user=user)
 
 
+async def sync_graph_context_to_session(dataset: str, session_id: str, user) -> dict:
+    """Sync permanent graph context into one session without full improve().
+
+    ``cognee.improve(session_ids=[...])`` also persists session cache
+    entries. The integration already does that explicitly via
+    ``persist_session_cache_to_graph()``, so call only Cognee's final
+    graph-context sync step to keep recall working without duplicating
+    session documents or holding the DB lock for the full improve path.
+    """
+    if not session_id or not user:
+        return {"synced": 0}
+
+    from cognee.modules.pipelines.layers.resolve_authorized_user_datasets import (
+        resolve_authorized_user_datasets,
+    )
+    from cognee.tasks.memify.sync_graph_to_session import sync_graph_to_session
+
+    _, authorized_datasets = await resolve_authorized_user_datasets(dataset, user=user)
+    if not authorized_datasets:
+        return {"synced": 0}
+
+    return await sync_graph_to_session(
+        user_id=str(user.id),
+        session_id=session_id,
+        dataset_id=authorized_datasets[0].id,
+        dataset_name=dataset,
+    )
+
+
 def _read_field(entry, field: str) -> str:
     if isinstance(entry, dict):
         return str(entry.get(field) or "")
     return str(getattr(entry, field, "") or "")
+
+
+def _load_bridge_state() -> dict:
+    try:
+        return json.loads(_BRIDGE_STATE_FILE.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _save_bridge_state(state: dict) -> None:
+    try:
+        _BRIDGE_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _BRIDGE_STATE_FILE.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def _bridge_state_key(dataset: str, session_id: str, user_id: str, kind: str) -> str:
+    return hashlib.sha256(f"{user_id}:{dataset}:{session_id}:{kind}".encode()).hexdigest()
+
+
+def _content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
 async def persist_session_cache_to_graph(dataset: str, session_id: str, user) -> bool:
@@ -416,6 +467,8 @@ async def persist_session_cache_to_graph(dataset: str, session_id: str, user) ->
         return False
 
     wrote = False
+    bridge_state = _load_bridge_state()
+    state_changed = False
 
     qa_entries = await session_manager.get_session(
         user_id=user_id,
@@ -434,8 +487,18 @@ async def persist_session_cache_to_graph(dataset: str, session_id: str, user) ->
             qa_lines.append("")
     qa_text = "\n".join(qa_lines).strip()
     if qa_text:
+        qa_document = f"Session ID: {session_id}\n\n{qa_text}"
+        qa_key = _bridge_state_key(dataset, session_id, user_id, "qa")
+        qa_hash = _content_hash(qa_document)
+        if bridge_state.get(qa_key) == qa_hash:
+            qa_text = ""
+        else:
+            bridge_state[qa_key] = qa_hash
+            state_changed = True
+
+    if qa_text:
         await cognee.remember(
-            f"Session ID: {session_id}\n\n{qa_text}",
+            qa_document,
             dataset_name=dataset,
             node_set=["user_sessions_from_cache"],
             self_improvement=False,
@@ -450,8 +513,18 @@ async def persist_session_cache_to_graph(dataset: str, session_id: str, user) ->
     )
     trace_text = "\n".join(str(value).strip() for value in trace_values or [] if str(value).strip())
     if trace_text:
+        trace_document = f"Session ID: {session_id}\n\n{trace_text}"
+        trace_key = _bridge_state_key(dataset, session_id, user_id, "trace")
+        trace_hash = _content_hash(trace_document)
+        if bridge_state.get(trace_key) == trace_hash:
+            trace_text = ""
+        else:
+            bridge_state[trace_key] = trace_hash
+            state_changed = True
+
+    if trace_text:
         await cognee.remember(
-            f"Session ID: {session_id}\n\n{trace_text}",
+            trace_document,
             dataset_name=dataset,
             node_set=["agent_trace_feedbacks"],
             self_improvement=False,
@@ -459,6 +532,9 @@ async def persist_session_cache_to_graph(dataset: str, session_id: str, user) ->
             user=user,
         )
         wrote = True
+
+    if state_changed:
+        _save_bridge_state(bridge_state)
 
     return wrote
 

--- a/integrations/claude-code/scripts/idle-watcher.py
+++ b/integrations/claude-code/scripts/idle-watcher.py
@@ -21,6 +21,7 @@ import os
 import signal
 import sys
 import time
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Optional
 
@@ -89,48 +90,70 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
     """
     sys.path.insert(0, os.path.dirname(__file__))
     try:
-        from _plugin_common import improve_via_http  # type: ignore
+        from _plugin_common import improve_via_http, sync_lock  # type: ignore
 
-        if improve_via_http(dataset, session_id, run_in_background=True):
-            _log("improve_via_http", session=session_id, dataset=dataset)
+        lock = sync_lock("idle-watcher")
+    except Exception as exc:
+        _log("sync_lock_import_error", error=str(exc)[:200])
+        lock = nullcontext(True)
+
+    with lock as acquired:
+        if not acquired:
+            _log("improve_skipped_lock_busy", session=session_id, dataset=dataset)
+            return False
+
+        try:
+            if improve_via_http(dataset, session_id, run_in_background=True):
+                _log("improve_via_http", session=session_id, dataset=dataset)
+                return True
+        except Exception as exc:
+            _log("improve_http_check_error", error=str(exc)[:200])
+
+        try:
+            from config import (  # type: ignore
+                ensure_cognee_ready,
+                ensure_dataset_ready,
+                ensure_identity,
+                persist_session_cache_to_graph,
+            )
+
+            await ensure_cognee_ready(config)
+            user_id, _ = await ensure_identity(config)
+
+            from uuid import UUID
+
+            import cognee
+            from cognee.modules.users.methods import get_user
+
+            user = await get_user(UUID(user_id)) if user_id else None
+            if user:
+                await ensure_dataset_ready(dataset, user)
+                await persist_session_cache_to_graph(dataset, session_id, user)
+            await cognee.improve(
+                dataset=dataset,
+                session_ids=[session_id],
+                user=user,
+                run_in_background=False,
+            )
             return True
-    except Exception as exc:
-        _log("improve_http_check_error", error=str(exc)[:200])
-
-    try:
-        from config import ensure_cognee_ready, ensure_identity  # type: ignore
-
-        await ensure_cognee_ready(config)
-        user_id, _ = await ensure_identity(config)
-
-        from uuid import UUID
-
-        import cognee
-        from cognee.modules.users.methods import get_user
-
-        user = await get_user(UUID(user_id)) if user_id else None
-        await cognee.improve(
-            dataset=dataset,
-            session_ids=[session_id],
-            user=user,
-            run_in_background=True,
-        )
-        return True
-    except Exception as exc:
-        _log("improve_error", error=str(exc)[:300])
-        return False
+        except Exception as exc:
+            _log("improve_error", error=str(exc)[:300])
+            return False
 
 
 async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
     _log("started", session=session_id, dataset=dataset, poll=POLL_SECONDS, idle=IDLE_SECONDS)
     last_improved_at = 0.0
+    exit_reason = "loop_complete"
 
     while not _should_stop:
         if _STOPFILE.exists():
             _log("stop_sentinel_seen")
+            exit_reason = "stop_sentinel"
             break
         if not _owns_pidfile():
             _log("pidfile_replaced")
+            exit_reason = "pidfile_replaced"
             break
 
         now = time.time()
@@ -150,7 +173,20 @@ async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
 
         await asyncio.sleep(POLL_SECONDS)
 
-    _log("exiting")
+    if _should_stop:
+        exit_reason = "signal"
+
+    ts = _read_activity_ts()
+    if exit_reason in {"signal", "stop_sentinel"} and ts and ts > last_improved_at:
+        _log("shutdown_trigger", reason=exit_reason, activity_age=round(time.time() - ts, 1))
+        ok = await _improve_once(session_id, dataset, config)
+        if ok:
+            last_improved_at = time.time()
+            _log("shutdown_improve_done")
+        else:
+            _log("shutdown_improve_failed")
+
+    _log("exiting", reason=exit_reason)
     try:
         if _owns_pidfile():
             _PIDFILE.unlink()

--- a/integrations/claude-code/scripts/idle-watcher.py
+++ b/integrations/claude-code/scripts/idle-watcher.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Idle watcher daemon — triggers ``cognee.improve()`` on quiet sessions.
+"""Idle watcher daemon — persists quiet sessions into Cognee.
 
 Launched detached from ``session-start.py``. Polls
 ``~/.cognee-plugin/activity.ts`` every ``POLL_SECONDS``. When the last
-activity is older than ``IDLE_SECONDS`` and we haven't improved since
-that point, fires ``cognee.improve(session_ids=[session_id])``.
+activity is older than ``IDLE_SECONDS`` and we haven't bridged since
+that point, persists the session cache and refreshes graph context.
 
 Stops cleanly on:
   * ``~/.cognee-plugin/watcher.stop`` sentinel file.
@@ -27,7 +27,7 @@ from typing import Optional
 
 # Tunable via env. Defaults chosen to avoid thrashing the LLM: 60s idle
 # threshold means you have to actively pause a full minute, and the 20s
-# improve cooldown prevents back-to-back runs when activity is sporadic.
+# bridge cooldown prevents back-to-back runs when activity is sporadic.
 POLL_SECONDS = float(os.environ.get("COGNEE_IDLE_POLL", "10"))
 IDLE_SECONDS = float(os.environ.get("COGNEE_IDLE_THRESHOLD", "60"))
 IMPROVE_COOLDOWN = float(os.environ.get("COGNEE_IMPROVE_COOLDOWN", "120"))
@@ -82,15 +82,10 @@ def _install_signal_handlers() -> None:
 
 
 async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
-    """Fire one improve cycle. Returns True on success.
-
-    Prefers the running backend via HTTP to avoid Kuzu single-writer lock
-    conflicts — the backend server already holds the lock. Falls back to
-    the local SDK when no backend is reachable.
-    """
+    """Fire one session bridge cycle. Returns True on success."""
     sys.path.insert(0, os.path.dirname(__file__))
     try:
-        from _plugin_common import improve_via_http, sync_lock  # type: ignore
+        from _plugin_common import sync_lock  # type: ignore
 
         lock = sync_lock("idle-watcher")
     except Exception as exc:
@@ -99,15 +94,8 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
 
     with lock as acquired:
         if not acquired:
-            _log("improve_skipped_lock_busy", session=session_id, dataset=dataset)
+            _log("bridge_skipped_lock_busy", session=session_id, dataset=dataset)
             return False
-
-        try:
-            if improve_via_http(dataset, session_id, run_in_background=True):
-                _log("improve_via_http", session=session_id, dataset=dataset)
-                return True
-        except Exception as exc:
-            _log("improve_http_check_error", error=str(exc)[:200])
 
         try:
             from config import (  # type: ignore
@@ -115,6 +103,7 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
                 ensure_dataset_ready,
                 ensure_identity,
                 persist_session_cache_to_graph,
+                sync_graph_context_to_session,
             )
 
             await ensure_cognee_ready(config)
@@ -122,22 +111,23 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
 
             from uuid import UUID
 
-            import cognee
             from cognee.modules.users.methods import get_user
 
             user = await get_user(UUID(user_id)) if user_id else None
             if user:
                 await ensure_dataset_ready(dataset, user)
-                await persist_session_cache_to_graph(dataset, session_id, user)
-            await cognee.improve(
-                dataset=dataset,
-                session_ids=[session_id],
-                user=user,
-                run_in_background=False,
-            )
+                wrote = await persist_session_cache_to_graph(dataset, session_id, user)
+                graph_result = await sync_graph_context_to_session(dataset, session_id, user)
+                _log(
+                    "session_bridge_done",
+                    session=session_id,
+                    dataset=dataset,
+                    wrote=wrote,
+                    graph_synced=graph_result.get("synced", 0),
+                )
             return True
         except Exception as exc:
-            _log("improve_error", error=str(exc)[:300])
+            _log("bridge_error", error=str(exc)[:300])
             return False
 
 
@@ -169,7 +159,7 @@ async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
             ok = await _improve_once(session_id, dataset, config)
             if ok:
                 last_improved_at = time.time()
-                _log("improve_done")
+                _log("bridge_done")
 
         await asyncio.sleep(POLL_SECONDS)
 
@@ -182,9 +172,9 @@ async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
         ok = await _improve_once(session_id, dataset, config)
         if ok:
             last_improved_at = time.time()
-            _log("shutdown_improve_done")
+            _log("shutdown_bridge_done")
         else:
-            _log("shutdown_improve_failed")
+            _log("shutdown_bridge_failed")
 
     _log("exiting", reason=exit_reason)
     try:
@@ -209,7 +199,13 @@ def main():
 
     session_id = bootstrap.get("session_id", "")
     dataset = bootstrap.get("dataset", "claude_sessions")
-    config = bootstrap.get("config", {})
+    try:
+        from config import load_config  # type: ignore
+
+        config = load_config()
+        config.update({k: v for k, v in bootstrap.get("config", {}).items() if v})
+    except Exception:
+        config = bootstrap.get("config", {})
     if not session_id:
         _log("fatal_no_session_id")
         sys.exit(1)

--- a/integrations/claude-code/scripts/idle-watcher.py
+++ b/integrations/claude-code/scripts/idle-watcher.py
@@ -160,6 +160,8 @@ async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
             if ok:
                 last_improved_at = time.time()
                 _log("bridge_done")
+                exit_reason = "bridge_complete"
+                break
 
         await asyncio.sleep(POLL_SECONDS)
 

--- a/integrations/claude-code/scripts/idle-watcher.py
+++ b/integrations/claude-code/scripts/idle-watcher.py
@@ -85,7 +85,10 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
     """Fire one session bridge cycle. Returns True on success."""
     sys.path.insert(0, os.path.dirname(__file__))
     try:
-        from _plugin_common import sync_lock  # type: ignore
+        from _plugin_common import (  # type: ignore
+            persist_session_cache_to_graph_via_http,
+            sync_lock,
+        )
 
         lock = sync_lock("idle-watcher")
     except Exception as exc:
@@ -102,9 +105,21 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
                 ensure_cognee_ready,
                 ensure_dataset_ready,
                 ensure_identity,
+                is_cloud_mode,
                 persist_session_cache_to_graph,
                 sync_graph_context_to_session,
             )
+
+            if is_cloud_mode(config):
+                wrote = persist_session_cache_to_graph_via_http(dataset, session_id)
+                _log(
+                    "session_bridge_done",
+                    session=session_id,
+                    dataset=dataset,
+                    via="http_remember",
+                    wrote=wrote,
+                )
+                return True
 
             await ensure_cognee_ready(config)
             user_id, _ = await ensure_identity(config)

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -84,6 +84,18 @@ def _format_entry(entry: dict) -> str:
     return "\n".join(lines)
 
 
+def _has_entry_content(entry: dict) -> bool:
+    """Return True when a recall entry has useful content to inject."""
+    source = entry.get("source", "")
+    if source == "graph_context":
+        return bool(str(entry.get("content", "") or entry.get("text", "")).strip())
+    if source == "trace":
+        fields = ("origin_function", "status", "session_feedback", "method_return_value")
+    else:
+        fields = ("question", "answer")
+    return any(str(entry.get(field, "") or "").strip() for field in fields)
+
+
 async def _run(prompt: str, out_stream=None):
     import cognee
     from cognee.modules.search.types import SearchType
@@ -142,6 +154,8 @@ async def _run(prompt: str, out_stream=None):
         if src == "graph":
             r["source"] = "graph_context"
             src = "graph_context"
+        if not _has_entry_content(r):
+            continue
         by_source.setdefault(src, []).append(r)
 
     counts = {k: len(v) for k, v in by_source.items()}

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -23,9 +23,10 @@ from _plugin_common import (
     load_resolved,
     notify,
     read_and_reset_save_counter,
+    recall_via_http,
     resolve_user,
 )
-from config import ensure_cognee_ready, get_session_id, load_config
+from config import ensure_cognee_ready, get_session_id, is_cloud_mode, load_config
 
 TOP_K = 5
 TRUNCATE_ANSWER = 500
@@ -97,9 +98,6 @@ def _has_entry_content(entry: dict) -> bool:
 
 
 async def _run(prompt: str, out_stream=None):
-    import cognee
-    from cognee.modules.search.types import SearchType
-
     config = load_config()
     await ensure_cognee_ready(config)
 
@@ -110,8 +108,6 @@ async def _run(prompt: str, out_stream=None):
 
     saves_last_turn = read_and_reset_save_counter(session_id)
 
-    user = await resolve_user(_load_user_id())
-
     # Run scopes independently: a failure in one (e.g. graph search hitting an
     # empty/locked Ladybug DB) must not discard hits already collected from the
     # others. cognee.recall loops over scopes and re-raises on the first failure,
@@ -121,19 +117,37 @@ async def _run(prompt: str, out_stream=None):
         (["session"], None),
         (["trace"], None),
         (["graph_context"], None),
-        (["graph"], SearchType.GRAPH_COMPLETION),
+        (["graph"], "GRAPH_COMPLETION"),
     ]
+    cloud_mode = is_cloud_mode(config)
+    if not cloud_mode:
+        import cognee
+        from cognee.modules.search.types import SearchType
+
+        user = await resolve_user(_load_user_id())
+
     for scope_list, qtype in scope_specs:
         try:
-            part = await cognee.recall(
-                prompt,
-                session_id=session_id,
-                top_k=TOP_K,
-                scope=scope_list,
-                only_context=True,
-                query_type=qtype,
-                user=user,
-            )
+            if cloud_mode:
+                part = recall_via_http(
+                    prompt,
+                    session_id=session_id,
+                    top_k=TOP_K,
+                    scope=scope_list,
+                    only_context=True,
+                    search_type=qtype,
+                )
+            else:
+                query_type = SearchType.GRAPH_COMPLETION if qtype == "GRAPH_COMPLETION" else None
+                part = await cognee.recall(
+                    prompt,
+                    session_id=session_id,
+                    top_k=TOP_K,
+                    scope=scope_list,
+                    only_context=True,
+                    query_type=query_type,
+                    user=user,
+                )
             if part:
                 results.extend(part)
         except Exception as exc:

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -23,8 +23,10 @@ from pathlib import Path
 
 # Add scripts dir to path for config import
 sys.path.insert(0, os.path.dirname(__file__))
+from _plugin_common import touch_activity
 from config import (
     ensure_cognee_ready,
+    ensure_dataset_ready,
     ensure_identity,
     get_dataset,
     get_session_id,
@@ -143,6 +145,17 @@ async def _start(out_stream=None):
     except Exception as e:
         print(f"cognee-plugin: identity warning ({e})", file=sys.stderr)
 
+    try:
+        if user_id:
+            from uuid import UUID
+
+            from cognee.modules.users.methods import get_user
+
+            user = await get_user(UUID(user_id))
+            await ensure_dataset_ready(dataset, user)
+    except Exception as e:
+        print(f"cognee-plugin: dataset warning ({e})", file=sys.stderr)
+
     # Write resolved values for other hooks
     _write_resolved(session_id, dataset, user_id, cwd, api_key=agent_api_key)
 
@@ -150,6 +163,11 @@ async def _start(out_stream=None):
     config_file = Path.home() / ".cognee-plugin" / "config.json"
     if not config_file.exists():
         save_config(config)
+
+    # Reset the idle clock for this Claude process before the watcher
+    # starts, otherwise a stale timestamp from a prior session can cause
+    # an immediate improve on startup.
+    touch_activity()
 
     # Launch the idle watcher. If COGNEE_IDLE_DISABLED is set, skip it.
     if os.environ.get("COGNEE_IDLE_DISABLED", "").lower() not in ("1", "true", "yes"):

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -27,9 +27,11 @@ from _plugin_common import touch_activity
 from config import (
     ensure_cognee_ready,
     ensure_dataset_ready,
+    ensure_dataset_ready_via_api,
     ensure_identity,
     get_dataset,
     get_session_id,
+    is_cloud_mode,
     load_config,
     save_config,
 )
@@ -144,7 +146,13 @@ async def _start(out_stream=None):
         print(f"cognee-plugin: identity warning ({e})", file=sys.stderr)
 
     try:
-        if user_id:
+        if user_id and is_cloud_mode(config):
+            await ensure_dataset_ready_via_api(
+                config.get("service_url", ""),
+                agent_api_key or config.get("api_key", ""),
+                dataset,
+            )
+        elif user_id:
             from uuid import UUID
 
             from cognee.modules.users.methods import get_user

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -80,8 +80,6 @@ def _spawn_idle_watcher(session_id: str, dataset: str, config: dict) -> None:
         "dataset": dataset,
         "config": {
             "service_url": config.get("service_url", ""),
-            "api_key": config.get("api_key", ""),
-            "llm_api_key": config.get("llm_api_key", ""),
             "llm_model": config.get("llm_model", ""),
             "dataset": dataset,
         },

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -29,7 +29,14 @@ from _plugin_common import (
     resolve_user,
     touch_activity,
 )
-from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
+from config import (
+    ensure_cognee_ready,
+    ensure_dataset_ready,
+    get_dataset,
+    get_session_id,
+    load_config,
+    persist_session_cache_to_graph,
+)
 
 # Hard cap per field to avoid ballooning the cache with massive tool outputs.
 _MAX_PARAMS_BYTES = 4000
@@ -41,9 +48,10 @@ async def _fire_improve_background(dataset: str, session_id: str, user, reason: 
     """Fire-and-forget improve() — intentionally detached from the caller.
 
     Prefers POST /api/v1/improve against a running backend (avoids the
-    Kuzu single-writer lock). Falls back to the SDK path with
-    ``run_in_background=True`` when no backend is reachable. Failures are
-    logged but never raised.
+    Kuzu single-writer lock). Falls back to the local SDK path in the
+    current process when no backend is reachable, so Cognee's session
+    persistence stages keep the resolved user/write-permission context.
+    Failures are logged but never raised.
     """
     from _plugin_common import improve_via_http  # type: ignore
 
@@ -58,6 +66,8 @@ async def _fire_improve_background(dataset: str, session_id: str, user, reason: 
     import cognee
 
     try:
+        await ensure_dataset_ready(dataset, user)
+        await persist_session_cache_to_graph(dataset, session_id, user)
         await cognee.improve(
             dataset=dataset,
             session_ids=[session_id],
@@ -166,6 +176,7 @@ async def _store_tool_call(payload: dict) -> None:
             entry,
             dataset_name=dataset,
             session_id=session_id,
+            self_improvement=False,
             user=user,
         )
     except Exception as exc:
@@ -223,6 +234,7 @@ async def _store_assistant_stop(payload: dict) -> None:
             entry,
             dataset_name=dataset,
             session_id=session_id,
+            self_improvement=False,
             user=user,
         )
     except Exception as exc:

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -21,11 +21,14 @@ import sys
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
+    append_http_bridge_entry,
     bump_save_counter,
     bump_turn_counter,
     hook_log,
     load_resolved,
     notify,
+    persist_session_cache_to_graph_via_http,
+    remember_entry_via_http,
     resolve_user,
     touch_activity,
 )
@@ -34,6 +37,7 @@ from config import (
     ensure_dataset_ready,
     get_dataset,
     get_session_id,
+    is_cloud_mode,
     load_config,
     persist_session_cache_to_graph,
     sync_graph_context_to_session,
@@ -48,6 +52,16 @@ _MAX_ASSISTANT_BYTES = 8000
 async def _fire_improve_background(dataset: str, session_id: str, user, reason: str) -> None:
     """Fire-and-forget session bridge; failures are logged but never raised."""
     try:
+        if is_cloud_mode(load_config()):
+            wrote = persist_session_cache_to_graph_via_http(dataset, session_id)
+            hook_log(
+                "auto_bridge_fired",
+                {"reason": reason, "session": session_id, "via": "http_remember", "wrote": wrote},
+            )
+            if wrote:
+                notify(f"session bridge persisted ({reason})")
+            return
+
         await ensure_dataset_ready(dataset, user)
         wrote = await persist_session_cache_to_graph(dataset, session_id, user)
         graph_result = await sync_graph_context_to_session(dataset, session_id, user)
@@ -105,9 +119,6 @@ def _load_session() -> tuple[str, str, str]:
 
 async def _store_tool_call(payload: dict) -> None:
     """Write a PostToolUse event as a TraceEntry."""
-    import cognee
-    from cognee.memory import TraceEntry
-
     tool_name = payload.get("tool_name", "unknown")
     tool_input = payload.get("tool_input") or {}
     tool_output = payload.get("tool_output") or payload.get("tool_response") or ""
@@ -142,43 +153,67 @@ async def _store_tool_call(payload: dict) -> None:
 
     config = load_config()
     await ensure_cognee_ready(config)
-    user = await resolve_user(user_id)
 
-    entry = TraceEntry(
-        origin_function=tool_name,
-        status=status,
-        method_params=params,
-        method_return_value=return_value,
-        error_message=error_message,
+    entry = {
+        "type": "trace",
+        "origin_function": tool_name,
+        "status": status,
+        "method_params": params,
+        "method_return_value": return_value,
+        "error_message": error_message,
         # LLM-backed feedback per step is expensive on a busy session —
         # fall back to the deterministic one-liner. Users who want the
         # LLM summary can flip this in a future config.
-        generate_feedback_with_llm=False,
-    )
+        "generate_feedback_with_llm": False,
+    }
 
     try:
-        result = await cognee.remember(
-            entry,
-            dataset_name=dataset,
-            session_id=session_id,
-            self_improvement=False,
-            user=user,
-        )
+        if is_cloud_mode(config):
+            result = remember_entry_via_http(dataset, session_id, entry)
+            user = None
+        else:
+            import cognee
+            from cognee.memory import TraceEntry
+
+            user = await resolve_user(user_id)
+            result = await cognee.remember(
+                TraceEntry(**entry),
+                dataset_name=dataset,
+                session_id=session_id,
+                self_improvement=False,
+                user=user,
+            )
     except Exception as exc:
         hook_log("trace_store_error", {"tool": tool_name, "error": str(exc)[:200]})
         notify(f"trace store failed ({exc})")
         return
 
     if result:
+        trace_id = (
+            result.get("entry_id")
+            if isinstance(result, dict)
+            else getattr(result, "entry_id", None)
+        )
         hook_log(
             "trace_stored",
             {
                 "tool": tool_name,
                 "status": status,
-                "trace_id": getattr(result, "entry_id", None),
+                "trace_id": trace_id,
             },
         )
         notify(f"trace stored ({tool_name}, {status})")
+        if is_cloud_mode(config):
+            trace_text = (
+                f"{tool_name} [{status}]\n"
+                f"Params: {json.dumps(params, ensure_ascii=False)}\n"
+                f"Return: {return_value}"
+            )
+            append_http_bridge_entry(
+                dataset,
+                session_id,
+                trace=trace_text,
+            )
         bump_save_counter(session_id, "trace")
 
         touch_activity()
@@ -191,9 +226,6 @@ async def _store_tool_call(payload: dict) -> None:
 
 async def _store_assistant_stop(payload: dict) -> None:
     """Write a Stop-hook payload (final assistant message) as a QAEntry."""
-    import cognee
-    from cognee.memory import QAEntry
-
     msg = str(payload.get("assistant_message") or payload.get("last_assistant_message") or "")
     if not msg or msg == "null":
         return
@@ -207,28 +239,42 @@ async def _store_assistant_stop(payload: dict) -> None:
 
     config = load_config()
     await ensure_cognee_ready(config)
-    user = await resolve_user(user_id)
 
     # Answer-only QAEntry: we don't have the matching question at Stop
     # time. Leaving question="" keeps the entry searchable by the
     # assistant message text.
-    entry = QAEntry(question="", answer=msg, context="")
+    entry = {"type": "qa", "question": "", "answer": msg, "context": ""}
 
     try:
-        result = await cognee.remember(
-            entry,
-            dataset_name=dataset,
-            session_id=session_id,
-            self_improvement=False,
-            user=user,
-        )
+        if is_cloud_mode(config):
+            result = remember_entry_via_http(dataset, session_id, entry)
+            user = None
+        else:
+            import cognee
+            from cognee.memory import QAEntry
+
+            user = await resolve_user(user_id)
+            result = await cognee.remember(
+                QAEntry(**entry),
+                dataset_name=dataset,
+                session_id=session_id,
+                self_improvement=False,
+                user=user,
+            )
     except Exception as exc:
         hook_log("stop_store_error", {"error": str(exc)[:200]})
         notify(f"stop store failed ({exc})")
         return
 
     if result:
-        hook_log("stop_stored", {"chars": len(msg), "qa_id": getattr(result, "entry_id", None)})
+        if is_cloud_mode(config):
+            append_http_bridge_entry(dataset, session_id, answer=msg)
+        qa_id = (
+            result.get("entry_id")
+            if isinstance(result, dict)
+            else getattr(result, "entry_id", None)
+        )
+        hook_log("stop_stored", {"chars": len(msg), "qa_id": qa_id})
         notify(f"assistant message stored ({len(msg)} chars)")
         bump_save_counter(session_id, "answer")
 

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -36,6 +36,7 @@ from config import (
     get_session_id,
     load_config,
     persist_session_cache_to_graph,
+    sync_graph_context_to_session,
 )
 
 # Hard cap per field to avoid ballooning the cache with massive tool outputs.
@@ -45,39 +46,23 @@ _MAX_ASSISTANT_BYTES = 8000
 
 
 async def _fire_improve_background(dataset: str, session_id: str, user, reason: str) -> None:
-    """Fire-and-forget improve() — intentionally detached from the caller.
-
-    Prefers POST /api/v1/improve against a running backend (avoids the
-    Kuzu single-writer lock). Falls back to the local SDK path in the
-    current process when no backend is reachable, so Cognee's session
-    persistence stages keep the resolved user/write-permission context.
-    Failures are logged but never raised.
-    """
-    from _plugin_common import improve_via_http  # type: ignore
-
-    try:
-        if improve_via_http(dataset, session_id, run_in_background=True):
-            hook_log("auto_improve_fired", {"reason": reason, "session": session_id, "via": "http"})
-            notify(f"auto-improve fired via HTTP ({reason})")
-            return
-    except Exception as exc:
-        hook_log("auto_improve_http_error", {"reason": reason, "error": str(exc)[:200]})
-
-    import cognee
-
+    """Fire-and-forget session bridge; failures are logged but never raised."""
     try:
         await ensure_dataset_ready(dataset, user)
-        await persist_session_cache_to_graph(dataset, session_id, user)
-        await cognee.improve(
-            dataset=dataset,
-            session_ids=[session_id],
-            user=user,
-            run_in_background=True,
+        wrote = await persist_session_cache_to_graph(dataset, session_id, user)
+        graph_result = await sync_graph_context_to_session(dataset, session_id, user)
+        hook_log(
+            "auto_bridge_fired",
+            {
+                "reason": reason,
+                "session": session_id,
+                "wrote": wrote,
+                "graph_synced": graph_result.get("synced", 0),
+            },
         )
-        hook_log("auto_improve_fired", {"reason": reason, "session": session_id, "via": "sdk"})
-        notify(f"auto-improve fired ({reason})")
+        notify(f"session bridge persisted ({reason})")
     except Exception as exc:
-        hook_log("auto_improve_error", {"reason": reason, "error": str(exc)[:200]})
+        hook_log("auto_bridge_error", {"reason": reason, "error": str(exc)[:200]})
 
 
 def _truncate_str(value, cap: int) -> str:

--- a/integrations/claude-code/scripts/store-user-prompt.py
+++ b/integrations/claude-code/scripts/store-user-prompt.py
@@ -63,6 +63,7 @@ async def _store(prompt: str):
             entry,
             dataset_name=dataset,
             session_id=session_id,
+            self_improvement=False,
             user=user,
         )
     except Exception as exc:

--- a/integrations/claude-code/scripts/store-user-prompt.py
+++ b/integrations/claude-code/scripts/store-user-prompt.py
@@ -18,14 +18,16 @@ from pathlib import Path
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
+    append_http_bridge_entry,
     bump_save_counter,
     hook_log,
     load_resolved,
     notify,
+    remember_entry_via_http,
     resolve_user,
     touch_activity,
 )
-from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
+from config import ensure_cognee_ready, get_dataset, get_session_id, is_cloud_mode, load_config
 
 MAX_TEXT = 4000
 _WATCHER_PID = Path.home() / ".cognee-plugin" / "watcher.pid"
@@ -101,9 +103,6 @@ def _ensure_idle_watcher(session_id: str, dataset: str, config: dict) -> None:
 
 
 async def _store(prompt: str):
-    import cognee
-    from cognee.memory import QAEntry
-
     session_id, dataset, user_id = _load_session()
     if not session_id:
         hook_log("no_session_id", {"event": "prompt"})
@@ -114,30 +113,41 @@ async def _store(prompt: str):
     _ensure_idle_watcher(session_id, dataset, config)
 
     await ensure_cognee_ready(config)
-    user = await resolve_user(user_id)
 
     # Question-only QAEntry: the answer fills in on the Stop hook as
     # a separate entry. Keeping the prompt in the `question` field
     # lets recall's tokenizer search it naturally.
-    entry = QAEntry(question=prompt[:MAX_TEXT], answer="", context="")
+    entry = {"type": "qa", "question": prompt[:MAX_TEXT], "answer": "", "context": ""}
 
     try:
-        result = await cognee.remember(
-            entry,
-            dataset_name=dataset,
-            session_id=session_id,
-            self_improvement=False,
-            user=user,
-        )
+        if is_cloud_mode(config):
+            result = remember_entry_via_http(dataset, session_id, entry)
+        else:
+            import cognee
+            from cognee.memory import QAEntry
+
+            user = await resolve_user(user_id)
+            result = await cognee.remember(
+                QAEntry(**entry),
+                dataset_name=dataset,
+                session_id=session_id,
+                self_improvement=False,
+                user=user,
+            )
     except Exception as exc:
         hook_log("prompt_store_error", {"error": str(exc)[:200]})
         notify(f"prompt store failed ({exc})")
         return
 
     if result:
-        hook_log(
-            "prompt_stored", {"chars": len(prompt), "qa_id": getattr(result, "entry_id", None)}
+        if is_cloud_mode(config):
+            append_http_bridge_entry(dataset, session_id, question=prompt[:MAX_TEXT])
+        qa_id = (
+            result.get("entry_id")
+            if isinstance(result, dict)
+            else getattr(result, "entry_id", None)
         )
+        hook_log("prompt_stored", {"chars": len(prompt), "qa_id": qa_id})
         notify(f"user prompt stored ({len(prompt)} chars)")
         bump_save_counter(session_id, "prompt")
 

--- a/integrations/claude-code/scripts/store-user-prompt.py
+++ b/integrations/claude-code/scripts/store-user-prompt.py
@@ -11,7 +11,9 @@ Configuration:
 import asyncio
 import json
 import os
+import subprocess
 import sys
+from pathlib import Path
 
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
@@ -26,6 +28,9 @@ from _plugin_common import (
 from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
 
 MAX_TEXT = 4000
+_WATCHER_PID = Path.home() / ".cognee-plugin" / "watcher.pid"
+_WATCHER_STOP = Path.home() / ".cognee-plugin" / "watcher.stop"
+_WATCHER_SCRIPT = Path(__file__).with_name("idle-watcher.py")
 
 
 def _load_session() -> tuple[str, str, str]:
@@ -40,6 +45,61 @@ def _load_session() -> tuple[str, str, str]:
     return session_id, dataset, user_id
 
 
+def _watcher_alive() -> bool:
+    if not _WATCHER_PID.exists():
+        return False
+    try:
+        pid = int(_WATCHER_PID.read_text(encoding="utf-8").strip())
+        os.kill(pid, 0)
+        return True
+    except Exception:
+        return False
+
+
+def _ensure_idle_watcher(session_id: str, dataset: str, config: dict) -> None:
+    """Start the idle watcher on a new prompt if the prior one exited after bridging."""
+    if os.environ.get("COGNEE_IDLE_DISABLED", "").lower() in ("1", "true", "yes"):
+        return
+    if not session_id or _watcher_alive():
+        return
+
+    try:
+        if _WATCHER_STOP.exists():
+            _WATCHER_STOP.unlink()
+    except Exception:
+        pass
+
+    bootstrap = {
+        "session_id": session_id,
+        "dataset": dataset,
+        "config": {
+            "service_url": config.get("service_url", ""),
+            "llm_model": config.get("llm_model", ""),
+            "dataset": dataset,
+        },
+    }
+
+    log_path = Path.home() / ".cognee-plugin" / "watcher.log"
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_fh = log_path.open("a", encoding="utf-8")
+    except Exception:
+        log_fh = subprocess.DEVNULL
+
+    try:
+        subprocess.Popen(
+            [sys.executable, str(_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            start_new_session=True,
+            close_fds=True,
+        )
+        hook_log("idle_watcher_restarted", {"session": session_id, "dataset": dataset})
+    except Exception as exc:
+        hook_log("idle_watcher_restart_failed", {"error": str(exc)[:200]})
+
+
 async def _store(prompt: str):
     import cognee
     from cognee.memory import QAEntry
@@ -50,6 +110,9 @@ async def _store(prompt: str):
         return
 
     config = load_config()
+    touch_activity()
+    _ensure_idle_watcher(session_id, dataset, config)
+
     await ensure_cognee_ready(config)
     user = await resolve_user(user_id)
 
@@ -77,7 +140,6 @@ async def _store(prompt: str):
         )
         notify(f"user prompt stored ({len(prompt)} chars)")
         bump_save_counter(session_id, "prompt")
-        touch_activity()
 
 
 def main():

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -22,17 +22,26 @@ import asyncio
 import json
 import os
 import signal
+import subprocess
 import sys
 from pathlib import Path
 
 # Add scripts dir to path for config/_plugin_common imports
 sys.path.insert(0, os.path.dirname(__file__))
-from _plugin_common import improve_via_http
-from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
+from _plugin_common import hook_log, improve_via_http, sync_lock
+from config import (
+    ensure_cognee_ready,
+    ensure_dataset_ready,
+    get_dataset,
+    get_session_id,
+    load_config,
+    persist_session_cache_to_graph,
+)
 
 _RESOLVED_CACHE = Path.home() / ".cognee-plugin" / "resolved.json"
 _WATCHER_PID = Path.home() / ".cognee-plugin" / "watcher.pid"
 _WATCHER_STOP = Path.home() / ".cognee-plugin" / "watcher.stop"
+_DETACHED_ARG = "--detached-final"
 
 
 def _stop_idle_watcher() -> None:
@@ -53,6 +62,51 @@ def _stop_idle_watcher() -> None:
             os.kill(pid, signal.SIGTERM)
         except Exception:
             pass
+
+
+def _spawn_detached_sync() -> bool:
+    """Run the expensive sync outside Claude's short SessionEnd hook window."""
+    try:
+        subprocess.Popen(
+            [sys.executable, str(Path(__file__).resolve()), _DETACHED_ARG],
+            cwd=os.getcwd(),
+            env=os.environ.copy(),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        return True
+    except Exception as exc:
+        hook_log("sync_detach_failed", {"error": str(exc)[:300]})
+        return False
+
+
+def _is_session_end_payload(payload_raw: str) -> bool:
+    """Return True only for an actual Claude Code SessionEnd hook payload."""
+    if not payload_raw.strip():
+        return False
+    try:
+        payload = json.loads(payload_raw)
+    except json.JSONDecodeError:
+        return False
+
+    def _contains_session_end(value) -> bool:
+        if isinstance(value, dict):
+            return any(_contains_session_end(item) for item in value.values())
+        if isinstance(value, list):
+            return any(_contains_session_end(item) for item in value)
+        if isinstance(value, str):
+            return value == "SessionEnd" or value.endswith(".SessionEnd")
+        return False
+
+    event = (
+        payload.get("hook_event_name")
+        or payload.get("hookEventName")
+        or payload.get("event")
+        or payload.get("hook")
+    )
+    return event == "SessionEnd" or _contains_session_end(payload)
 
 
 def _load_resolved() -> tuple:
@@ -85,52 +139,85 @@ async def _resolve_user(user_id: str):
     return await get_default_user()
 
 
-async def _sync():
+async def _sync(stop_watcher: bool):
     import cognee
 
     session_id, dataset, user_id = _load_resolved()
-
-    # Prefer the running backend to avoid the Kuzu single-writer lock.
-    if improve_via_http(dataset, session_id, run_in_background=True):
-        print(
-            f"cognee-sync: via HTTP dataset={dataset} session={session_id}",
-            file=sys.stderr,
-        )
-        return
-
-    # Fallback: no backend running → run improve() locally via the SDK.
-    config = load_config()
-    await ensure_cognee_ready(config)
-    user = await _resolve_user(user_id)
-
-    result = await cognee.improve(
-        dataset=dataset,
-        session_ids=[session_id],
-        run_in_background=True,
-        user=user,
+    hook_log(
+        "sync_start",
+        {"session": session_id, "dataset": dataset, "stop_watcher": stop_watcher},
     )
 
-    # Log summary to stderr (visible in hook output, not in Claude's context)
-    if result and isinstance(result, dict):
-        for ds_id, run_info in result.items():
-            status = getattr(run_info, "status", "unknown")
-            print(f"cognee-sync: dataset={ds_id} status={status}", file=sys.stderr)
-    else:
-        print(f"cognee-sync: dataset={dataset} session={session_id} completed", file=sys.stderr)
+    with sync_lock("sync-session-to-graph") as acquired:
+        if not acquired:
+            hook_log("sync_skipped_lock_busy", {"session": session_id, "dataset": dataset})
+            print("cognee-sync: skipped, another sync is running", file=sys.stderr)
+            return
+
+        if stop_watcher:
+            _stop_idle_watcher()
+            hook_log("sync_stopped_watcher", {"session": session_id, "dataset": dataset})
+
+        # Prefer the running backend to avoid the Kuzu single-writer lock.
+        if improve_via_http(dataset, session_id, run_in_background=False):
+            hook_log("sync_http_done", {"session": session_id, "dataset": dataset})
+            print(
+                f"cognee-sync: via HTTP dataset={dataset} session={session_id}",
+                file=sys.stderr,
+            )
+            return
+
+        # Fallback: no backend running → run improve() locally via the SDK.
+        config = load_config()
+        await ensure_cognee_ready(config)
+        user = await _resolve_user(user_id)
+        await ensure_dataset_ready(dataset, user)
+        await persist_session_cache_to_graph(dataset, session_id, user)
+
+        result = await cognee.improve(
+            dataset=dataset,
+            session_ids=[session_id],
+            run_in_background=False,
+            user=user,
+        )
+
+        hook_log("sync_sdk_done", {"session": session_id, "dataset": dataset})
+        # Log summary to stderr (visible in hook output, not in Claude's context)
+        if result and isinstance(result, dict):
+            for ds_id, run_info in result.items():
+                status = getattr(run_info, "status", "unknown")
+                print(f"cognee-sync: dataset={ds_id} status={status}", file=sys.stderr)
+        else:
+            print(f"cognee-sync: dataset={dataset} session={session_id} completed", file=sys.stderr)
 
 
 def main():
-    # Read stdin (SessionEnd payload) but we only use config for IDs
-    sys.stdin.read()
+    detached_final = _DETACHED_ARG in sys.argv
+    payload_raw = "" if detached_final else sys.stdin.read()
+    is_session_end = _is_session_end_payload(payload_raw)
+    hook_log(
+        "sync_payload",
+        {
+            "is_session_end": is_session_end,
+            "detached_final": detached_final,
+            "payload_preview": payload_raw[:200],
+        },
+    )
 
-    # Stop the idle watcher first — we're about to run a blocking
-    # improve() ourselves and don't want a racing one from the watcher.
-    _stop_idle_watcher()
+    # Only a true SessionEnd should stop the watcher. Manual syncs and
+    # slash-command invocations happen mid-session, and killing the watcher
+    # there prevents later idle persistence.
+    if is_session_end:
+        spawned = _spawn_detached_sync()
+        _stop_idle_watcher()
+        hook_log("sync_deferred_to_shutdown_worker", {"spawned": spawned})
+        return
 
     try:
-        asyncio.run(_sync())
+        asyncio.run(_sync(stop_watcher=False))
     except Exception as exc:
         # Non-fatal: session sync failure should not crash Claude Code
+        hook_log("sync_failed", {"error": str(exc)[:300]})
         print(f"cognee-sync: failed ({exc})", file=sys.stderr)
 
 

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -1,17 +1,9 @@
 #!/usr/bin/env python3
 """Bridge session cache entries into the permanent knowledge graph on session end.
 
-Calls cognee.improve(session_ids=[...]) to run:
-  1. Apply feedback weights from session scores
-  2. Persist session Q&A into the permanent graph
-  3. Default enrichment (triplet embeddings)
-  4. Sync graph knowledge back into session cache
-
-Execution path:
-    1. If a local backend is running (COGNEE_LOCAL_API_URL or
-       http://localhost:8000), POST to /api/v1/improve so the server
-       — which holds the Kuzu single-writer lock — runs the pipeline.
-    2. Otherwise, fall back to direct cognee.improve() SDK call.
+Runs the integration's explicit session bridge:
+  1. Persist session Q&A/trace cache into the permanent graph
+  2. Sync graph knowledge back into the session cache for recall
 
 Configuration:
     Uses resolved session ID and dataset from SessionStart hook
@@ -28,7 +20,7 @@ from pathlib import Path
 
 # Add scripts dir to path for config/_plugin_common imports
 sys.path.insert(0, os.path.dirname(__file__))
-from _plugin_common import hook_log, improve_via_http, sync_lock
+from _plugin_common import hook_log, sync_lock
 from config import (
     ensure_cognee_ready,
     ensure_dataset_ready,
@@ -36,6 +28,7 @@ from config import (
     get_session_id,
     load_config,
     persist_session_cache_to_graph,
+    sync_graph_context_to_session,
 )
 
 _RESOLVED_CACHE = Path.home() / ".cognee-plugin" / "resolved.json"
@@ -140,8 +133,6 @@ async def _resolve_user(user_id: str):
 
 
 async def _sync(stop_watcher: bool):
-    import cognee
-
     session_id, dataset, user_id = _load_resolved()
     hook_log(
         "sync_start",
@@ -158,37 +149,28 @@ async def _sync(stop_watcher: bool):
             _stop_idle_watcher()
             hook_log("sync_stopped_watcher", {"session": session_id, "dataset": dataset})
 
-        # Prefer the running backend to avoid the Kuzu single-writer lock.
-        if improve_via_http(dataset, session_id, run_in_background=False):
-            hook_log("sync_http_done", {"session": session_id, "dataset": dataset})
-            print(
-                f"cognee-sync: via HTTP dataset={dataset} session={session_id}",
-                file=sys.stderr,
-            )
-            return
-
-        # Fallback: no backend running → run improve() locally via the SDK.
         config = load_config()
         await ensure_cognee_ready(config)
         user = await _resolve_user(user_id)
         await ensure_dataset_ready(dataset, user)
-        await persist_session_cache_to_graph(dataset, session_id, user)
+        wrote = await persist_session_cache_to_graph(dataset, session_id, user)
+        graph_result = await sync_graph_context_to_session(dataset, session_id, user)
 
-        result = await cognee.improve(
-            dataset=dataset,
-            session_ids=[session_id],
-            run_in_background=False,
-            user=user,
+        hook_log(
+            "sync_bridge_done",
+            {
+                "session": session_id,
+                "dataset": dataset,
+                "wrote": wrote,
+                "graph_synced": graph_result.get("synced", 0),
+            },
         )
-
-        hook_log("sync_sdk_done", {"session": session_id, "dataset": dataset})
-        # Log summary to stderr (visible in hook output, not in Claude's context)
-        if result and isinstance(result, dict):
-            for ds_id, run_info in result.items():
-                status = getattr(run_info, "status", "unknown")
-                print(f"cognee-sync: dataset={ds_id} status={status}", file=sys.stderr)
-        else:
-            print(f"cognee-sync: dataset={dataset} session={session_id} completed", file=sys.stderr)
+        print(
+            "cognee-sync: "
+            f"dataset={dataset} session={session_id} wrote={wrote} "
+            f"graph_synced={graph_result.get('synced', 0)}",
+            file=sys.stderr,
+        )
 
 
 def main():

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -20,12 +20,13 @@ from pathlib import Path
 
 # Add scripts dir to path for config/_plugin_common imports
 sys.path.insert(0, os.path.dirname(__file__))
-from _plugin_common import hook_log, sync_lock
+from _plugin_common import hook_log, persist_session_cache_to_graph_via_http, sync_lock
 from config import (
     ensure_cognee_ready,
     ensure_dataset_ready,
     get_dataset,
     get_session_id,
+    is_cloud_mode,
     load_config,
     persist_session_cache_to_graph,
     sync_graph_context_to_session,
@@ -150,6 +151,19 @@ async def _sync(stop_watcher: bool):
             hook_log("sync_stopped_watcher", {"session": session_id, "dataset": dataset})
 
         config = load_config()
+        if is_cloud_mode(config):
+            wrote = persist_session_cache_to_graph_via_http(dataset, session_id)
+            hook_log(
+                "sync_bridge_done",
+                {"session": session_id, "dataset": dataset, "via": "http_remember", "wrote": wrote},
+            )
+            print(
+                "cognee-sync: "
+                f"dataset={dataset} session={session_id} via=http_remember wrote={wrote}",
+                file=sys.stderr,
+            )
+            return
+
         await ensure_cognee_ready(config)
         user = await _resolve_user(user_id)
         await ensure_dataset_ready(dataset, user)


### PR DESCRIPTION
**Summary**
This PR reworks the Claude Code Cognee integration hooks to make session persistence more reliable across both local SDK mode and API mode, reduce duplicate graph writes, and avoid idle watcher lock contention.

**Changes**

- Replace direct/full cognee.improve(session_ids=[...]) calls with an explicit session bridge:
- persist session cache into the graph
- sync graph context back into the session for recall
- Ensure dataset creation and ACL readiness before session graph writes.
- Add idempotency for session-cache-to-graph persistence using ~/.cognee-plugin/bridge_state.json.
- Add a cross-hook sync lock to prevent watcher, SessionEnd, and manual sync from racing.
- Update idle watcher lifecycle:
- exits after a successful idle bridge to release graph DB handles
- restarts on the next user prompt if needed
- Remove API/LLM secrets from idle watcher process arguments.
- Improve recall filtering to avoid injecting empty recall entries.
- Run SessionEnd sync through a detached final worker, while only true SessionEnd stops the watcher.
- Fix API mode so hooks use backend HTTP endpoints instead of accidentally relying on local SDK/database state.
- Add API-mode dataset readiness via POST /api/v1/datasets using the authenticated agent API key.
- Add authenticated API headers for backend persistence/recall calls.
- Add an API-mode graph bridge that mirrors the working local bridge:
- prompt/answer session text is cached locally as a small hook-side shadow
- session QA is uploaded to /api/v1/remember as user_sessions_from_cache.txt
- trace feedback is uploaded to /api/v1/remember as agent_trace_feedbacks.txt
- bridge uploads are idempotent via ~/.cognee-plugin/http_bridge_state.json
- Keep local non-API mode on the existing SDK path, including self_improvement=False.
- Avoid API-mode user resolution through local Cognee databases where possible, preventing backend mode from touching the wrong local DB.
- Validate API-mode recall returns session and graph context after bridge persistence.