### PR TITLE
feat(hermes): add standalone Cognee memory plugin

### DIFF
--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -1,0 +1,99 @@
+# Cognee Memory Plugin for Hermes Agent
+
+Standalone Hermes memory provider backed by Cognee.
+
+This replaces the closed in-tree Hermes PR path. Hermes no longer accepts new
+providers under `plugins/memory/`; this integration is shaped as a standalone
+plugin that can be installed into `~/.hermes/plugins/cognee` or distributed as a
+Python package with the `hermes_agent.plugins` entry point.
+
+## Features
+
+- Stores each completed Hermes turn in Cognee session memory.
+- Uses `cognee_recall` for session-first recall with graph fallback.
+- Exposes `cognee_remember` for durable graph memory.
+- Exposes `cognee_forget` for deletion requests.
+- Runs `cognee.improve()` at Hermes session end to bridge session memory into the graph.
+- Mirrors explicit Hermes memory writes through `on_memory_write`.
+- Supports local embedded Cognee and remote Cognee service mode.
+
+## Install For Local Hermes Development
+
+From this repository:
+
+```bash
+mkdir -p ~/.hermes/plugins/cognee
+cp -R integrations/hermes-agent/. ~/.hermes/plugins/cognee/
+hermes memory setup
+```
+
+Select `cognee` in the memory provider picker.
+
+## Install From Pip
+
+```bash
+pip install cognee-integration-hermes-agent
+hermes memory setup
+```
+
+The package exposes:
+
+```toml
+[project.entry-points."hermes_agent.plugins"]
+cognee = "cognee_integration_hermes"
+```
+
+## Configuration
+
+The setup wizard writes non-secret settings to `$HERMES_HOME/cognee.json` and
+secrets to `$HERMES_HOME/.env`.
+
+Local embedded mode:
+
+```bash
+LLM_API_KEY=sk-...
+LLM_MODEL=gpt-4o-mini
+COGNEE_DATASET=hermes
+```
+
+Remote service mode:
+
+```bash
+COGNEE_SERVICE_URL=https://your-cognee-service.example
+COGNEE_API_KEY=...
+COGNEE_DATASET=hermes
+```
+
+Optional settings:
+
+| Setting | Env var | Default |
+| --- | --- | --- |
+| `dataset` | `COGNEE_DATASET` | `hermes` |
+| `top_k` | `COGNEE_TOP_K` | `5` |
+| `auto_route` | `COGNEE_AUTO_ROUTE` | `true` |
+| `improve_on_end` | `COGNEE_IMPROVE_ON_END` | `true` |
+| `session_prefix` | `COGNEE_SESSION_PREFIX` | `hermes` |
+| `service_url` | `COGNEE_SERVICE_URL` | empty |
+| `data_root` | `COGNEE_DATA_ROOT` | `$HERMES_HOME/cognee/data` |
+| `system_root` | `COGNEE_SYSTEM_ROOT` | `$HERMES_HOME/cognee/system` |
+
+## Hermes Commands
+
+When Cognee is the active memory provider:
+
+```bash
+hermes cognee status
+hermes cognee setup
+hermes cognee config
+hermes cognee install
+```
+
+## Development
+
+```bash
+cd integrations/hermes-agent
+uv sync --dev
+uv run pytest -q
+uv run ruff check .
+```
+

--- a/integrations/hermes-agent/__init__.py
+++ b/integrations/hermes-agent/__init__.py
@@ -1,0 +1,17 @@
+"""Directory-plugin entry point for Hermes Agent."""
+
+try:
+    from .cognee_integration_hermes import CogneeMemoryProvider
+except ImportError:  # pragma: no cover - supports direct pytest/path imports.
+    import sys
+    from pathlib import Path
+
+    plugin_dir = Path(__file__).resolve().parent
+    if str(plugin_dir) not in sys.path:
+        sys.path.insert(0, str(plugin_dir))
+    from cognee_integration_hermes import CogneeMemoryProvider
+
+
+def register(ctx) -> None:
+    """Register Cognee as the active Hermes memory provider."""
+    ctx.register_memory_provider(CogneeMemoryProvider())

--- a/integrations/hermes-agent/after-install.md
+++ b/integrations/hermes-agent/after-install.md
@@ -1,0 +1,13 @@
+# Cognee Hermes Memory Plugin
+
+The Cognee memory plugin has been installed.
+
+Run:
+
+```bash
+hermes memory setup
+```
+
+Then select `cognee`. The setup flow can configure local embedded Cognee or a
+remote Cognee service.
+

--- a/integrations/hermes-agent/cli.py
+++ b/integrations/hermes-agent/cli.py
@@ -1,0 +1,14 @@
+"""Directory-plugin CLI shim for Hermes Agent."""
+
+try:
+    from .cognee_integration_hermes.cli import cognee_command, register_cli
+except ImportError:  # pragma: no cover - supports direct path imports.
+    import sys
+    from pathlib import Path
+
+    plugin_dir = Path(__file__).resolve().parent
+    if str(plugin_dir) not in sys.path:
+        sys.path.insert(0, str(plugin_dir))
+    from cognee_integration_hermes.cli import cognee_command, register_cli
+
+__all__ = ["cognee_command", "register_cli"]

--- a/integrations/hermes-agent/cognee_integration_hermes/__init__.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/__init__.py
@@ -1,0 +1,11 @@
+"""Cognee memory provider plugin for Hermes Agent."""
+
+from .provider import CogneeMemoryProvider
+
+__all__ = ["CogneeMemoryProvider", "register"]
+
+
+def register(ctx) -> None:
+    """Pip entry-point registration hook for Hermes Agent."""
+    ctx.register_memory_provider(CogneeMemoryProvider())
+

--- a/integrations/hermes-agent/cognee_integration_hermes/cli.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/cli.py
@@ -1,0 +1,91 @@
+"""CLI commands for the Cognee Hermes memory plugin."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+from .config import config_path, load_config
+
+
+def _provider_active() -> bool:
+    try:
+        from hermes_cli.config import cfg_get
+        from hermes_cli.config import load_config as load_hermes_config
+
+        config = load_hermes_config()
+        return cfg_get(config, "memory", "provider") == "cognee"
+    except Exception:
+        return False
+
+
+def _print_status(args) -> None:
+    cfg = load_config()
+    path = config_path()
+    print("\nCognee memory")
+    print("-" * 40)
+    print(f"  Active provider: {'yes' if _provider_active() else 'no'}")
+    print(f"  Cognee package:  {'installed' if importlib.util.find_spec('cognee') else 'missing'}")
+    print(f"  Mode:            {'remote' if cfg.get('service_url') else 'local'}")
+    print(f"  Dataset:         {cfg.get('dataset')}")
+    print(f"  Config:          {path or '(unknown)'}")
+    print(f"  Service URL:     {cfg.get('service_url') or '(none)'}")
+    print(f"  LLM key:         {'set' if cfg.get('llm_api_key') else 'missing'}")
+    print(f"  API key:         {'set' if cfg.get('api_key') else 'missing'}")
+    print(f"  Improve on end:  {cfg.get('improve_on_end')}")
+    print()
+
+
+def _print_config(args) -> None:
+    cfg = dict(load_config())
+    for key in ("llm_api_key", "api_key", "identity_password"):
+        if cfg.get(key):
+            cfg[key] = "***"
+    print(json.dumps(cfg, indent=2, sort_keys=True))
+
+
+def _run_setup(args) -> None:
+    try:
+        from hermes_cli.memory_setup import cmd_setup_provider
+
+        cmd_setup_provider("cognee")
+    except Exception as exc:
+        print(f"Could not launch Hermes memory setup: {exc}")
+        print("Run: hermes memory setup")
+
+
+def _print_install(args) -> None:
+    here = Path(__file__).resolve().parents[1]
+    print("\nInstall as a local Hermes directory plugin:")
+    print("  mkdir -p ~/.hermes/plugins/cognee")
+    print(f"  cp -R {here}/. ~/.hermes/plugins/cognee/")
+    print("  hermes memory setup")
+    print("\nInstall from a standalone git repo once published:")
+    print("  hermes plugins install <owner>/<repo>")
+    print("  hermes memory setup")
+    print("\nInstall via pip:")
+    print("  pip install cognee-integration-hermes-agent")
+    print("  hermes memory setup\n")
+
+
+def cognee_command(args) -> None:
+    sub = getattr(args, "cognee_command", None)
+    if sub == "setup":
+        _run_setup(args)
+    elif sub == "config":
+        _print_config(args)
+    elif sub == "install":
+        _print_install(args)
+    else:
+        _print_status(args)
+
+
+def register_cli(subparser) -> None:
+    """Build the `hermes cognee` command tree."""
+    subs = subparser.add_subparsers(dest="cognee_command")
+    subs.add_parser("status", help="Show Cognee memory status")
+    subs.add_parser("setup", help="Run Hermes memory setup for Cognee")
+    subs.add_parser("config", help="Print Cognee plugin config with secrets redacted")
+    subs.add_parser("install", help="Print installation commands")
+    subparser.set_defaults(func=cognee_command)

--- a/integrations/hermes-agent/cognee_integration_hermes/config.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/config.py
@@ -1,0 +1,143 @@
+"""Configuration helpers for the Cognee Hermes plugin."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DATASET = "hermes"
+DEFAULT_IDENTITY_EMAIL = "hermes-agent@cognee.local"
+DEFAULT_IDENTITY_PASSWORD = "hermes-agent-plugin"
+
+
+def str_to_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "no", "n", "off"}:
+        return False
+    return default
+
+
+def str_to_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def resolve_hermes_home(hermes_home: str | Path | None = None) -> Path | None:
+    if hermes_home:
+        return Path(hermes_home).expanduser()
+    try:
+        from hermes_constants import get_hermes_home
+
+        return Path(get_hermes_home()).expanduser()
+    except Exception:
+        return None
+
+
+def config_path(hermes_home: str | Path | None = None) -> Path | None:
+    home = resolve_hermes_home(hermes_home)
+    return home / "cognee.json" if home else None
+
+
+def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
+    """Load plugin config from environment variables and HERMES_HOME/cognee.json."""
+    service_url = os.environ.get("COGNEE_SERVICE_URL") or os.environ.get("COGNEE_BASE_URL", "")
+    config: dict[str, Any] = {
+        "llm_api_key": os.environ.get("LLM_API_KEY", ""),
+        "llm_model": os.environ.get("LLM_MODEL", ""),
+        "service_url": service_url,
+        "api_key": os.environ.get("COGNEE_API_KEY", ""),
+        "dataset": os.environ.get("COGNEE_DATASET", DEFAULT_DATASET),
+        "top_k": str_to_int(os.environ.get("COGNEE_TOP_K"), 5),
+        "auto_route": str_to_bool(os.environ.get("COGNEE_AUTO_ROUTE"), True),
+        "improve_on_end": str_to_bool(os.environ.get("COGNEE_IMPROVE_ON_END"), True),
+        "session_prefix": os.environ.get("COGNEE_SESSION_PREFIX", "hermes"),
+        "data_root": os.environ.get("COGNEE_DATA_ROOT", ""),
+        "system_root": os.environ.get("COGNEE_SYSTEM_ROOT", ""),
+        "identity_email": os.environ.get("COGNEE_HERMES_USER_EMAIL", DEFAULT_IDENTITY_EMAIL),
+        "identity_password": os.environ.get(
+            "COGNEE_HERMES_USER_PASSWORD",
+            DEFAULT_IDENTITY_PASSWORD,
+        ),
+        "recall_timeout": str_to_int(os.environ.get("COGNEE_RECALL_TIMEOUT"), 60),
+        "write_timeout": str_to_int(os.environ.get("COGNEE_WRITE_TIMEOUT"), 120),
+        "improve_timeout": str_to_int(os.environ.get("COGNEE_IMPROVE_TIMEOUT"), 300),
+    }
+
+    path = config_path(hermes_home)
+    if path and path.exists():
+        try:
+            file_config = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(file_config, dict):
+                config.update(
+                    {key: value for key, value in file_config.items() if value is not None}
+                )
+        except Exception:
+            pass
+
+    config["top_k"] = max(1, str_to_int(config.get("top_k"), 5))
+    config["recall_timeout"] = max(1, str_to_int(config.get("recall_timeout"), 60))
+    config["write_timeout"] = max(1, str_to_int(config.get("write_timeout"), 120))
+    config["improve_timeout"] = max(1, str_to_int(config.get("improve_timeout"), 300))
+    config["auto_route"] = str_to_bool(config.get("auto_route"), True)
+    config["improve_on_end"] = str_to_bool(config.get("improve_on_end"), True)
+    return config
+
+
+def save_config(values: dict[str, Any], hermes_home: str | Path) -> Path:
+    """Merge non-secret values into HERMES_HOME/cognee.json."""
+    path = config_path(hermes_home)
+    if path is None:
+        raise RuntimeError("Could not resolve HERMES_HOME.")
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing: dict[str, Any] = {}
+    if path.exists():
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                existing = loaded
+        except Exception:
+            existing = {}
+
+    existing.update({key: value for key, value in values.items() if value is not None})
+    path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def write_env_vars(env_path: Path, values: dict[str, str]) -> None:
+    """Append or update environment variables in a Hermes .env file."""
+    if not values:
+        return
+
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    existing_lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
+
+    updated: set[str] = set()
+    new_lines: list[str] = []
+    for line in existing_lines:
+        key = line.split("=", 1)[0].strip() if "=" in line else ""
+        if key in values:
+            new_lines.append(f"{key}={values[key]}")
+            updated.add(key)
+        else:
+            new_lines.append(line)
+
+    for key, value in values.items():
+        if key not in updated:
+            new_lines.append(f"{key}={value}")
+
+    env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+    try:
+        env_path.chmod(0o600)
+    except OSError:
+        pass

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -1,0 +1,797 @@
+"""Hermes MemoryProvider implementation backed by Cognee."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from .config import (
+    DEFAULT_DATASET,
+    load_config,
+    str_to_bool,
+    write_env_vars,
+)
+from .config import (
+    save_config as save_plugin_config,
+)
+from .schemas import FORGET_SCHEMA, RECALL_SCHEMA, REMEMBER_SCHEMA
+
+try:
+    from agent.memory_provider import MemoryProvider
+except ImportError:  # pragma: no cover - lets package smoke tests run outside Hermes.
+    class MemoryProvider:  # type: ignore[no-redef]
+        @property
+        def name(self) -> str:
+            raise NotImplementedError
+
+
+logger = logging.getLogger(__name__)
+
+_BREAKER_THRESHOLD = 5
+_BREAKER_COOLDOWN_SECS = 120
+
+
+class _AsyncBridge:
+    """Run Cognee async SDK calls from Hermes' sync MemoryProvider interface."""
+
+    def __init__(self) -> None:
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+
+    def _ensure_loop(self) -> None:
+        with self._lock:
+            if self._loop is not None and self._loop.is_running():
+                return
+            self._loop = asyncio.new_event_loop()
+            self._thread = threading.Thread(
+                target=self._loop.run_forever,
+                daemon=True,
+                name="cognee-hermes-event-loop",
+            )
+            self._thread.start()
+
+    def run(self, coro, timeout: float):
+        self._ensure_loop()
+        assert self._loop is not None
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result(timeout=timeout)
+
+    def shutdown(self) -> None:
+        with self._lock:
+            if self._loop and self._loop.is_running():
+                self._loop.call_soon_threadsafe(self._loop.stop)
+            if self._thread and self._thread.is_alive():
+                self._thread.join(timeout=5.0)
+            self._loop = None
+            self._thread = None
+
+
+def _has_cognee() -> bool:
+    return importlib.util.find_spec("cognee") is not None
+
+
+def _safe_session_component(value: str) -> str:
+    cleaned = "".join(ch if ch.isalnum() or ch in {"_", "-"} else "_" for ch in value)
+    return cleaned.strip("_") or "session"
+
+
+def _format_turn(user_content: str, assistant_content: str) -> str:
+    return f"User: {user_content}\nAssistant: {assistant_content}"
+
+
+def _coerce_result_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if hasattr(value, "model_dump"):
+        try:
+            dumped = value.model_dump()
+            if isinstance(dumped, dict):
+                return dumped
+        except Exception:
+            pass
+    if hasattr(value, "dict"):
+        try:
+            dumped = value.dict()
+            if isinstance(dumped, dict):
+                return dumped
+        except Exception:
+            pass
+    return {"text": str(value)}
+
+
+def _result_text(value: Any) -> str:
+    data = _coerce_result_dict(value)
+    for key in ("answer", "text", "content", "chunk_text", "summary"):
+        found = data.get(key)
+        if found:
+            return str(found)
+    return str(value)
+
+
+class CogneeMemoryProvider(MemoryProvider):
+    """Cognee V2/V1.1 knowledge graph memory for Hermes Agent."""
+
+    def __init__(self) -> None:
+        self._config: dict[str, Any] = {}
+        self._bridge = _AsyncBridge()
+        self._initialized = False
+        self._remote_mode = False
+        self._user = None
+        self._session_id = ""
+        self._session_cognee_id = ""
+        self._dataset = DEFAULT_DATASET
+        self._top_k = 5
+        self._auto_route = True
+        self._improve_on_end = True
+        self._writes_enabled = True
+        self._hermes_home: str | None = None
+        self._prefetch_result = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread: Optional[threading.Thread] = None
+        self._sync_thread: Optional[threading.Thread] = None
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+
+    @property
+    def name(self) -> str:
+        return "cognee"
+
+    def is_available(self) -> bool:
+        if not _has_cognee():
+            return False
+        cfg = load_config()
+        return bool(cfg.get("service_url") or cfg.get("llm_api_key"))
+
+    def get_config_schema(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "service_url",
+                "description": "Cognee service URL (blank for local embedded mode)",
+                "required": False,
+                "env_var": "COGNEE_SERVICE_URL",
+            },
+            {
+                "key": "api_key",
+                "description": "Cognee service API key",
+                "secret": True,
+                "required": False,
+                "env_var": "COGNEE_API_KEY",
+            },
+            {
+                "key": "llm_api_key",
+                "description": "LLM API key for local embedded Cognee",
+                "secret": True,
+                "required": False,
+                "env_var": "LLM_API_KEY",
+            },
+            {
+                "key": "llm_model",
+                "description": "LLM model for local embedded Cognee",
+                "required": False,
+                "env_var": "LLM_MODEL",
+            },
+            {
+                "key": "dataset",
+                "description": "Default Cognee dataset",
+                "default": DEFAULT_DATASET,
+                "env_var": "COGNEE_DATASET",
+            },
+            {
+                "key": "auto_route",
+                "description": "Let Cognee choose the recall strategy",
+                "default": "true",
+                "choices": ["true", "false"],
+            },
+            {
+                "key": "improve_on_end",
+                "description": "Run Cognee improve() when a Hermes session ends",
+                "default": "true",
+                "choices": ["true", "false"],
+            },
+        ]
+
+    def save_config(self, values: dict[str, Any], hermes_home: str) -> None:
+        non_secret = {
+            key: value
+            for key, value in values.items()
+            if key not in {"api_key", "llm_api_key"}
+        }
+        if non_secret:
+            save_plugin_config(non_secret, hermes_home)
+
+    def post_setup(self, hermes_home: str, config: dict[str, Any]) -> None:
+        """Hermes memory setup hook for a focused Cognee setup flow."""
+        print("\nCognee memory setup")
+        print("-" * 40)
+        print("  Deployment:")
+        print("    local  - embedded Cognee in the Hermes process")
+        print("    remote - Cognee service or Cognee Cloud")
+
+        current = load_config(hermes_home)
+        default_mode = "remote" if current.get("service_url") else "local"
+        mode = _prompt("Mode", default=default_mode).strip().lower()
+        remote = mode in {"remote", "cloud", "service"}
+
+        env_values: dict[str, str] = {}
+        file_values: dict[str, Any] = {
+            "dataset": _prompt("Dataset", default=str(current.get("dataset") or DEFAULT_DATASET)),
+            "auto_route": _prompt_bool("Auto-route recall", current.get("auto_route", True)),
+            "improve_on_end": _prompt_bool(
+                "Improve graph on session end",
+                current.get("improve_on_end", True),
+            ),
+        }
+
+        if remote:
+            service_url = _prompt(
+                "Cognee service URL",
+                default=str(current.get("service_url") or ""),
+            )
+            if service_url:
+                file_values["service_url"] = service_url
+                env_values["COGNEE_SERVICE_URL"] = service_url
+            api_key = _prompt_secret("Cognee API key", keep=bool(current.get("api_key")))
+            if api_key:
+                env_values["COGNEE_API_KEY"] = api_key
+        else:
+            file_values["service_url"] = ""
+            env_values["COGNEE_SERVICE_URL"] = ""
+            llm_key = _prompt_secret("LLM API key", keep=bool(current.get("llm_api_key")))
+            if llm_key:
+                env_values["LLM_API_KEY"] = llm_key
+            llm_model = _prompt("LLM model", default=str(current.get("llm_model") or ""))
+            if llm_model:
+                file_values["llm_model"] = llm_model
+                env_values["LLM_MODEL"] = llm_model
+
+        save_plugin_config(file_values, hermes_home)
+        write_env_vars(Path(hermes_home) / ".env", env_values)
+
+        if not isinstance(config.get("memory"), dict):
+            config["memory"] = {}
+        config["memory"]["provider"] = self.name
+
+        try:
+            from hermes_cli.config import save_config
+
+            save_config(config)
+        except Exception:
+            pass
+
+        print("\n  Memory provider: cognee")
+        print("  Activation saved to config.yaml")
+        print("  Provider config saved to cognee.json")
+        if env_values:
+            print("  Secrets saved to .env")
+        print("\n  Start a new Hermes session to activate Cognee memory.\n")
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._hermes_home = kwargs.get("hermes_home")
+        self._config = load_config(self._hermes_home)
+        self._session_id = session_id
+        self._dataset = str(self._config.get("dataset") or DEFAULT_DATASET)
+        self._top_k = int(self._config.get("top_k") or 5)
+        self._auto_route = str_to_bool(self._config.get("auto_route"), True)
+        self._improve_on_end = str_to_bool(self._config.get("improve_on_end"), True)
+        self._writes_enabled = kwargs.get("agent_context", "primary") in {"", "primary", None}
+        self._session_cognee_id = self._build_cognee_session_id(session_id, **kwargs)
+
+        self._configure_cognee_local_roots()
+        self._configure_cognee_models()
+
+        service_url = str(self._config.get("service_url") or "")
+        if service_url:
+            try:
+                api_key = str(self._config.get("api_key") or "")
+                self._bridge.run(self._do_serve(service_url, api_key), timeout=30)
+                self._remote_mode = True
+            except Exception as exc:
+                self._remote_mode = False
+                logger.warning("Cognee remote connection failed, using local mode: %s", exc)
+
+        try:
+            self._user = self._bridge.run(self._ensure_identity(), timeout=30)
+        except Exception as exc:
+            self._user = None
+            logger.warning("Cognee identity initialization failed; using SDK default user: %s", exc)
+
+        self._initialized = True
+
+    def system_prompt_block(self) -> str:
+        mode = "remote" if self._remote_mode else "local"
+        return (
+            "# Cognee Memory\n"
+            f"Active ({mode}). Dataset: {self._dataset}.\n"
+            "Use cognee_recall for prior context, cognee_remember for durable facts, "
+            "and cognee_forget when the user asks to remove Cognee memory."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=3.0)
+        with self._prefetch_lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        if not result:
+            return ""
+        return f"## Cognee Memory\n{result}"
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if not query or self._is_breaker_open():
+            return
+
+        cognee_session_id = self._session_cognee_id_for(session_id)
+
+        def _run() -> None:
+            try:
+                results = self._bridge.run(
+                    self._do_recall(query, None, min(self._top_k, 5), "auto", cognee_session_id),
+                    timeout=float(self._config.get("recall_timeout", 60)),
+                )
+                lines = self._format_recall_lines(results, limit=5)
+                if lines:
+                    with self._prefetch_lock:
+                        self._prefetch_result = "\n".join(lines)
+                self._record_success()
+            except Exception as exc:
+                self._record_failure()
+                logger.debug("Cognee prefetch failed: %s", exc)
+
+        self._prefetch_thread = threading.Thread(
+            target=_run,
+            daemon=True,
+            name="cognee-hermes-prefetch",
+        )
+        self._prefetch_thread.start()
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if not self._writes_enabled or self._is_breaker_open():
+            return
+
+        cognee_session_id = self._session_cognee_id_for(session_id)
+        content = _format_turn(user_content, assistant_content)
+
+        def _sync() -> None:
+            try:
+                self._bridge.run(
+                    self._do_remember_session(content, cognee_session_id),
+                    timeout=float(self._config.get("write_timeout", 120)),
+                )
+                self._record_success()
+            except Exception as exc:
+                self._record_failure()
+                logger.warning("Cognee session sync failed: %s", exc)
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
+
+        self._sync_thread = threading.Thread(
+            target=_sync,
+            daemon=True,
+            name="cognee-hermes-sync",
+        )
+        self._sync_thread.start()
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        return [RECALL_SCHEMA, REMEMBER_SCHEMA, FORGET_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
+        if self._is_breaker_open():
+            return json.dumps(
+                {
+                    "error": (
+                        "Cognee is temporarily unavailable after repeated failures. "
+                        "The provider will retry automatically after cooldown."
+                    )
+                }
+            )
+        if tool_name == "cognee_recall":
+            return self._handle_recall(args)
+        if tool_name == "cognee_remember":
+            return self._handle_remember(args)
+        if tool_name == "cognee_forget":
+            return self._handle_forget(args)
+        return json.dumps({"error": f"Unknown Cognee tool: {tool_name}"})
+
+    def on_session_end(self, messages: list[dict[str, Any]]) -> None:
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=10.0)
+        if not self._writes_enabled or not self._improve_on_end or self._is_breaker_open():
+            return
+        try:
+            self._bridge.run(
+                self._do_improve(),
+                timeout=float(self._config.get("improve_timeout", 300)),
+            )
+            self._record_success()
+        except Exception as exc:
+            self._record_failure()
+            logger.warning("Cognee session-end improve failed: %s", exc)
+
+    def on_session_switch(
+        self,
+        new_session_id: str,
+        *,
+        parent_session_id: str = "",
+        reset: bool = False,
+        **kwargs,
+    ) -> None:
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
+        self._session_id = new_session_id
+        self._session_cognee_id = self._build_cognee_session_id(new_session_id, **kwargs)
+        if reset:
+            with self._prefetch_lock:
+                self._prefetch_result = ""
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> None:
+        if action not in {"add", "replace"} or not content or self._is_breaker_open():
+            return
+        metadata = dict(metadata or {})
+        source = metadata.get("write_origin") or "hermes_memory_tool"
+        payload = f"Hermes {target} memory ({action}, {source}): {content}"
+
+        def _sync() -> None:
+            try:
+                self._bridge.run(
+                    self._do_remember_permanent(payload, self._dataset),
+                    timeout=float(self._config.get("write_timeout", 120)),
+                )
+                self._record_success()
+            except Exception as exc:
+                self._record_failure()
+                logger.debug("Cognee memory-write mirror failed: %s", exc)
+
+        threading.Thread(target=_sync, daemon=True, name="cognee-hermes-memory-write").start()
+
+    def on_delegation(
+        self,
+        task: str,
+        result: str,
+        *,
+        child_session_id: str = "",
+        **kwargs,
+    ) -> None:
+        if not task and not result:
+            return
+        content = f"Delegated task: {task}\nResult: {result}"
+        self.sync_turn(content, "", session_id=self._session_id)
+
+    def shutdown(self) -> None:
+        for thread in (self._prefetch_thread, self._sync_thread):
+            if thread and thread.is_alive():
+                thread.join(timeout=5.0)
+        if self._remote_mode:
+            try:
+                self._bridge.run(self._do_disconnect(), timeout=5)
+            except Exception:
+                pass
+        self._bridge.shutdown()
+
+    def _build_cognee_session_id(self, session_id: str, **kwargs) -> str:
+        prefix = str(self._config.get("session_prefix") or "hermes")
+        workspace = str(kwargs.get("agent_workspace") or "")
+        user_id = str(kwargs.get("user_id") or "")
+        parts = [prefix]
+        if workspace:
+            parts.append(_safe_session_component(workspace))
+        if user_id:
+            parts.append(_safe_session_component(user_id))
+        parts.append(_safe_session_component(session_id))
+        return "_".join(parts)
+
+    def _session_cognee_id_for(self, session_id: str) -> str:
+        if not session_id or session_id == self._session_id:
+            return self._session_cognee_id
+        return self._build_cognee_session_id(session_id)
+
+    def _configure_cognee_local_roots(self) -> None:
+        if not self._hermes_home:
+            return
+        try:
+            import cognee
+
+            data_root = self._config.get("data_root") or str(
+                Path(self._hermes_home) / "cognee" / "data"
+            )
+            system_root = self._config.get("system_root") or str(
+                Path(self._hermes_home) / "cognee" / "system"
+            )
+            cognee.config.data_root_directory(str(data_root))
+            cognee.config.system_root_directory(str(system_root))
+        except Exception as exc:
+            logger.debug("Cognee root configuration failed: %s", exc)
+
+    def _configure_cognee_models(self) -> None:
+        try:
+            import cognee
+
+            if self._config.get("llm_api_key"):
+                cognee.config.set_llm_api_key(str(self._config["llm_api_key"]))
+            if self._config.get("llm_model"):
+                cognee.config.set_llm_model(str(self._config["llm_model"]))
+        except Exception as exc:
+            logger.debug("Cognee model configuration failed: %s", exc)
+
+    async def _ensure_identity(self):
+        email = str(self._config.get("identity_email") or "hermes-agent@cognee.local")
+        password = str(self._config.get("identity_password") or "hermes-agent-plugin")
+        try:
+            from cognee.modules.users.methods import (
+                create_user,
+                get_default_user,
+                get_user_by_email,
+            )
+        except Exception:
+            return None
+
+        user = await get_user_by_email(email)
+        if user:
+            return user
+        try:
+            return await create_user(
+                email=email,
+                password=password,
+                is_verified=True,
+                is_active=True,
+            )
+        except Exception:
+            user = await get_user_by_email(email)
+            if user:
+                return user
+            return await get_default_user()
+
+    async def _do_serve(self, url: str, api_key: str):
+        import cognee
+
+        kwargs = {"url": url}
+        if api_key:
+            kwargs["api_key"] = api_key
+        return await cognee.serve(**kwargs)
+
+    async def _do_disconnect(self):
+        import cognee
+
+        return await cognee.disconnect()
+
+    async def _do_recall(
+        self,
+        query: str,
+        search_type: Optional[str],
+        top_k: int,
+        scope: str,
+        session_id: str,
+    ) -> list[Any]:
+        import cognee
+
+        kwargs: dict[str, Any] = {
+            "top_k": top_k,
+            "auto_route": self._auto_route,
+        }
+        if self._user is not None:
+            kwargs["user"] = self._user
+
+        normalized_scope = (scope or "auto").lower()
+        if normalized_scope == "session":
+            kwargs["session_id"] = session_id
+        elif normalized_scope == "graph":
+            kwargs["datasets"] = [self._dataset]
+        else:
+            kwargs["session_id"] = session_id
+            kwargs["datasets"] = [self._dataset]
+
+        if search_type and normalized_scope != "session":
+            kwargs["query_type"] = _resolve_search_type(search_type)
+
+        return await cognee.recall(query_text=query, **kwargs)
+
+    async def _do_remember_session(self, content: str, session_id: str):
+        import cognee
+
+        kwargs: dict[str, Any] = {
+            "data": content,
+            "dataset_name": self._dataset,
+            "session_id": session_id,
+            "self_improvement": False,
+        }
+        if self._user is not None:
+            kwargs["user"] = self._user
+        return await cognee.remember(**kwargs)
+
+    async def _do_remember_permanent(self, content: str, dataset: str):
+        import cognee
+
+        kwargs: dict[str, Any] = {
+            "data": content,
+            "dataset_name": dataset,
+            "self_improvement": True,
+            "session_ids": [self._session_cognee_id],
+        }
+        if self._user is not None:
+            kwargs["user"] = self._user
+        return await cognee.remember(**kwargs)
+
+    async def _do_forget(
+        self,
+        dataset: Optional[str],
+        *,
+        everything: bool = False,
+        memory_only: bool = False,
+    ) -> dict[str, Any]:
+        import cognee
+
+        kwargs: dict[str, Any] = {
+            "everything": everything,
+            "memory_only": memory_only,
+        }
+        if dataset and not everything:
+            kwargs["dataset"] = dataset
+        if self._user is not None:
+            kwargs["user"] = self._user
+        return await cognee.forget(**kwargs)
+
+    async def _do_improve(self):
+        import cognee
+
+        kwargs: dict[str, Any] = {
+            "dataset": self._dataset,
+            "session_ids": [self._session_cognee_id],
+            "run_in_background": False,
+        }
+        if self._user is not None:
+            kwargs["user"] = self._user
+        return await cognee.improve(**kwargs)
+
+    def _handle_recall(self, args: dict[str, Any]) -> str:
+        query = str(args.get("query") or "").strip()
+        if not query:
+            return json.dumps({"error": "Missing required parameter: query"})
+        top_k = min(max(1, int(args.get("top_k") or self._top_k)), 20)
+        scope = str(args.get("scope") or "auto")
+        search_type = args.get("search_type")
+
+        try:
+            results = self._bridge.run(
+                self._do_recall(query, search_type, top_k, scope, self._session_cognee_id),
+                timeout=float(self._config.get("recall_timeout", 60)),
+            )
+            self._record_success()
+            items = [self._normalize_recall_item(item) for item in results]
+            if not items:
+                return json.dumps({"result": "No relevant Cognee memory found.", "count": 0})
+            return json.dumps({"results": items, "count": len(items)})
+        except Exception as exc:
+            self._record_failure()
+            return json.dumps({"error": f"Cognee recall failed: {exc}"})
+
+    def _handle_remember(self, args: dict[str, Any]) -> str:
+        content = str(args.get("content") or "").strip()
+        if not content:
+            return json.dumps({"error": "Missing required parameter: content"})
+        dataset = str(args.get("dataset") or self._dataset)
+
+        try:
+            result = self._bridge.run(
+                self._do_remember_permanent(content, dataset),
+                timeout=float(self._config.get("write_timeout", 120)),
+            )
+            self._record_success()
+            status = getattr(result, "status", "completed")
+            return json.dumps({"result": "Content stored in Cognee.", "status": str(status)})
+        except Exception as exc:
+            self._record_failure()
+            return json.dumps({"error": f"Cognee remember failed: {exc}"})
+
+    def _handle_forget(self, args: dict[str, Any]) -> str:
+        dataset = args.get("dataset")
+        everything = bool(args.get("everything", False))
+        memory_only = bool(args.get("memory_only", False))
+        if not dataset and not everything:
+            return json.dumps({"error": "Specify dataset or set everything=true."})
+
+        try:
+            result = self._bridge.run(
+                self._do_forget(dataset, everything=everything, memory_only=memory_only),
+                timeout=float(self._config.get("write_timeout", 120)),
+            )
+            self._record_success()
+            return json.dumps({"result": "Cognee memory deleted.", "details": result})
+        except Exception as exc:
+            self._record_failure()
+            return json.dumps({"error": f"Cognee forget failed: {exc}"})
+
+    def _normalize_recall_item(self, item: Any) -> dict[str, Any]:
+        data = _coerce_result_dict(item)
+        normalized = {
+            "text": _result_text(item),
+            "source": data.get("source") or data.get("_source") or "cognee",
+        }
+        for key in ("score", "dataset", "dataset_name", "node_name"):
+            if data.get(key) is not None:
+                normalized[key] = data[key]
+        return normalized
+
+    def _format_recall_lines(self, results: list[Any], *, limit: int) -> list[str]:
+        lines = []
+        for item in results[:limit]:
+            normalized = self._normalize_recall_item(item)
+            text = normalized.get("text", "").strip()
+            if not text:
+                continue
+            source = normalized.get("source", "cognee")
+            lines.append(f"- [{source}] {text[:500]}")
+        return lines
+
+    def _is_breaker_open(self) -> bool:
+        if self._consecutive_failures < _BREAKER_THRESHOLD:
+            return False
+        if time.monotonic() >= self._breaker_open_until:
+            self._consecutive_failures = 0
+            return False
+        return True
+
+    def _record_success(self) -> None:
+        self._consecutive_failures = 0
+
+    def _record_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= _BREAKER_THRESHOLD:
+            self._breaker_open_until = time.monotonic() + _BREAKER_COOLDOWN_SECS
+            logger.warning(
+                "Cognee circuit breaker tripped after %d consecutive failures; pausing for %ds.",
+                self._consecutive_failures,
+                _BREAKER_COOLDOWN_SECS,
+            )
+
+
+def _resolve_search_type(search_type: str):
+    try:
+        from cognee.modules.search.types import SearchType
+
+        key = str(search_type).upper().strip()
+        return getattr(SearchType, key)
+    except Exception:
+        from cognee.modules.search.types import SearchType
+
+        return SearchType.GRAPH_COMPLETION
+
+
+def _prompt(label: str, default: str | None = None) -> str:
+    suffix = f" [{default}]" if default else ""
+    try:
+        value = input(f"  {label}{suffix}: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        value = ""
+    return value or (default or "")
+
+
+def _prompt_bool(label: str, default: bool) -> bool:
+    default_text = "y" if default else "n"
+    value = _prompt(f"{label} (y/n)", default=default_text).strip().lower()
+    return value in {"y", "yes", "true", "1", "on"}
+
+
+def _prompt_secret(label: str, *, keep: bool) -> str:
+    import getpass
+    import sys
+
+    suffix = " (blank to keep current)" if keep else ""
+    try:
+        if sys.stdin.isatty():
+            return getpass.getpass(f"  {label}{suffix}: ").strip()
+        return input(f"  {label}{suffix}: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        return ""

--- a/integrations/hermes-agent/cognee_integration_hermes/schemas.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/schemas.py
@@ -1,0 +1,85 @@
+"""Tool schemas exposed by the Cognee memory provider."""
+
+RECALL_SCHEMA = {
+    "name": "cognee_recall",
+    "description": (
+        "Search Cognee session memory and the persistent knowledge graph for relevant "
+        "information. Use for questions that may depend on prior conversations, stored "
+        "facts, project context, or knowledge already captured by Cognee."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Natural language query to search for.",
+            },
+            "scope": {
+                "type": "string",
+                "description": "Search scope: auto, session, or graph. Default: auto.",
+                "enum": ["auto", "session", "graph"],
+            },
+            "search_type": {
+                "type": "string",
+                "description": (
+                    "Optional Cognee SearchType override, for example GRAPH_COMPLETION, "
+                    "RAG_COMPLETION, CHUNKS, CHUNKS_LEXICAL, TEMPORAL, or FEELING_LUCKY."
+                ),
+            },
+            "top_k": {
+                "type": "integer",
+                "description": "Maximum number of results to return. Default: provider config.",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+REMEMBER_SCHEMA = {
+    "name": "cognee_remember",
+    "description": (
+        "Persist important content into Cognee's knowledge graph. Use when the user "
+        "explicitly asks to remember, store, save, or preserve a durable fact or decision."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": "Text content to store permanently.",
+            },
+            "dataset": {
+                "type": "string",
+                "description": "Optional Cognee dataset name. Defaults to the provider dataset.",
+            },
+        },
+        "required": ["content"],
+    },
+}
+
+FORGET_SCHEMA = {
+    "name": "cognee_forget",
+    "description": (
+        "Delete Cognee memory. Use only when the user asks to remove or clear stored "
+        "information. Requires either a dataset or everything=true."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "dataset": {
+                "type": "string",
+                "description": "Dataset to delete.",
+            },
+            "everything": {
+                "type": "boolean",
+                "description": "Delete all Cognee data visible to this integration.",
+            },
+            "memory_only": {
+                "type": "boolean",
+                "description": "Delete only memory-layer records when supported by Cognee.",
+            },
+        },
+        "required": [],
+    },
+}
+

--- a/integrations/hermes-agent/plugin.yaml
+++ b/integrations/hermes-agent/plugin.yaml
@@ -1,0 +1,9 @@
+name: cognee
+kind: exclusive
+version: 0.1.0
+description: "Cognee memory provider for Hermes Agent: session-aware graph memory, recall, forget, and session-end improvement."
+pip_dependencies:
+  - cognee>=1.0.0,<2.0.0
+hooks:
+  - on_session_end
+  - on_memory_write

--- a/integrations/hermes-agent/pyproject.toml
+++ b/integrations/hermes-agent/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cognee-integration-hermes-agent"
+version = "0.1.0"
+description = "Standalone Cognee memory provider plugin for Hermes Agent."
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [
+    {name = "Cognee team"}
+]
+dependencies = [
+    "cognee>=1.0.0,<2.0.0",
+]
+
+[project.entry-points."hermes_agent.plugins"]
+cognee = "cognee_integration_hermes"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["cognee_integration_hermes*"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.14.6",
+]
+

--- a/integrations/hermes-agent/tests/test_smoke.py
+++ b/integrations/hermes-agent/tests/test_smoke.py
@@ -1,0 +1,70 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def test_provider_imports():
+    from cognee_integration_hermes import CogneeMemoryProvider
+
+    provider = CogneeMemoryProvider()
+    assert provider.name == "cognee"
+    assert {schema["name"] for schema in provider.get_tool_schemas()} == {
+        "cognee_recall",
+        "cognee_remember",
+        "cognee_forget",
+    }
+
+
+def test_directory_plugin_registers_provider():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("hermes_cognee_plugin", ROOT / "__init__.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    class Collector:
+        def __init__(self):
+            self.provider = None
+
+        def register_memory_provider(self, provider):
+            self.provider = provider
+
+    collector = Collector()
+    module.register(collector)
+
+    assert collector.provider is not None
+    assert collector.provider.name == "cognee"
+
+
+def test_missing_tool_returns_json_error():
+    from cognee_integration_hermes import CogneeMemoryProvider
+
+    provider = CogneeMemoryProvider()
+    result = json.loads(provider.handle_tool_call("unknown", {}))
+    assert "error" in result
+
+
+def test_save_and_load_config(tmp_path, monkeypatch):
+    from cognee_integration_hermes.config import load_config, save_config
+
+    monkeypatch.delenv("COGNEE_SERVICE_URL", raising=False)
+    monkeypatch.delenv("COGNEE_BASE_URL", raising=False)
+    save_config({"dataset": "test_ds", "auto_route": False}, tmp_path)
+
+    config = load_config(tmp_path)
+    assert config["dataset"] == "test_ds"
+    assert config["auto_route"] is False
+
+
+def test_empty_service_url_clears_remote_mode(tmp_path, monkeypatch):
+    from cognee_integration_hermes.config import load_config, save_config
+
+    monkeypatch.setenv("COGNEE_SERVICE_URL", "https://remote.example")
+    save_config({"service_url": ""}, tmp_path)
+
+    assert load_config(tmp_path)["service_url"] == ""

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -49,6 +49,18 @@ integrations:
     migration_status: done
     notes: "Codex local plugin marketplace with Cognee CLI skills for setup, memory, codebase ingestion, and UI launch"
 
+  - slug: hermes-agent
+    name: "Cognee Memory Plugin for Hermes Agent"
+    owner: cognee
+    language: python
+    registry: pypi
+    package_name: "cognee-integration-hermes-agent"
+    cognee_dependency: sdk
+    current_version: "0.1.0"
+    migration_status: done
+    source_repo: https://github.com/NousResearch/hermes-agent/pull/7418
+    notes: "Standalone Hermes memory provider plugin; replaces closed in-tree PR path"
+
   - slug: dify
     name: "Cognee Tool Plugin for Dify"
     owner: cognee


### PR DESCRIPTION
## Summary
- add a standalone Hermes Agent memory provider integration backed by Cognee
- support Hermes directory-plugin loading and pip entry-point distribution
- add Cognee setup/config helpers, CLI commands, memory tools, and smoke tests
- register the integration in the monorepo inventory

## Context
Hermes closed the in-tree provider PR because new memory providers now need to ship as standalone plugins instead of under NousResearch/hermes-agent plugins/memory.

## Test plan
- [x] python3 -B -m pytest integrations/hermes-agent/tests -q
- [x] python3 -m ruff check integrations/hermes-agent
- [x] python3 scripts/check_version_pins.py