### PR TITLE
feat: adds optional transcript clear on user message

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -154,6 +154,19 @@ The script reads three small JSON state files written by the plugin:
 
 Any missing piece is silently omitted, so the line stays short on idle turns.
 
+## Auto-clear demo hook
+
+For demos where each response should leave Claude with an empty transcript context, enable the Stop-hook clear path:
+
+```bash
+export COGNEE_CLAUDE_CLEAR_AFTER_MESSAGE=true
+claude --plugin-dir /path/to/cognee-integrations/integrations/claude-code
+```
+
+When enabled, the plugin's `Stop` hook empties Claude Code's `transcript_path` after each assistant response. Memory capture runs first, so the response can still be stored in Cognee before the local Claude context is deleted.
+
+This is a demo-only workaround. Claude Code hooks do not expose a supported action for executing built-in slash commands like `/clear`, so the hook clears the backing transcript file directly.
+
 ## Audit log
 
 The UserPromptSubmit hook also appends a JSONL entry per prompt to `~/.cognee-plugin/recall-audit.log`, recording the timestamp, session_id, prompt text, hit counts, and the full `additionalContext` injected into Claude's input. This is the source of truth for "what did the plugin give Claude on prompt X" — Claude Code does not persist hook `additionalContext` into its JSONL transcript.
@@ -173,6 +186,7 @@ tail -n 1 ~/.cognee-plugin/recall-audit.log | jq -r .context
 | `api_key` | `COGNEE_API_KEY` | -- | Cognee Cloud API key |
 | `llm_api_key` | `LLM_API_KEY` | -- | LLM provider key (local mode) |
 | `llm_model` | `LLM_MODEL` | -- | LLM model name (local mode) |
+| demo auto-clear | `COGNEE_CLAUDE_CLEAR_AFTER_MESSAGE` | disabled | When truthy, empties Claude transcript context after each assistant response |
 | `top_k` | -- | `5` | Results returned by automatic session search (per scope) |
 
 Config is resolved in order: env vars > `~/.cognee-plugin/config.json` > defaults.

--- a/integrations/claude-code/hooks/hooks.json
+++ b/integrations/claude-code/hooks/hooks.json
@@ -48,6 +48,12 @@
             "type": "command",
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/store-to-session.py --stop",
             "async": true
+          },
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/clear-transcript-context.py",
+            "timeout": 5,
+            "statusMessage": "Clearing Claude context..."
           }
         ]
       }

--- a/integrations/claude-code/scripts/clear-transcript-context.py
+++ b/integrations/claude-code/scripts/clear-transcript-context.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Clear Claude Code transcript context after each assistant response.
+
+Claude Code hooks cannot execute the built-in /clear command directly. This
+Stop hook is the integration-level demo workaround: when enabled, it empties
+the transcript file Claude passes in the hook payload.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ENV_NAME = "COGNEE_CLAUDE_CLEAR_AFTER_MESSAGE"
+TRUTHY = {"1", "true", "yes", "on"}
+PLUGIN_DIR = Path.home() / ".cognee-plugin"
+LOG_FILE = PLUGIN_DIR / "hook.log"
+
+
+def _enabled() -> bool:
+    return os.environ.get(ENV_NAME, "").strip().lower() in TRUTHY
+
+
+def _log(event: str, detail: dict | None = None) -> None:
+    try:
+        PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        line = {
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "pid": os.getpid(),
+            "event": event,
+        }
+        if detail:
+            line["detail"] = detail
+        with LOG_FILE.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(line, default=str) + "\n")
+    except Exception:
+        pass
+
+
+def _clear_transcript(payload: dict) -> tuple[bool, str]:
+    transcript_raw = str(payload.get("transcript_path") or "").strip()
+    if not transcript_raw:
+        return False, "missing transcript_path"
+
+    transcript_path = Path(transcript_raw).expanduser()
+    if not transcript_path.exists() or not transcript_path.is_file():
+        return False, "transcript_path is not a file"
+
+    try:
+        transcript_path.write_text("", encoding="utf-8")
+    except Exception as exc:
+        return False, str(exc)[:200]
+
+    _log(
+        "claude_context_cleared",
+        {
+            "transcript_path": str(transcript_path),
+        },
+    )
+    return True, str(transcript_path)
+
+
+def main() -> int:
+    payload_raw = sys.stdin.read()
+    if not _enabled() or not payload_raw.strip():
+        return 0
+
+    try:
+        payload = json.loads(payload_raw)
+    except json.JSONDecodeError:
+        _log("clear_context_invalid_payload")
+        return 0
+
+    if payload.get("stop_hook_active"):
+        _log("clear_context_skipped_stop_hook_active")
+        return 0
+
+    ok, detail = _clear_transcript(payload)
+    if not ok:
+        _log("clear_context_failed", {"reason": detail})
+        return 0
+
+    output = {
+        "systemMessage": "Cognee demo: Claude transcript context was emptied.",
+        "suppressOutput": True,
+    }
+    print(json.dumps(output))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds an opt-in demo hook for the Claude Code integration that clears Claude’s local transcript context after each assistant response.

When `COGNEE_CLAUDE_CLEAR_AFTER_MESSAGE=true` is set, the new `Stop` hook reads Claude Code’s `transcript_path` from the hook payload and truncates that file after the existing memory-capture hook runs. This gives demo sessions a clean local transcript context on the next user message while still allowing the response to be stored in Cognee first.

## Changes

- Adds `scripts/clear-transcript-context.py`
  - no-ops unless `COGNEE_CLAUDE_CLEAR_AFTER_MESSAGE` is truthy
  - reads `transcript_path` from the Stop hook payload
  - empties the transcript file directly
  - logs success/failure to `~/.cognee-plugin/hook.log`
- Wires the script into the Claude Code `Stop` hook after `store-to-session.py --stop`
- Documents the env var and demo-only behavior in the Claude Code README

## Notes

Claude Code hooks cannot directly invoke built-in slash commands like `/clear`, so this feature clears the backing transcript file instead. This is intended as an opt-in demo workaround, not the default behavior.

## Testing

- `python3 -m py_compile integrations/claude-code/scripts/clear-transcript-context.py`
- `uvx ruff check integrations/claude-code/scripts/clear-transcript-context.py`
- `python3 -m json.tool integrations/claude-code/hooks/hooks.json`
- Simulated Stop hook payload and verified the transcript file is truncated to `0` bytes
- `claude plugin validate integrations/claude-code`