### PR TITLE
ci: add NMZivkovic to review core-team + trigger on core-team.txt changes

### DIFF
--- a/.github/core-team.txt
+++ b/.github/core-team.txt
@@ -7,5 +7,6 @@ hajdul88
 hande-k
 lxobr
 pazone
+NMZivkovic
 siillee
 vasilije1990

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - 'integrations/**'
       - '.github/workflows/ci.yml'
+      - '.github/core-team.txt'
   push:
     branches: [main]
     paths:
       - 'integrations/**'
       - '.github/workflows/ci.yml'
+      - '.github/core-team.txt'
 
 jobs:
   detect-changes:


### PR DESCRIPTION
Follow-up to #74 (which merged at the staging-fix commit, before these two landed):
- Adds `NMZivkovic` to `.github/core-team.txt` so they get the advisory Claude review.
- Adds `.github/core-team.txt` to `ci.yml` paths so editing the review gate-list re-runs the gated review.

Doubles as the live self-test of the review pipeline on a real PR (you in core-team + `ANTHROPIC_API_KEY` set + the `$HOME/.claude/skills` staging fix already on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)