### PR TITLE
fix(cognee-openclaw): per-agent runtime agentId + agentDatasetTemplate

### DIFF
--- a/integrations/openclaw/__tests__/test_syncFiles.ts
+++ b/integrations/openclaw/__tests__/test_syncFiles.ts
@@ -54,6 +54,7 @@ function baseCfg(overrides: Partial<CogneePluginConfig> = {}): Required<CogneePl
     companyDataset: "",
     userDatasetPrefix: "",
     agentDatasetPrefix: "",
+    agentDatasetTemplate: "",
     userId: "",
     agentId: "default",
     recallScopes: ["agent", "user", "company"] as MemoryScope[],
@@ -189,6 +190,42 @@ describe("datasetNameForScope", () => {
   it("uses agentDatasetPrefix with agentId", () => {
     expect(datasetNameForScope("agent", baseCfg({ agentDatasetPrefix: "proj-agent", agentId: "coder" }))).toBe("proj-agent-coder");
   });
+
+  it("prefers runtimeAgentId over cfg.agentId for the agent scope", () => {
+    const cfg = baseCfg({ agentDatasetPrefix: "proj-agent", agentId: "default" });
+    expect(datasetNameForScope("agent", cfg, "ebay")).toBe("proj-agent-ebay");
+    expect(datasetNameForScope("agent", cfg, "research")).toBe("proj-agent-research");
+  });
+
+  it("falls back to cfg.agentId when runtimeAgentId is empty or whitespace", () => {
+    const cfg = baseCfg({ agentDatasetPrefix: "proj-agent", agentId: "static" });
+    expect(datasetNameForScope("agent", cfg, "")).toBe("proj-agent-static");
+    expect(datasetNameForScope("agent", cfg, "   ")).toBe("proj-agent-static");
+    expect(datasetNameForScope("agent", cfg, undefined)).toBe("proj-agent-static");
+  });
+
+  it("ignores runtimeAgentId for non-agent scopes", () => {
+    const cfg = baseCfg({ companyDataset: "shared", userDatasetPrefix: "u", userId: "alice" });
+    expect(datasetNameForScope("company", cfg, "ebay")).toBe("shared");
+    expect(datasetNameForScope("user", cfg, "ebay")).toBe("u-alice");
+  });
+
+  it("agentDatasetTemplate substitutes {agentId} and overrides agentDatasetPrefix", () => {
+    const cfg = baseCfg({ agentDatasetTemplate: "{agentId}", agentDatasetPrefix: "ignored", agentId: "default" });
+    expect(datasetNameForScope("agent", cfg, "ebay")).toBe("ebay");
+    expect(datasetNameForScope("agent", cfg, "research")).toBe("research");
+  });
+
+  it("agentDatasetTemplate supports prefixed templates", () => {
+    const cfg = baseCfg({ agentDatasetTemplate: "memory-{agentId}-prod", agentId: "default" });
+    expect(datasetNameForScope("agent", cfg, "ebay")).toBe("memory-ebay-prod");
+  });
+
+  it("agentDatasetTemplate falls back to cfg.agentId when runtimeAgentId is absent", () => {
+    const cfg = baseCfg({ agentDatasetTemplate: "ds-{agentId}", agentId: "static" });
+    expect(datasetNameForScope("agent", cfg)).toBe("ds-static");
+    expect(datasetNameForScope("agent", cfg, "")).toBe("ds-static");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -207,6 +244,9 @@ describe("isMultiScopeEnabled", () => {
   });
   it("returns true when agentDatasetPrefix is set", () => {
     expect(isMultiScopeEnabled(baseCfg({ agentDatasetPrefix: "proj-agent" }))).toBe(true);
+  });
+  it("returns true when agentDatasetTemplate is set", () => {
+    expect(isMultiScopeEnabled(baseCfg({ agentDatasetTemplate: "{agentId}" }))).toBe(true);
   });
 });
 

--- a/integrations/openclaw/openclaw.plugin.json
+++ b/integrations/openclaw/openclaw.plugin.json
@@ -46,6 +46,10 @@
         "type": "string",
         "description": "Prefix for agent-scoped datasets (becomes '{prefix}-{agentId}'). Setting this enables multi-scope mode."
       },
+      "agentDatasetTemplate": {
+        "type": "string",
+        "description": "Template for the per-agent dataset name with '{agentId}' placeholder (e.g. '{agentId}' for bare id, 'memory-{agentId}' for prefixed). Takes precedence over agentDatasetPrefix when set. Enables multi-scope mode."
+      },
       "userId": {
         "type": "string",
         "description": "User identifier for user-scoped memory (or set OPENCLAW_USER_ID env var)"

--- a/integrations/openclaw/src/config.ts
+++ b/integrations/openclaw/src/config.ts
@@ -85,6 +85,7 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
   const companyDataset = raw.companyDataset?.trim() || "";
   const userDatasetPrefix = raw.userDatasetPrefix?.trim() || "";
   const agentDatasetPrefix = raw.agentDatasetPrefix?.trim() || "";
+  const agentDatasetTemplate = raw.agentDatasetTemplate?.trim() || "";
   const userId = raw.userId?.trim() || process.env.OPENCLAW_USER_ID || "";
   const agentId = raw.agentId?.trim() || process.env.OPENCLAW_AGENT_ID || "default";
   const recallScopes = Array.isArray(raw.recallScopes) ? raw.recallScopes : DEFAULT_RECALL_SCOPES;
@@ -103,7 +104,7 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
 
   return {
     mode, baseUrl, apiKey, username, password, datasetName,
-    companyDataset, userDatasetPrefix, agentDatasetPrefix, userId, agentId,
+    companyDataset, userDatasetPrefix, agentDatasetPrefix, agentDatasetTemplate, userId, agentId,
     recallScopes, defaultWriteScope, scopeRouting,
     recallInjectionPosition,
     enableSessions, persistSessionsAfterEnd,

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -92,14 +92,16 @@ const memoryCogneePlugin = {
     ]);
 
     // Fix #8: Log when scopes have no dataset ID during recall
-    async function getRecallDatasetIds(): Promise<{ ids: string[]; missingScopes: string[] }> {
+    async function getRecallDatasetIds(
+      runtimeAgentId?: string,
+    ): Promise<{ ids: string[]; missingScopes: string[] }> {
       const state = await loadDatasetState();
       const ids: string[] = [];
       const missingScopes: string[] = [];
 
       if (multiScope) {
         for (const scope of cfg.recallScopes) {
-          const dsName = datasetNameForScope(scope, cfg);
+          const dsName = datasetNameForScope(scope, cfg, runtimeAgentId);
           const dsId = state[dsName] ?? scopedIndexes[scope]?.datasetId;
           if (dsId) {
             ids.push(dsId);
@@ -390,7 +392,7 @@ const memoryCogneePlugin = {
           return;
         }
 
-        const { ids: recallDatasetIds, missingScopes } = await getRecallDatasetIds();
+        const { ids: recallDatasetIds, missingScopes } = await getRecallDatasetIds(ctx.agentId);
 
         // Fix #8: Log missing scopes so users know what's not being searched
         if (missingScopes.length > 0) {
@@ -408,7 +410,7 @@ const memoryCogneePlugin = {
             const state = await loadDatasetState();
 
             const searchPromises = cfg.recallScopes.map(async (scope): Promise<{ scope: MemoryScope; results: CogneeSearchResult[] } | null> => {
-              const dsName = datasetNameForScope(scope, cfg);
+              const dsName = datasetNameForScope(scope, cfg, ctx.agentId);
               const dsId = state[dsName] ?? scopedIndexes[scope]?.datasetId;
               if (!dsId) return null;
 
@@ -516,7 +518,7 @@ const memoryCogneePlugin = {
             const targetDatasetIds: string[] = [];
             if (multiScope) {
               const state = await loadDatasetState();
-              const agentDsName = datasetNameForScope("agent", cfg);
+              const agentDsName = datasetNameForScope("agent", cfg, ctx.agentId);
               const agentDsId = state[agentDsName] ?? scopedIndexes.agent?.datasetId;
               if (agentDsId) targetDatasetIds.push(agentDsId);
             } else if (datasetId) {

--- a/integrations/openclaw/src/scope.ts
+++ b/integrations/openclaw/src/scope.ts
@@ -103,16 +103,25 @@ export function routeFileToScope(
 
 /**
  * Determine whether multi-scope mode is active.
- * Active when at least one scope-specific dataset prefix/name is configured.
+ * Active when at least one scope-specific dataset prefix/name/template is configured.
  */
 export function isMultiScopeEnabled(cfg: Required<CogneePluginConfig>): boolean {
-  return !!(cfg.companyDataset || cfg.userDatasetPrefix || cfg.agentDatasetPrefix);
+  return !!(cfg.companyDataset || cfg.userDatasetPrefix || cfg.agentDatasetPrefix || cfg.agentDatasetTemplate);
 }
 
 /**
  * Resolve the Cognee dataset name for a given memory scope.
+ *
+ * `runtimeAgentId` lets multi-agent gateways pass the active agent's identity
+ * (from PluginHookAgentContext.agentId) so the "agent" scope routes to the
+ * caller's dataset rather than the static plugin-config agentId. Falls back to
+ * cfg.agentId when runtimeAgentId is absent (CLI / background sync paths).
  */
-export function datasetNameForScope(scope: MemoryScope, cfg: Required<CogneePluginConfig>): string {
+export function datasetNameForScope(
+  scope: MemoryScope,
+  cfg: Required<CogneePluginConfig>,
+  runtimeAgentId?: string,
+): string {
   switch (scope) {
     case "company":
       return cfg.companyDataset || `${cfg.datasetName}-company`;
@@ -120,9 +129,14 @@ export function datasetNameForScope(scope: MemoryScope, cfg: Required<CogneePlug
       return cfg.userDatasetPrefix
         ? `${cfg.userDatasetPrefix}-${cfg.userId || "default"}`
         : `${cfg.datasetName}-user-${cfg.userId || "default"}`;
-    case "agent":
+    case "agent": {
+      const id = runtimeAgentId?.trim() || cfg.agentId || "default";
+      if (cfg.agentDatasetTemplate) {
+        return cfg.agentDatasetTemplate.replace(/\{agentId\}/g, id);
+      }
       return cfg.agentDatasetPrefix
-        ? `${cfg.agentDatasetPrefix}-${cfg.agentId || "default"}`
-        : `${cfg.datasetName}-agent-${cfg.agentId || "default"}`;
+        ? `${cfg.agentDatasetPrefix}-${id}`
+        : `${cfg.datasetName}-agent-${id}`;
+    }
   }
 }

--- a/integrations/openclaw/src/types.ts
+++ b/integrations/openclaw/src/types.ts
@@ -48,6 +48,16 @@ export type CogneePluginConfig = {
   companyDataset?: string;
   userDatasetPrefix?: string;
   agentDatasetPrefix?: string;
+  /**
+   * Template for the per-agent dataset name. Use `{agentId}` as the placeholder.
+   * Examples:
+   *   "{agentId}"               → bare agent id ("research", "ebay")
+   *   "memory-{agentId}"        → "memory-research"
+   * When set, takes precedence over `agentDatasetPrefix` and the legacy
+   * `${datasetName}-agent-{id}` fallback. Multi-agent gateways should set this
+   * to align with how their per-agent datasets are named in Cognee.
+   */
+  agentDatasetTemplate?: string;
   userId?: string;
   agentId?: string;
   recallScopes?: MemoryScope[];


### PR DESCRIPTION
## Summary

Phase-1 fix for #55 — per-agent recall isolation on multi-agent OpenClaw gateways. Threads the live agent's identity through `datasetNameForScope` via a new optional `runtimeAgentId` parameter, sourced from `PluginHookAgentContext.agentId` in the relevant hooks. Adds a new `agentDatasetTemplate` config field so operators can choose any per-agent naming pattern.

CLI commands and background-sync paths (no live agent context) keep the existing `cfg.agentId` fallback, so single-agent gateways are unaffected.

## Changes

- **`src/scope.ts`** — `datasetNameForScope(scope, cfg, runtimeAgentId?)`. `runtimeAgentId` is preferred over `cfg.agentId` for the `"agent"` scope. Adds `agentDatasetTemplate` (e.g. `"{agentId}"` or `"memory-{agentId}-prod"`) with precedence: template > prefix > legacy `${datasetName}-agent-${id}`. `isMultiScopeEnabled` also flips on `agentDatasetTemplate`.
- **`src/plugin.ts`** — `getRecallDatasetIds(runtimeAgentId?)` threads the id through. `before_prompt_build` hook and the `agent_end` session-persist branch now pass `ctx.agentId`. All other call sites (init log lines, CLI `cognee status` / `cognee scopes`, `runSync` / `runAutoSync` background paths) keep the static fallback — they have no per-call agent context.
- **`src/types.ts`** + **`src/config.ts`** — new `agentDatasetTemplate?: string` plumbed through with the same `?.trim() || ""` pattern used by the other multi-scope fields.
- **`openclaw.plugin.json`** — declares the new config field with description.
- **`__tests__/test_syncFiles.ts`** — 7 new cases (runtime override, fallback semantics when runtime id is empty/whitespace/undefined, template substitution with bare and prefixed forms, isMultiScopeEnabled with the new field, non-agent scope unaffected).

## Test plan

- [x] `npm install && npm run build && npm test` — 46/46 green, no diagnostic warnings beyond pre-existing.
- [x] Deployed to an 8-agent OpenClaw gateway (oc1, `main`/`coder`/`research`/`finance`/`social`/`training`/`ebay`/`tracker`). Configured `agentDatasetTemplate: "{agentId}"` to align with cognee dataset names already created by an external sync script.
- [x] Same prompt (`"what is the latest topic you indexed?"`) sent to `research` and `ebay`. Each surfaced its own workspace memory — research returned `memory/2026-05-08.md` (Cognee Memory Sync cron failure); ebay returned its own listings (Zooz ZEN55 LR, ULINE test, calculated-shipping rules). No cross-agent bleed.
- [x] Gateway logs: `cognee-openclaw: injecting N memories across 1 scope(s)` per turn, hitting the agent-specific dataset.

## Scope

Recall path + session-persist target dataset only. **autoIndex is intentionally out of scope** — the local `scopedSyncIndexes` map (in `persistence.ts`) is still keyed by scope (`"company"|"user"|"agent"`), not by `(scope, agentId)`. Enabling autoIndex on a multi-agent gateway with only this patch would cause hash collisions between identically-named files across agents' workspaces (e.g. every agent has its own `MEMORY.md`). Phase-2 patch in a follow-up: per-agent-key the scoped sync index plus a migration step for existing single-agent indexes.

## Compatibility

- Single-agent users see no behavior change. With no `agentDatasetTemplate` set and no `runtimeAgentId` passed (e.g. CLI), the function returns exactly what it returned before.
- `agentDatasetTemplate` is additive. When unset, the existing `agentDatasetPrefix` / `datasetName-agent-id` paths run unchanged.
- New parameter on `datasetNameForScope` is optional. Existing imports do not need to change.

Fixes #55
