### PR TITLE
fix: pin cognee version to 1.2.1

### DIFF
--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -94,6 +94,7 @@ _UV_BIN = _UV_DIR / ("uv.exe" if os.name == "nt" else "uv")
 _UV_PYTHON_DIR = _GLOBAL_STATE_DIR / "python"
 _UV_INSTALL_URL = "https://astral.sh/uv/install.sh"
 _PINNED_PYTHON = os.environ.get("COGNEE_PLUGIN_PYTHON", "") or "3.12"
+_PINNED_COGNEE = "cognee==1.2.1"
 _INSTALL_TIMEOUT_SECONDS = float(os.environ.get("COGNEE_INSTALL_TIMEOUT", "") or 600.0)
 
 # Install single-flight. Distinct from the server boot lock (which is short, on
@@ -173,16 +174,16 @@ def _write_venv_ready(version: str) -> None:
 
 
 def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
-    """Ensure the plugin venv exists and holds the latest cognee.
+    """Ensure the plugin venv exists and holds the pinned cognee version.
 
     Called from the server-boot critical section (so it is already
     single-flighted) and only at boot points — i.e. when no healthy server is
-    serving. Always tries to upgrade to the latest cognee BEFORE the server
-    boots, so the server's FastAPI lifespan migrations run on the new code.
+    serving. Always installs the exact pinned version (_PINNED_COGNEE) so the
+    server's FastAPI lifespan migrations run on a known-good release.
 
-    Fails soft: if the upgrade can't run (e.g. offline) but a usable cognee is
-    already installed, returns True with whatever version is present. Returns
-    False only when no importable cognee venv exists afterwards.
+    Fails soft: if the install can't run (e.g. offline) but a usable cognee is
+    already present, returns True with whatever version is there. Returns False
+    only when no importable cognee venv exists afterwards.
     """
     apply_cognee_env()
     for directory in (_COGNEE_SYSTEM_DIR, _COGNEE_DATA_DIR, _COGNEE_CACHE_DIR):
@@ -226,7 +227,7 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
             except FileExistsError:
                 # Another process owns the install. Don't install concurrently —
                 # wait for it to produce a usable venv, then reuse it.
-                if _venv_cognee_version():
+                if _venv_cognee_version() == "1.2.1":
                     return True
                 if time.monotonic() >= deadline:
                     return bool(_venv_cognee_version())
@@ -249,7 +250,15 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
                         timeout=timeout,
                     )
                 subprocess.run(
-                    [uv, "pip", "install", "--upgrade", "--python", str(_VENV_PYTHON), "cognee"],
+                    [
+                        uv,
+                        "pip",
+                        "install",
+                        "--upgrade",
+                        "--python",
+                        str(_VENV_PYTHON),
+                        _PINNED_COGNEE,
+                    ],
                     env=env,
                     check=True,
                     capture_output=True,
@@ -270,7 +279,7 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
                     timeout=timeout,
                 )
                 subprocess.run(
-                    [str(_VENV_PYTHON), "-m", "pip", "install", "--upgrade", "cognee"],
+                    [str(_VENV_PYTHON), "-m", "pip", "install", "--upgrade", _PINNED_COGNEE],
                     check=True,
                     capture_output=True,
                     text=True,

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -93,6 +93,7 @@ _UV_BIN = _UV_DIR / ("uv.exe" if os.name == "nt" else "uv")
 _UV_PYTHON_DIR = _GLOBAL_STATE_DIR / "python"
 _UV_INSTALL_URL = "https://astral.sh/uv/install.sh"
 _PINNED_PYTHON = os.environ.get("COGNEE_PLUGIN_PYTHON", "") or "3.12"
+_PINNED_COGNEE = "cognee==1.2.1"
 _INSTALL_TIMEOUT_SECONDS = float(os.environ.get("COGNEE_INSTALL_TIMEOUT", "") or 600.0)
 
 # Install single-flight. Distinct from the server boot lock (which is short): a
@@ -172,16 +173,16 @@ def _write_venv_ready(version: str) -> None:
 
 
 def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
-    """Ensure the shared plugin venv exists and holds the latest cognee.
+    """Ensure the shared plugin venv exists and holds the pinned cognee version.
 
     Called from the server-boot critical section (so it is already
     single-flighted) and only at boot points — i.e. when no healthy server is
-    serving. Always tries to upgrade to the latest cognee BEFORE the server
-    boots, so the server's FastAPI lifespan migrations run on the new code.
+    serving. Always installs the exact pinned version (_PINNED_COGNEE) so the
+    server's FastAPI lifespan migrations run on a known-good release.
 
-    Fails soft: if the upgrade can't run (e.g. offline) but a usable cognee is
-    already installed, returns True with whatever version is present. Returns
-    False only when no importable cognee venv exists afterwards.
+    Fails soft: if the install can't run (e.g. offline) but a usable cognee is
+    already present, returns True with whatever version is there. Returns False
+    only when no importable cognee venv exists afterwards.
     """
     apply_cognee_env()
     for directory in (_COGNEE_SYSTEM_DIR, _COGNEE_DATA_DIR, _COGNEE_CACHE_DIR):
@@ -225,7 +226,7 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
             except FileExistsError:
                 # Another process owns the install. Don't install concurrently —
                 # wait for it to produce a usable venv, then reuse it.
-                if _venv_cognee_version():
+                if _venv_cognee_version() == "1.2.1":
                     return True
                 if time.monotonic() >= deadline:
                     return bool(_venv_cognee_version())
@@ -248,7 +249,15 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
                         timeout=timeout,
                     )
                 subprocess.run(
-                    [uv, "pip", "install", "--upgrade", "--python", str(_VENV_PYTHON), "cognee"],
+                    [
+                        uv,
+                        "pip",
+                        "install",
+                        "--upgrade",
+                        "--python",
+                        str(_VENV_PYTHON),
+                        _PINNED_COGNEE,
+                    ],
                     env=env,
                     check=True,
                     capture_output=True,
@@ -269,7 +278,7 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
                     timeout=timeout,
                 )
                 subprocess.run(
-                    [str(_VENV_PYTHON), "-m", "pip", "install", "--upgrade", "cognee"],
+                    [str(_VENV_PYTHON), "-m", "pip", "install", "--upgrade", _PINNED_COGNEE],
                     check=True,
                     capture_output=True,
                     text=True,


### PR DESCRIPTION
This PR pins the cognee version in Claude and Codex integrations to 1.2.1, preventing accidental breakage when cognee updates happen.