### PR TITLE
feat: multiple agents in openclaw. falkor backend skill

### DIFF
--- a/integrations/openclaw/skills/README.md
+++ b/integrations/openclaw/skills/README.md
@@ -1,0 +1,54 @@
+# OpenClaw × Cognee setup skills
+
+A hub of **self-contained setup skills** for running the OpenClaw ↔ Cognee
+integration in various configurations. Each subdirectory holds one skill: a
+single `SKILL.md` that an agent (or a person) can read and execute end-to-end to
+stand up a working deployment — generate the files, run the services, verify it,
+and wire up the OpenClaw plugin.
+
+The goal is discoverability: point an LLM at this repo and these skills are easy
+to find and follow. Skills here are **generators** — they embed the exact file
+contents to create (Dockerfiles, compose files, config), so the agent writes and
+runs them rather than improvising.
+
+## Available skills
+
+| Skill | Directory | What it sets up |
+|-------|-----------|-----------------|
+| `cognee-falkor-setup` | [`falkor/`](./falkor/SKILL.md) | Cognee with **FalkorDB** as the vector + graph store (custom image + adapter), running alongside FalkorDB, with per-agent graphs. |
+
+_More setups will be added here over time (e.g. other vector/graph backends,
+cloud deployments, alternative LLM providers)._
+
+## How to use a skill
+
+1. Browse the table above (or list the subdirectories) and open the relevant `SKILL.md`.
+2. Follow it top to bottom. Each skill states its **preconditions**, the **files to generate**, the **commands to run**, and **verification checks** with "if it fails" guidance.
+3. Don't skip the verification steps — they're what make the skill reliable rather than hopeful.
+
+For agents: each `SKILL.md` has YAML frontmatter (`name`, `description`). Match a
+task to a skill by its `description`, then execute the body. Treat the fenced
+file blocks as exact content to write verbatim.
+
+## Conventions for adding a new skill
+
+Keep this hub consistent so skills stay easy to find and trust:
+
+- **One directory per skill**, named for the thing it sets up (e.g. `falkor/`, `neo4j/`, `cloud/`).
+- **A single `SKILL.md`** as the entry point, with frontmatter:
+  ```yaml
+  ---
+  name: <kebab-case-skill-name>
+  description: Use when <trigger>. <One-line summary of what it stands up and that it is self-contained.>
+  ---
+  ```
+- **Self-contained & generator-style**: embed exact file contents in fenced code
+  blocks; don't describe fragile files in prose (agents free-handing an entrypoint
+  or Dockerfile is the main failure mode).
+- **Self-verifying**: after each major step, include a concrete check (a `curl`,
+  a log grep, an in-container assertion) and a short "if it fails, do X" note so
+  the agent self-corrects instead of shipping something silently broken.
+- **State preconditions up front** (can write files? run Docker? has API keys?) so
+  the skill fails loudly when it can't proceed.
+- **Pin versions** (base images, packages) with a note on how to bump them.
+- **Add a row to the table above** when you create a new skill.

--- a/integrations/openclaw/skills/falkor/SKILL.md
+++ b/integrations/openclaw/skills/falkor/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: cognee-falkor-setup
+description: Use when an agent must stand up the OpenClaw↔Cognee integration with FalkorDB as the vector + graph store. This skill is SELF-CONTAINED — it tells you to generate every file (Dockerfile, sitecustomize.py, docker-compose.yaml) from the exact contents below, build a custom Cognee image that loads the FalkorDB adapter, run Cognee + FalkorDB together, self-verify the adapter registered, and point the OpenClaw cognee plugin at it (including per-agent graphs). No other files in this directory are required.
+---
+
+# Cognee + FalkorDB setup for OpenClaw (self-contained)
+
+You (the agent) will **generate** the files below, build a custom Cognee image,
+run it alongside FalkorDB, verify the FalkorDB adapter is active, then configure
+the OpenClaw `cognee-openclaw` plugin. Follow the steps in order. Each major step
+has a **verify** check — if a check fails, follow its "if it fails" note before
+continuing. Do not skip verification.
+
+## Preconditions (fail loudly if unmet)
+
+- You can **write files** in a working directory and **run Docker** (`docker`, `docker compose`).
+- You have an **LLM API key** (OpenAI by default) for Cognee's entity extraction.
+- Pick a working directory, e.g. the directory containing this skill. All paths below are relative to it.
+
+If you cannot write files or run Docker, stop and report that — this skill cannot proceed.
+
+## Why this construction (read once)
+
+The stock `cognee/cognee` image does **not** ship the FalkorDB adapter, and there
+is **no env var** that turns it on. Cognee's `falkor` provider only becomes
+resolvable after `cognee_community_hybrid_adapter_falkor.register` is imported —
+that import registers the `falkor` graph + vector providers and the
+`falkor_graph_local` / `falkor_vector_local` per-dataset handlers. So we:
+
+1. install the adapter into Cognee's venv, and
+2. drop a `sitecustomize.py` on the image's `PYTHONPATH` (`/app`). Python
+   auto-imports `sitecustomize` at interpreter startup for **every** process —
+   the gunicorn master, each worker, and the alembic migration — so `register`
+   runs before any DB engine is created, **without editing Cognee's entrypoint**.
+
+This is deliberately the smallest possible change (no custom entrypoint, no app
+wrapper) so it stays correct across Cognee patch releases.
+
+## Step 1 — Generate the files
+
+Create these three files **verbatim** in your working directory.
+
+### `sitecustomize.py`
+
+```python
+# Auto-imported by Python on startup because it sits on PYTHONPATH=/app in the
+# cognee image. Importing the adapter's `register` module here makes the
+# "falkor" graph + vector providers and the falkor_*_local per-dataset handlers
+# resolvable BEFORE Cognee creates any engine — no entrypoint/app edits needed.
+import cognee_community_hybrid_adapter_falkor.register  # noqa: F401
+```
+
+### `Dockerfile`
+
+```dockerfile
+# Custom Cognee image with the FalkorDB hybrid adapter registered.
+# Keeps the stock entrypoint and stock app (cognee.api.client:app); the adapter
+# is activated by sitecustomize.py (auto-imported via PYTHONPATH=/app).
+FROM cognee/cognee:1.1.0
+
+# uv installs into the uv-created venv (which has no pip). --no-deps on the
+# adapter avoids re-resolving the already-installed cognee; its other deps
+# (starlette, instructor) are already present. Install the falkordb client too.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+RUN uv pip install --python /app/.venv/bin/python --no-deps "cognee-community-hybrid-adapter-falkor==0.3.0" \
+ && uv pip install --python /app/.venv/bin/python "falkordb>=1.0.9,<2.0.0"
+
+# Auto-imported on every interpreter start -> registers the FalkorDB adapter.
+COPY sitecustomize.py /app/sitecustomize.py
+
+# Use FalkorDB for BOTH vector and graph, with per-dataset isolation (each
+# dataset -> its own FalkorDB graph keyed by dataset_id) and multi-user access
+# control. URLs point at the "falkordb" compose service; override via env if you
+# rename it or run Cognee outside compose.
+ENV GRAPH_DATABASE_PROVIDER=falkor \
+    GRAPH_DATABASE_URL=falkordb \
+    GRAPH_DATABASE_PORT=6379 \
+    VECTOR_DB_PROVIDER=falkor \
+    VECTOR_DB_URL=falkordb \
+    VECTOR_DB_PORT=6379 \
+    GRAPH_DATASET_DATABASE_HANDLER=falkor_graph_local \
+    VECTOR_DATASET_DATABASE_HANDLER=falkor_vector_local \
+    ENABLE_BACKEND_ACCESS_CONTROL=True
+```
+
+> Version pins: `cognee/cognee:1.1.0` matches this repo. The adapter is pinned to
+> `0.3.0`; the adapter supports `cognee >=1.0.3,<2.0.0`. If the build fails on the
+> adapter install, check the latest compatible version on PyPI
+> (`cognee-community-hybrid-adapter-falkor`) and update the pin — do **not** drop
+> the pin entirely.
+
+### `docker-compose.yaml`
+
+```yaml
+services:
+  falkordb:
+    image: falkordb/falkordb:latest
+    container_name: falkordb
+    ports:
+      - "127.0.0.1:6379:6379"   # FalkorDB/Redis protocol
+      - "127.0.0.1:3001:3000"   # FalkorDB browser UI (optional)
+    volumes:
+      - falkordb_data:/data
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  cognee:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: cognee-falkor:1.1.0
+    container_name: cognee
+    depends_on:
+      falkordb:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:8000:8000"
+    environment:
+      - LLM_API_KEY=${LLM_API_KEY}
+      - AUTO_FEEDBACK=true
+    volumes:
+      - cognee_data:/app/cognee/.cognee_system
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8000/health" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+volumes:
+  falkordb_data:
+  cognee_data:
+```
+
+**Verify (files):** `ls sitecustomize.py Dockerfile docker-compose.yaml` lists all three.
+
+## Step 2 — Build and run
+
+```bash
+export LLM_API_KEY="sk-..."          # required; or put LLM_API_KEY=... in a .env file here
+docker compose up -d --build
+```
+
+**Verify (build & containers):**
+```bash
+docker compose ps          # both 'falkordb' and 'cognee' present
+```
+*If the build failed on the adapter install:* re-read the Dockerfile version pin
+note above, adjust the adapter version, and rerun `docker compose up -d --build`.
+
+## Step 3 — Verify the FalkorDB adapter actually registered (critical)
+
+This is the check that distinguishes a working Falkor backend from a silently
+broken one. Wait for health, then confirm the providers resolve **inside the
+container**:
+
+```bash
+# 1. API healthy (retry for ~60s on first boot while migrations run)
+until curl -fsS http://localhost:8000/health >/dev/null; do sleep 3; done; echo "health OK"
+
+# 2. The 'falkor' providers + per-dataset handlers are registered
+docker exec cognee /app/.venv/bin/python -c "import sitecustomize; \
+from cognee.infrastructure.databases.graph.supported_databases import supported_databases as g; \
+from cognee.infrastructure.databases.vector.supported_databases import supported_databases as v; \
+from cognee.infrastructure.databases.dataset_database_handler.supported_dataset_database_handlers import supported_dataset_database_handlers as h; \
+print('graph falkor:', 'falkor' in g); print('vector falkor:', 'falkor' in v); \
+print('handlers:', [k for k in h if 'falkor' in k])"
+
+# 3. FalkorDB reachable
+docker exec falkordb redis-cli PING        # -> PONG
+```
+
+**Expected:** `graph falkor: True`, `vector falkor: True`,
+`handlers: ['falkor_graph_local', 'falkor_vector_local']`, and `PONG`.
+
+*If `graph falkor: False`:* the adapter didn't register. Confirm
+`docker exec cognee ls /app/sitecustomize.py` exists and that the `uv pip install`
+of `cognee-community-hybrid-adapter-falkor` succeeded in the build logs
+(`docker compose build cognee` and read the output). Fix and rebuild. Do not
+proceed until this prints `True`.
+
+## Step 4 — Point the OpenClaw plugin at this Cognee
+
+The `cognee-openclaw` plugin is backend-agnostic — it only needs the API URL. In
+`~/.openclaw/openclaw.json`:
+
+```json5
+{
+  plugins: {
+    slots: { memory: "cognee-openclaw" },
+    entries: {
+      "cognee-openclaw": {
+        enabled: true,
+        hooks: { allowConversationAccess: true },
+        config: {
+          baseUrl: "http://localhost:8000",
+          // For multiple agents: give each its own graph.
+          agentDatasetPrefix: "openclaw-cognee-agent",
+          recallScopes: ["agent"],
+          defaultWriteScope: "agent"
+        }
+      }
+    }
+  }
+}
+```
+
+**Per-agent graphs:** when the gateway hosts more than one agent
+(`agents.list.length > 1`), the plugin auto-enables per-agent memory — each
+agent's files + chat route to `{agentDatasetPrefix}-{agentId}` (agentId
+lowercased), i.e. its own FalkorDB graph. Give each agent its own `workspace` in
+`agents.list` and seed a one-line `MEMORY.md` in each so its dataset is created
+on gateway start. Force the mode with `perAgentMemory: true|false` if needed.
+
+## Step 5 — Verify end-to-end
+
+```bash
+openclaw gateway stop && openclaw gateway start
+
+# Datasets show up in Cognee as agents become active:
+TOKEN=$(curl -s -X POST http://localhost:8000/api/v1/auth/login \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode username=default_user@example.com \
+  --data-urlencode password=default_password \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['access_token'])")
+curl -s http://localhost:8000/api/v1/datasets -H "Authorization: Bearer $TOKEN"
+
+# One FalkorDB graph per dataset_id:
+docker exec falkordb redis-cli GRAPH.LIST
+```
+
+Chat-derived memory only lands in the graph after the session-cache → `/improve`
+bridge runs (on `session_end`, or force it with
+`openclaw cognee improve --dataset <name>`). For a quick multi-agent isolation
+check: tell agent A something, end its session, ask agent B — B should not know it.
+
+## Operations & cleanup
+
+```bash
+docker compose logs -f cognee      # follow Cognee logs
+docker compose restart cognee      # after env changes
+docker compose down                # stop, keep data
+docker compose down -v             # stop AND wipe Cognee + FalkorDB data
+```
+
+Wipe Cognee data via API (keeps containers), then clear the plugin's local state:
+```bash
+openclaw cognee forget --everything --confirm
+rm -f ~/.openclaw/memory/cognee/*.json
+```
+
+## Gotchas (each has bitten a real setup)
+
+- **Stock image won't work via env vars alone.** Without `sitecustomize.py` importing `register`, `*_PROVIDER=falkor` fails at engine creation. The Step 3 check catches this.
+- **Adapter version drift.** Keep the Dockerfile pin; bump it deliberately if PyPI breaks against the cognee base tag.
+- **Base-image tag.** Bump `cognee/cognee:1.1.0` and the adapter pin together if you move Cognee versions.
+- **`GRAPH_DATABASE_URL` must resolve to the FalkorDB host** — under this compose it's the service name `falkordb`.
+- **Stale plugin state.** If datasets look empty or chat lands in the wrong graph after recreating the server, `rm -f ~/.openclaw/memory/cognee/*.json` and restart the gateway so it rebuilds against the fresh server.
+- **Stable credentials.** If you set `apiKey`/`username` on the plugin, keep them constant — dataset ownership is per-user; switching identities orphans existing datasets.

--- a/integrations/openclaw/src/config.ts
+++ b/integrations/openclaw/src/config.ts
@@ -94,6 +94,12 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
   const defaultWriteScope = raw.defaultWriteScope || DEFAULT_WRITE_SCOPE;
   const scopeRouting = Array.isArray(raw.scopeRouting) ? raw.scopeRouting : DEFAULT_SCOPE_ROUTING;
 
+  // Per-agent memory: opt-in. Explicit config wins. When unset, it defaults to
+  // false here and is auto-enabled in plugin.ts only when the gateway hosts
+  // multiple agents (agents.list.length > 1) — so single-agent installs keep
+  // the legacy shared behavior and are unaffected by the upgrade.
+  const perAgentMemory = typeof raw.perAgentMemory === "boolean" ? raw.perAgentMemory : false;
+
   // Recall injection
   const validPositions = ["prependSystemContext", "appendSystemContext", "prependContext"] as const;
   const recallInjectionPosition = raw.recallInjectionPosition && validPositions.includes(raw.recallInjectionPosition)
@@ -107,7 +113,7 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
   return {
     mode, baseUrl, apiKey, username, password, datasetName,
     companyDataset, userDatasetPrefix, agentDatasetPrefix, agentDatasetTemplate, userId, agentId,
-    recallScopes, defaultWriteScope, scopeRouting,
+    recallScopes, defaultWriteScope, scopeRouting, perAgentMemory,
     recallInjectionPosition,
     enableSessions, persistSessionsAfterEnd,
     searchType, searchPrompt, deleteMode,

--- a/integrations/openclaw/src/persistence.ts
+++ b/integrations/openclaw/src/persistence.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
-import type { DatasetState, MemoryScope, ScopedSyncIndexes, SyncIndex } from "./types.js";
+import type { AgentSyncIndexes, DatasetState, MemoryScope, ScopedSyncIndexes, SyncIndex } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // State file paths
@@ -11,6 +11,7 @@ export const STATE_DIR = join(homedir(), ".openclaw", "memory", "cognee");
 export const STATE_PATH = join(STATE_DIR, "datasets.json");
 export const SYNC_INDEX_PATH = join(STATE_DIR, "sync-index.json");
 export const SCOPED_SYNC_INDEX_PATH = join(STATE_DIR, "scoped-sync-indexes.json");
+export const AGENT_SYNC_INDEX_PATH = join(STATE_DIR, "agent-sync-indexes.json");
 
 // ---------------------------------------------------------------------------
 // Dataset state (maps dataset name -> dataset ID)
@@ -108,4 +109,64 @@ export async function migrateLegacyIndex(defaultScope: MemoryScope): Promise<Sco
   };
   await saveScopedSyncIndexes(scoped);
   return scoped;
+}
+
+// ---------------------------------------------------------------------------
+// Per-agent sync indexes (agent scope, keyed by normalized agentId)
+//
+// The `agent` scope is private per agent, so it lives here instead of in the
+// shared ScopedSyncIndexes. `company`/`user` stay shared in
+// scoped-sync-indexes.json.
+// ---------------------------------------------------------------------------
+
+export async function loadAgentSyncIndexes(): Promise<AgentSyncIndexes> {
+  try {
+    const raw = await fs.readFile(AGENT_SYNC_INDEX_PATH, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    const result: AgentSyncIndexes = {};
+    for (const [agentId, value] of Object.entries(parsed)) {
+      if (value && typeof value === "object") {
+        const idx = value as SyncIndex;
+        idx.entries ??= {};
+        result[agentId] = idx;
+      }
+    }
+    return result;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw error;
+  }
+}
+
+export async function saveAgentSyncIndexes(indexes: AgentSyncIndexes): Promise<void> {
+  await fs.mkdir(dirname(AGENT_SYNC_INDEX_PATH), { recursive: true });
+  await fs.writeFile(AGENT_SYNC_INDEX_PATH, JSON.stringify(indexes, null, 2), "utf-8");
+}
+
+/**
+ * One-time migration: when upgrading to per-agent memory, move any legacy shared
+ * `agent` scope entry from scoped-sync-indexes.json into the per-agent map under
+ * the given agentId, and drop it from the shared file. Idempotent: a no-op once
+ * the agent-sync-indexes file exists or there is no shared agent entry.
+ *
+ * Returns the migrated AgentSyncIndexes if a migration happened, else null.
+ */
+export async function migrateAgentScopeToPerAgent(agentId: string): Promise<AgentSyncIndexes | null> {
+  // Already migrated? (file exists and non-empty)
+  try {
+    await fs.access(AGENT_SYNC_INDEX_PATH);
+    return null;
+  } catch { /* file absent — proceed */ }
+
+  const shared = await loadScopedSyncIndexes();
+  const legacyAgent = shared.agent;
+  if (!legacyAgent || Object.keys(legacyAgent.entries).length === 0) return null;
+
+  const agentIndexes: AgentSyncIndexes = { [agentId]: { ...legacyAgent } };
+  await saveAgentSyncIndexes(agentIndexes);
+
+  delete shared.agent;
+  await saveScopedSyncIndexes(shared);
+  return agentIndexes;
 }

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -1,5 +1,8 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import type { CogneeSearchResult, MemoryScope, ScopedSyncIndexes, SyncIndex } from "./types.js";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { AgentSyncIndexes, CogneeSearchResult, MemoryScope, ScopedSyncIndexes, SyncIndex, SyncResult } from "./types.js";
+// SyncResult is used as the return type of the per-agent sync helpers below.
 import { MEMORY_SCOPES } from "./types.js";
 import { CogneeHttpClient } from "./client.js";
 import { resolveConfig } from "./config.js";
@@ -9,14 +12,25 @@ import {
   loadDatasetState,
   loadScopedSyncIndexes,
   loadSyncIndex,
+  loadAgentSyncIndexes,
   saveDatasetState,
   saveScopedSyncIndexes,
   saveSyncIndex,
+  saveAgentSyncIndexes,
   migrateLegacyIndex,
+  migrateAgentScopeToPerAgent,
   SYNC_INDEX_PATH,
 } from "./persistence.js";
-import { datasetNameForScope, isMultiScopeEnabled, routeFileToScope } from "./scope.js";
+import { datasetNameForScope, isMultiScopeEnabled, normalizeAgentId, routeFileToScope } from "./scope.js";
 import { syncFiles, syncFilesScoped } from "./sync.js";
+
+/** Expand a leading `~` in a workspace path to the user's home directory. */
+function expandHome(p: string | undefined): string | undefined {
+  if (!p) return p;
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return join(homedir(), p.slice(2));
+  return p;
+}
 
 // ---------------------------------------------------------------------------
 // Plugin registration
@@ -39,6 +53,25 @@ const memoryCogneePlugin = {
   kind: "memory" as const,
   register(api: OpenClawPluginApi) {
     const cfg = resolveConfig(api.pluginConfig);
+
+    // Auto-enable per-agent memory when the gateway hosts more than one agent,
+    // unless the plugin config set `perAgentMemory` explicitly. This keeps
+    // single-agent installs (the common case) on the legacy shared behavior so
+    // the upgrade is non-breaking; multi-agent gateways get per-agent isolation.
+    const perAgentExplicit =
+      typeof (api.pluginConfig as { perAgentMemory?: unknown } | undefined)?.perAgentMemory === "boolean";
+    if (!perAgentExplicit) {
+      try {
+        const agentList = api.runtime?.config?.loadConfig?.()?.agents?.list;
+        if (Array.isArray(agentList) && agentList.length > 1) {
+          cfg.perAgentMemory = true;
+          api.logger.info?.(`cognee-openclaw: per-agent memory auto-enabled (${agentList.length} agents configured)`);
+        }
+      } catch (error) {
+        api.logger.debug?.(`cognee-openclaw: could not read agents.list for perAgentMemory auto-enable: ${String(error)}`);
+      }
+    }
+
     const client = new CogneeHttpClient(cfg.baseUrl, cfg.apiKey, cfg.username, cfg.password, cfg.requestTimeoutMs, cfg.ingestionTimeoutMs, cfg.mode);
     const multiScope = isMultiScopeEnabled(cfg);
 
@@ -49,13 +82,45 @@ const memoryCogneePlugin = {
     let datasetId: string | undefined;
     let syncIndex: SyncIndex = { entries: {} };
 
-    // Multi-scope state
+    // Multi-scope state (company/user shared; agent scope lives in agentIndexes
+    // when perAgentMemory is on).
     let scopedIndexes: ScopedSyncIndexes = {};
+
+    // Per-agent agent-scope state (perAgentMemory mode), keyed by normalized agentId.
+    let agentIndexes: AgentSyncIndexes = {};
+    const perAgentMemory = multiScope && cfg.perAgentMemory;
+
+    // Serialize sync work per agent so concurrent turns of the SAME agent don't
+    // double-run. Keyed by normalized agentId.
+    const agentLocks = new Map<string, Promise<unknown>>();
+    function withAgentLock<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
+      const prev = agentLocks.get(agentId) ?? Promise.resolve();
+      const next = prev.catch(() => {}).then(fn);
+      agentLocks.set(agentId, next.catch(() => {}));
+      return next;
+    }
+
+    // Global lock around the read-modify-write of agent-sync-indexes.json.
+    // DIFFERENT agents are NOT serialized by agentLocks, so without this their
+    // concurrent load→mutate→save would clobber each other's bucket (they share
+    // one file). This makes the reload+set+save atomic so distinct buckets merge.
+    let indexSaveChain: Promise<unknown> = Promise.resolve();
+    function withIndexSaveLock<T>(fn: () => Promise<T>): Promise<T> {
+      const next = indexSaveChain.catch(() => {}).then(fn);
+      indexSaveChain = next.catch(() => {});
+      return next;
+    }
 
     // Session state
     let sessionId: string | undefined;
-    // Cached because session_end fires without ctx.
+    // Cached as a fallback for paths that may lack ctx.
     let lastAgentId: string | undefined;
+    let lastWorkspaceDir: string | undefined;
+    // Per-agent workspace cache (normalized agentId -> workspaceDir), populated
+    // on agent_end. session_end's ctx carries agentId but NOT workspaceDir, so
+    // this lets the final sweep find the right agent's workspace without falling
+    // back to a single global (which mis-attributes when >1 agent is active).
+    const agentWorkspaces = new Map<string, string>();
 
     let resolvedWorkspaceDir: string | undefined;
     let resolveServiceReady: (() => void) | undefined;
@@ -88,6 +153,17 @@ const memoryCogneePlugin = {
             }
             scopedIndexes = indexes;
           })
+          .then(async () => {
+            if (!perAgentMemory) return;
+            // Move any legacy shared `agent` scope entry into the per-agent map.
+            const migrated = await migrateAgentScopeToPerAgent(normalizeAgentId(undefined, cfg));
+            if (migrated) {
+              api.logger.info?.("cognee-openclaw: migrated shared agent scope index to per-agent");
+              // Reload shared indexes (migration removed the agent entry from them).
+              scopedIndexes = await loadScopedSyncIndexes();
+            }
+            agentIndexes = await loadAgentSyncIndexes();
+          })
           .catch((error) => {
             api.logger.warn?.(`cognee-openclaw: failed to load scoped sync indexes: ${String(error)}`);
           })
@@ -103,6 +179,16 @@ const memoryCogneePlugin = {
           }),
     ]);
 
+    // Resolve the locally-cached fallback dataset id for a scope. For the agent
+    // scope under perAgentMemory, that's the per-agent index; otherwise the
+    // shared scoped index.
+    function scopeFallbackDatasetId(scope: MemoryScope, runtimeAgentId?: string): string | undefined {
+      if (scope === "agent" && perAgentMemory) {
+        return agentIndexes[normalizeAgentId(runtimeAgentId, cfg)]?.datasetId;
+      }
+      return scopedIndexes[scope]?.datasetId;
+    }
+
     // Fix #8: Log when scopes have no dataset ID during recall
     async function getRecallDatasetIds(
       runtimeAgentId?: string,
@@ -114,7 +200,7 @@ const memoryCogneePlugin = {
       if (multiScope) {
         for (const scope of cfg.recallScopes) {
           const dsName = datasetNameForScope(scope, cfg, runtimeAgentId);
-          const dsId = state[dsName] ?? scopedIndexes[scope]?.datasetId;
+          const dsId = state[dsName] ?? scopeFallbackDatasetId(scope, runtimeAgentId);
           if (dsId) {
             ids.push(dsId);
           } else {
@@ -126,6 +212,91 @@ const memoryCogneePlugin = {
       }
 
       return { ids, missingScopes };
+    }
+
+    // Sync ONE agent's `agent`-scope files from its own workspace into its own
+    // dataset + per-agent index. Serialized per agentId. Used by per-agent mode.
+    async function syncAgentScope(
+      workspaceDir: string,
+      rawAgentId: string | undefined,
+      logger: { info?: (msg: string) => void; warn?: (msg: string) => void },
+    ): Promise<SyncResult> {
+      await stateReady;
+      const agentId = normalizeAgentId(rawAgentId, cfg);
+      return withAgentLock(agentId, async () => {
+        const allFiles = await collectMemoryFiles(workspaceDir);
+        const agentFiles = allFiles.filter(
+          (f) => routeFileToScope(f.path, cfg.scopeRouting, cfg.defaultWriteScope) === "agent",
+        );
+        // Start from this agent's latest persisted bucket.
+        const idx = (await loadAgentSyncIndexes())[agentId] ?? { entries: {} };
+        const dsName = datasetNameForScope("agent", cfg, agentId);
+        // syncFiles mutates `idx` in place (entries/dataIds) but does not persist
+        // it (persistIndex=false); we own persistence below.
+        const result = await syncFiles(client, agentFiles, agentFiles, idx, cfg, logger, dsName, false);
+        // Atomic merge-save: reload the latest on-disk map (may include other
+        // agents' buckets written meanwhile), set just our bucket, save.
+        await withIndexSaveLock(async () => {
+          const latest = await loadAgentSyncIndexes();
+          latest[agentId] = idx;
+          await saveAgentSyncIndexes(latest);
+          agentIndexes = latest;
+        });
+        return result;
+      });
+    }
+
+    // Sync ONLY the shared scopes (company/user) from a workspace. Never run
+    // from a per-agent workspace (it lacks company/user files and would forget
+    // them); only from the default/gateway workspace at startup.
+    async function syncSharedScopes(
+      workspaceDir: string,
+      logger: { info?: (msg: string) => void; warn?: (msg: string) => void },
+    ): Promise<SyncResult> {
+      await stateReady;
+      const files = await collectMemoryFiles(workspaceDir);
+      return syncFilesScoped(client, files, files, scopedIndexes, cfg, logger, undefined, ["company", "user"]);
+    }
+
+    // Seed every configured agent's files from its own workspace (startup/CLI).
+    async function seedAllAgents(
+      defaultWorkspace: string,
+      logger: { info?: (msg: string) => void; warn?: (msg: string) => void },
+    ): Promise<void> {
+      const config = api.runtime?.config?.loadConfig?.();
+      const list = config?.agents?.list as Array<{ id: string; workspace?: string }> | undefined;
+      const defWs = expandHome(config?.agents?.defaults?.workspace) || defaultWorkspace;
+      const agents = Array.isArray(list) && list.length > 0
+        ? list
+        : [{ id: cfg.agentId, workspace: defWs }];
+      for (const a of agents) {
+        const ws = expandHome(a.workspace) || defWs;
+        if (!ws) continue;
+        try {
+          const r = await syncAgentScope(ws, a.id, logger);
+          logger.info?.(`cognee-openclaw: seeded agent "${normalizeAgentId(a.id, cfg)}": ${r.added} added, ${r.updated} updated, ${r.deleted} deleted, ${r.skipped} unchanged`);
+        } catch (e) {
+          logger.warn?.(`cognee-openclaw: failed to seed agent "${a.id}": ${String(e)}`);
+        }
+      }
+    }
+
+    // Resolve an agent's workspace from OpenClaw config (agents.list[].workspace
+    // by agentId), with sensible fallbacks. Used by the per-agent file paths so
+    // startup seeding and the agent_end/session_end sweeps always read the SAME
+    // directory — otherwise a runtime ctx.workspaceDir that differs from the
+    // seed workspace makes the sweep see the seeded file as "missing" and forget
+    // it. Resolving from config (the single source of truth) avoids that.
+    function resolveAgentWorkspace(rawAgentId: string | undefined): string | undefined {
+      const target = normalizeAgentId(rawAgentId, cfg);
+      try {
+        const config = api.runtime?.config?.loadConfig?.();
+        const list = config?.agents?.list as Array<{ id: string; workspace?: string }> | undefined;
+        const match = list?.find((a) => normalizeAgentId(a.id, cfg) === target);
+        return expandHome(match?.workspace) || expandHome(config?.agents?.defaults?.workspace) || resolvedWorkspaceDir;
+      } catch {
+        return resolvedWorkspaceDir;
+      }
     }
 
     async function runSync(
@@ -143,7 +314,12 @@ const memoryCogneePlugin = {
 
       logger.info?.(`cognee-openclaw: found ${files.length} memory file(s), syncing...`);
 
-      if (multiScope) {
+      if (perAgentMemory) {
+        // Per-agent mode: this path syncs only the shared scopes (company/user)
+        // from the given workspace; the `agent` scope is handled per agent via
+        // syncAgentScope/seedAllAgents (each from its own workspace).
+        return syncFilesScoped(client, files, files, scopedIndexes, cfg, logger, runtimeAgentId, ["company", "user"]);
+      } else if (multiScope) {
         return syncFilesScoped(client, files, files, scopedIndexes, cfg, logger, runtimeAgentId);
       } else {
         const result = await syncFiles(client, files, files, syncIndex, cfg, logger);
@@ -156,11 +332,13 @@ const memoryCogneePlugin = {
       datasetId = undefined;
       syncIndex = { entries: {} };
       scopedIndexes = {};
+      agentIndexes = {};
 
       await Promise.all([
         saveDatasetState({}),
         saveSyncIndex({ entries: {} }),
         saveScopedSyncIndexes({}),
+        saveAgentSyncIndexes({}),
       ]);
     }
 
@@ -184,6 +362,7 @@ const memoryCogneePlugin = {
       if (multiScope) {
         let changed = false;
         for (const scope of MEMORY_SCOPES) {
+          if (scope === "agent" && perAgentMemory) continue; // handled per-agent below
           const expectedName = datasetNameForScope(scope, cfg);
           const idx = scopedIndexes[scope];
           const actualName = idx?.datasetName ?? expectedName;
@@ -197,6 +376,20 @@ const memoryCogneePlugin = {
         if (changed) {
           await saveScopedSyncIndexes(scopedIndexes);
         }
+      }
+
+      if (perAgentMemory) {
+        agentIndexes = await loadAgentSyncIndexes();
+        let agentChanged = false;
+        for (const [agentId, idx] of Object.entries(agentIndexes)) {
+          const expectedName = datasetNameForScope("agent", cfg, agentId);
+          const actualName = idx.datasetName ?? expectedName;
+          if (actualName === datasetName || expectedName === datasetName) {
+            delete agentIndexes[agentId];
+            agentChanged = true;
+          }
+        }
+        if (agentChanged) await saveAgentSyncIndexes(agentIndexes);
       }
     }
 
@@ -213,7 +406,24 @@ const memoryCogneePlugin = {
       cognee
         .command("index")
         .description("Sync memory files to Cognee (add new, update changed, skip unchanged)")
-        .action(async () => {
+        .option("--agent <id>", "Per-agent mode: sync only this agent's workspace")
+        .action(async (opts: { agent?: string }) => {
+          if (perAgentMemory) {
+            if (opts.agent) {
+              // Resolve this agent's workspace from config; fall back to cwd.
+              const config = api.runtime?.config?.loadConfig?.();
+              const list = config?.agents?.list as Array<{ id: string; workspace?: string }> | undefined;
+              const match = list?.find((a) => normalizeAgentId(a.id, cfg) === normalizeAgentId(opts.agent, cfg));
+              const ws = expandHome(match?.workspace) || cliWorkspaceDir;
+              const r = await syncAgentScope(ws, opts.agent, ctx.logger);
+              console.log(`Sync complete [agent=${normalizeAgentId(opts.agent, cfg)}]: ${r.added} added, ${r.updated} updated, ${r.deleted} deleted, ${r.skipped} unchanged, ${r.errors} errors`);
+              process.exit(0);
+            }
+            const shared = await runSync(cliWorkspaceDir, ctx.logger);   // company/user
+            await seedAllAgents(cliWorkspaceDir, ctx.logger);            // each agent's own files
+            console.log(`Shared sync complete: ${shared.added} added, ${shared.updated} updated, ${shared.deleted} deleted, ${shared.skipped} unchanged. Per-agent files seeded (see log).`);
+            process.exit(0);
+          }
           const result = await runSync(cliWorkspaceDir, ctx.logger);
           const summary = `Sync complete: ${result.added} added, ${result.updated} updated, ${result.deleted} deleted, ${result.skipped} unchanged, ${result.errors} errors`;
           ctx.logger.info?.(summary);
@@ -230,7 +440,10 @@ const memoryCogneePlugin = {
 
           if (multiScope) {
             const state = await loadDatasetState();
-            for (const scope of MEMORY_SCOPES) {
+            // Shared scopes (company/user). In per-agent mode the agent scope is
+            // reported per-agent below instead of here.
+            const scopesToShow = perAgentMemory ? (["company", "user"] as MemoryScope[]) : MEMORY_SCOPES;
+            for (const scope of scopesToShow) {
               const dsName = datasetNameForScope(scope, cfg);
               const scopeIndex = scopedIndexes[scope] ?? { entries: {} };
               const entryCount = Object.keys(scopeIndex.entries).length;
@@ -249,6 +462,22 @@ const memoryCogneePlugin = {
               console.log(`  Workspace files: ${scopeFiles.length}`);
               console.log(`  New (unindexed): ${newCount}`);
               console.log(`  Changed (dirty): ${dirty}`);
+            }
+
+            if (perAgentMemory) {
+              agentIndexes = await loadAgentSyncIndexes();
+              const config = api.runtime?.config?.loadConfig?.();
+              const list = config?.agents?.list as Array<{ id: string; workspace?: string }> | undefined;
+              const agentKeys = new Set<string>(Object.keys(agentIndexes));
+              for (const a of list ?? []) agentKeys.add(normalizeAgentId(a.id, cfg));
+              if (agentKeys.size === 0) agentKeys.add(normalizeAgentId(undefined, cfg));
+              for (const agentId of agentKeys) {
+                const idx = agentIndexes[agentId] ?? { entries: {} };
+                const dsName = datasetNameForScope("agent", cfg, agentId);
+                console.log(`\n[AGENT:${agentId}] Dataset: ${dsName}`);
+                console.log(`  Dataset ID: ${state[dsName] ?? idx.datasetId ?? "(not set)"}`);
+                console.log(`  Indexed files: ${Object.keys(idx.entries).length}`);
+              }
             }
           } else {
             const entryCount = Object.keys(syncIndex.entries).length;
@@ -475,6 +704,11 @@ const memoryCogneePlugin = {
         try {
           const result = await runSync(resolvedWorkspaceDir, logger);
           logger.info?.(`cognee-openclaw: auto-sync complete: ${result.added} added, ${result.updated} updated, ${result.deleted} deleted, ${result.skipped} unchanged`);
+          // Per-agent mode: seed each configured agent's files from its OWN
+          // workspace (runSync above only handled the shared company/user scopes).
+          if (perAgentMemory) {
+            await seedAllAgents(resolvedWorkspaceDir, logger);
+          }
         } catch (error) {
           logger.warn?.(`cognee-openclaw: auto-sync failed: ${String(error)}`);
         }
@@ -539,7 +773,7 @@ const memoryCogneePlugin = {
 
             const searchPromises = cfg.recallScopes.map(async (scope): Promise<{ scope: MemoryScope; results: CogneeSearchResult[] } | null> => {
               const dsName = datasetNameForScope(scope, cfg, ctx.agentId);
-              const dsId = state[dsName] ?? scopedIndexes[scope]?.datasetId;
+              const dsId = state[dsName] ?? scopeFallbackDatasetId(scope, ctx.agentId);
               if (!dsId) return null;
 
               const results = await client.recall({
@@ -638,12 +872,25 @@ const memoryCogneePlugin = {
         await Promise.all([stateReady, serviceReady]);
 
         lastAgentId = ctx.agentId;
+        lastWorkspaceDir = ctx.workspaceDir || resolvedWorkspaceDir;
         if (cfg.enableSessions && ctx.sessionId) sessionId = ctx.sessionId;
 
-        const workspaceDir = resolvedWorkspaceDir!;
+        const workspaceDir = ctx.workspaceDir || resolvedWorkspaceDir!;
+        // Remember this agent's workspace so session_end can sweep the right one.
+        if (workspaceDir) agentWorkspaces.set(normalizeAgentId(ctx.agentId, cfg), workspaceDir);
 
         try {
-          if (multiScope) {
+          if (perAgentMemory) {
+            // Sync ONLY this agent's agent-scope files from its OWN workspace
+            // into its own dataset + per-agent index. Resolve the workspace from
+            // config (not ctx.workspaceDir) so it matches the startup seed and a
+            // mismatched runtime cwd can't make the sweep "forget" the seed file.
+            const agentWs = resolveAgentWorkspace(ctx.agentId) || workspaceDir;
+            const result = await syncAgentScope(agentWs, ctx.agentId, api.logger);
+            if (result.added || result.updated || result.deleted) {
+              api.logger.info?.(`cognee-openclaw: post-agent sync [agent=${normalizeAgentId(ctx.agentId, cfg)}]: ${result.added} added, ${result.updated} updated, ${result.deleted} deleted`);
+            }
+          } else if (multiScope) {
             try {
               scopedIndexes = await loadScopedSyncIndexes();
             } catch { /* keep cached scopedIndexes */ }
@@ -709,25 +956,49 @@ const memoryCogneePlugin = {
 
       // Final sweep when the openclaw session closes. Catches memory file
       // edits that happened outside an agent_end.
-      api.on("session_end", async (event) => {
+      //
+      // CRITICAL: resolve the agent + session from THIS event's ctx, not the
+      // global lastAgentId. With >1 agent active, lastAgentId is whichever agent
+      // ran most recently, so using it would bridge one agent's session into
+      // another agent's dataset.
+      // PluginHookSessionContext carries agentId + sessionId, so prefer those.
+      api.on("session_end", async (event, ctx) => {
         await Promise.all([stateReady, serviceReady]);
-        if (!resolvedWorkspaceDir) {
-          sessionId = undefined;
-          return;
-        }
-        try {
-          const result = await runSync(resolvedWorkspaceDir, api.logger, lastAgentId);
-          api.logger.info?.(`cognee-openclaw: session-end sync: ${result.added} added, ${result.updated} updated, ${result.deleted} deleted`);
-        } catch (error) {
-          api.logger.warn?.(`cognee-openclaw: session-end sync failed: ${String(error)}`);
+
+        const endAgentId = ctx?.agentId ?? lastAgentId;
+        const endSessionId = ctx?.sessionId ?? event.sessionId;
+        if (!ctx?.agentId) {
+          api.logger.debug?.(`cognee-openclaw: session_end without ctx.agentId; falling back to lastAgentId="${endAgentId ?? "(none)"}"`);
         }
 
-        // Bridge session-cache QAs (including any auto-captured feedback) into the graph.
-        if (cfg.improveOnSessionEnd && event.sessionId) {
-          const dsName = multiScope ? datasetNameForScope("agent", cfg, lastAgentId) : cfg.datasetName;
+        // Per-agent: resolve from config (matches the startup seed). Otherwise
+        // fall back to the cached workspace for this agent.
+        const sweepWorkspace = perAgentMemory
+          ? (resolveAgentWorkspace(endAgentId) || lastWorkspaceDir || resolvedWorkspaceDir)
+          : (agentWorkspaces.get(normalizeAgentId(endAgentId, cfg)) || lastWorkspaceDir || resolvedWorkspaceDir);
+
+        if (sweepWorkspace) {
           try {
-            const result = await client.improve({ datasetName: dsName, sessionIds: [event.sessionId] });
-            api.logger.info?.(`cognee-openclaw: session-end improve dispatched for session ${event.sessionId} (status=${result.status ?? "?"})`);
+            if (perAgentMemory) {
+              // Final sweep for THIS session's agent, from its own workspace.
+              const result = await syncAgentScope(sweepWorkspace, endAgentId, api.logger);
+              api.logger.info?.(`cognee-openclaw: session-end sync [agent=${normalizeAgentId(endAgentId, cfg)}]: ${result.added} added, ${result.updated} updated, ${result.deleted} deleted`);
+            } else {
+              const result = await runSync(sweepWorkspace, api.logger, endAgentId);
+              api.logger.info?.(`cognee-openclaw: session-end sync: ${result.added} added, ${result.updated} updated, ${result.deleted} deleted`);
+            }
+          } catch (error) {
+            api.logger.warn?.(`cognee-openclaw: session-end sync failed: ${String(error)}`);
+          }
+        }
+
+        // Bridge session-cache QAs (including any auto-captured feedback) into
+        // THIS session's agent dataset — keyed by endAgentId + endSessionId.
+        if (cfg.improveOnSessionEnd && endSessionId) {
+          const dsName = multiScope ? datasetNameForScope("agent", cfg, endAgentId) : cfg.datasetName;
+          try {
+            const result = await client.improve({ datasetName: dsName, sessionIds: [endSessionId] });
+            api.logger.info?.(`cognee-openclaw: session-end improve dispatched for session ${endSessionId} -> dataset "${dsName}" (status=${result.status ?? "?"})`);
           } catch (error) {
             api.logger.warn?.(`cognee-openclaw: session-end improve failed: ${error instanceof Error ? error.message : String(error)}`);
           }

--- a/integrations/openclaw/src/scope.ts
+++ b/integrations/openclaw/src/scope.ts
@@ -110,6 +110,19 @@ export function isMultiScopeEnabled(cfg: Required<CogneePluginConfig>): boolean 
 }
 
 /**
+ * Normalize an agent identifier to a stable key.
+ *
+ * OpenClaw lowercases agent ids at runtime (PluginHookAgentContext.agentId is e.g.
+ * "william", not "William"), but config (`agents.list[].id`, `cfg.agentId`) may be
+ * mixed-case. Lowercasing everywhere keeps startup seeding (which reads config)
+ * and runtime hooks (which read ctx.agentId) pointed at the SAME dataset and
+ * the SAME per-agent index bucket — otherwise you get split, e.g. "…-William" vs "…-william".
+ */
+export function normalizeAgentId(agentId: string | undefined, cfg: Required<CogneePluginConfig>): string {
+  return (agentId?.trim() || cfg.agentId || "default").toLowerCase();
+}
+
+/**
  * Resolve the Cognee dataset name for a given memory scope.
  *
  * `runtimeAgentId` lets multi-agent gateways pass the active agent's identity
@@ -130,7 +143,12 @@ export function datasetNameForScope(
         ? `${cfg.userDatasetPrefix}-${cfg.userId || "default"}`
         : `${cfg.datasetName}-user-${cfg.userId || "default"}`;
     case "agent": {
-      const id = runtimeAgentId?.trim() || cfg.agentId || "default";
+      const rawId = runtimeAgentId?.trim() || cfg.agentId || "default";
+      // Lowercase ONLY in per-agent mode, so existing single-agent / non-per-agent
+      // installs keep their exact dataset names (no orphaning on upgrade).
+      // OpenClaw already lowercases the runtime ctx.agentId, so per-agent mode
+      // stays internally consistent across startup-seed and runtime hooks.
+      const id = cfg.perAgentMemory ? rawId.toLowerCase() : rawId;
       if (cfg.agentDatasetTemplate) {
         return cfg.agentDatasetTemplate.replace(/\{agentId\}/g, id);
       }

--- a/integrations/openclaw/src/sync.ts
+++ b/integrations/openclaw/src/sync.ts
@@ -22,6 +22,12 @@ export async function syncFiles(
   cfg: Required<CogneePluginConfig>,
   logger: { info?: (msg: string) => void; warn?: (msg: string) => void },
   overrideDatasetName?: string,
+  /**
+   * Persist the mutated syncIndex to the legacy single-scope file. Callers that
+   * own their own persistence (scoped sync, per-agent sync) pass false so they
+   * don't clobber sync-index.json. Defaults to true for legacy single-scope use.
+   */
+  persistIndex = true,
 ): Promise<SyncResult & { datasetId?: string }> {
   const result: SyncResult = { added: 0, updated: 0, skipped: 0, errors: 0, deleted: 0 };
   const dsName = overrideDatasetName || cfg.datasetName;
@@ -144,7 +150,7 @@ export async function syncFiles(
     }
   }
 
-  await saveSyncIndex(syncIndex);
+  if (persistIndex) await saveSyncIndex(syncIndex);
   return { ...result, datasetId };
 }
 
@@ -160,6 +166,12 @@ export async function syncFilesScoped(
   cfg: Required<CogneePluginConfig>,
   logger: { info?: (msg: string) => void; warn?: (msg: string) => void },
   runtimeAgentId?: string,
+  /**
+   * Restrict processing to these scopes. Used to sync only the shared scopes
+   * (`company`/`user`) from the default workspace when per-agent memory owns
+   * the `agent` scope. When omitted, all scopes are processed (legacy behavior).
+   */
+  onlyScopes?: MemoryScope[],
 ): Promise<SyncResult & { datasetIds: Record<MemoryScope, string | undefined> }> {
   const totalResult: SyncResult = { added: 0, updated: 0, skipped: 0, errors: 0, deleted: 0 };
   const datasetIds: Record<MemoryScope, string | undefined> = { company: undefined, user: undefined, agent: undefined };
@@ -183,12 +195,14 @@ export async function syncFilesScoped(
   }
 
   // Determine which scopes need processing
+  const scopeFilter = onlyScopes ? new Set<MemoryScope>(onlyScopes) : null;
   const allScopes = new Set<MemoryScope>([
     ...changedByScope.keys(),
     ...(Object.keys(scopedIndexes) as MemoryScope[]),
   ]);
 
   for (const scope of allScopes) {
+    if (scopeFilter && !scopeFilter.has(scope)) continue;
     const dsName = datasetNameForScope(scope, cfg, runtimeAgentId);
     const scopeChanged = changedByScope.get(scope) ?? [];
     const scopeFull = fullByScope.get(scope) ?? [];
@@ -205,7 +219,7 @@ export async function syncFilesScoped(
 
     logger.info?.(`cognee-openclaw: [${scope}] syncing ${scopeChanged.length} changed file(s) to dataset "${dsName}"${hasDeletedFiles ? " + deletions" : ""}`);
 
-    const result = await syncFiles(client, scopeChanged, scopeFull, scopeIndex, cfg, logger, dsName);
+    const result = await syncFiles(client, scopeChanged, scopeFull, scopeIndex, cfg, logger, dsName, false);
     totalResult.added += result.added;
     totalResult.updated += result.updated;
     totalResult.skipped += result.skipped;

--- a/integrations/openclaw/src/types.ts
+++ b/integrations/openclaw/src/types.ts
@@ -63,6 +63,15 @@ export type CogneePluginConfig = {
   recallScopes?: MemoryScope[];
   defaultWriteScope?: MemoryScope;
   scopeRouting?: ScopeRoute[];
+  /**
+   * Per-agent memory mode. When enabled, the `agent` scope is keyed by the
+   * runtime agentId: each agent's files are read from its own workspace
+   * (`ctx.workspaceDir`) and tracked in a per-agent sync index, so multiple
+   * agents in one gateway each get their own dataset/graph without colliding.
+   * Defaults to true when multi-scope is active (any agent dataset
+   * prefix/template set). `company`/`user` scopes remain shared.
+   */
+  perAgentMemory?: boolean;
 
   // --- Session ---
   enableSessions?: boolean;
@@ -140,6 +149,13 @@ export type SyncIndex = {
 
 /** Per-scope sync indexes, keyed by MemoryScope */
 export type ScopedSyncIndexes = Partial<Record<MemoryScope, SyncIndex>>;
+
+/**
+ * Per-agent sync indexes for the `agent` scope, keyed by (normalized) agentId.
+ * Each entry tracks that agent's files + its agent-scope dataset id/name.
+ * `company`/`user` scopes stay in ScopedSyncIndexes (shared across agents).
+ */
+export type AgentSyncIndexes = Record<string, SyncIndex>;
 
 export type MemoryFile = {
   /** Relative path from workspace root (e.g. "MEMORY.md", "memory/tools.md") */


### PR DESCRIPTION
This PR enables the OpenClaw integration to handle multiple agents in a way that they each have their own memory, their own graphs, etc.
Also a skill has been added which describes how to generate files and run them to start Falkor as the Cognee backend.
The `skills` directory will hold all such setups in the future.