### PR TITLE
fix(recall): query the HTTP server first, don't trust empty CLI output

### DIFF
--- a/integrations/claude-code/agents/cognee-recall.md
+++ b/integrations/claude-code/agents/cognee-recall.md
@@ -40,15 +40,18 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "<query>" 10 --graph
 **Ground-truth (if a result is empty but you expect content) — authoritative:**
 ```bash
 curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
-  -H "Content-Type: application/json" ${COGNEE_API_KEY:+-H "X-Api-Key: $COGNEE_API_KEY"} \
-  -d "{\"query\": \"<query>\", \"top_k\": 10, \"only_context\": true, \"scope\": [\"graph\"]}"
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: ${COGNEE_API_KEY:-}" \
+  -d '{"query": "<query>", "top_k": 10, "only_context": true, "scope": ["graph"]}'
 ```
+
+Category filtering uses `node_name` on the same call (the CLI doesn't expose it): add `"node_name": ["project_docs"]` (or `user_context` / `agent_actions`).
 
 ## The server is the source of truth (read this before reporting "not found")
 
 - **An empty result is only valid if it came from the server.** `cognee-cli` is a thin client over the same server and can print empty stdout even when content exists. **Never conclude "not found" from an empty/clean CLI run** — confirm with the `curl` above first.
 - **Do not re-run the same search to "retry."** One server answer is authoritative — report it and stop. (Re-running the CLI and chasing async warnings is how a confident-but-wrong "nothing found" verdict gets produced.)
-- Category filtering (`--node-set user_context|project_docs|agent_actions`) is optional and hits the same server.
+- **If the output is an `{"error": ...}` object instead of a list**, the server was reachable but rejected/failed the request (e.g. auth) — report that error and check `COGNEE_API_KEY`. It is **not** "no results", and the wrapper deliberately does **not** fall back to the local CLI in that case.
 
 ## Output
 

--- a/integrations/claude-code/agents/cognee-recall.md
+++ b/integrations/claude-code/agents/cognee-recall.md
@@ -25,35 +25,35 @@ Cognee organizes knowledge into three categories:
 
 ## Search commands
 
-**More session context:**
+Always search via the wrapper — it queries the **running server first** (`/api/v1/recall`, the source of truth), searches **all authorized datasets** (so a hit isn't missed because it's in another dataset), and falls back to `cognee-cli` only if the server is unreachable.
+
+**Session context:**
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "<query>" 10 --session
 ```
 
-**Permanent graph (all categories):**
+**Permanent graph:**
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "<query>" 10 --graph
 ```
 
-**Permanent graph (specific category):**
+**Ground-truth (if a result is empty but you expect content) — authoritative:**
 ```bash
-cognee-cli recall "<query>" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set user_context -k 10 -f json
-cognee-cli recall "<query>" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set project_docs -k 10 -f json
-cognee-cli recall "<query>" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set agent_actions -k 10 -f json
+curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
+  -H "Content-Type: application/json" ${COGNEE_API_KEY:+-H "X-Api-Key: $COGNEE_API_KEY"} \
+  -d "{\"query\": \"<query>\", \"top_k\": 10, \"only_context\": true, \"scope\": [\"graph\"]}"
 ```
 
-## Routing
+## The server is the source of truth (read this before reporting "not found")
 
-Determine which category to search based on the query:
-- "my preferences" / "how I like" / "what I told you" → `user_context`
-- "the codebase" / "architecture" / "project docs" → `project_docs`
-- "what we did" / "previous actions" / "tool results" → `agent_actions`
-- General or unclear → search all (no `--node-set` filter)
+- **An empty result is only valid if it came from the server.** `cognee-cli` is a thin client over the same server and can print empty stdout even when content exists. **Never conclude "not found" from an empty/clean CLI run** — confirm with the `curl` above first.
+- **Do not re-run the same search to "retry."** One server answer is authoritative — report it and stop. (Re-running the CLI and chasing async warnings is how a confident-but-wrong "nothing found" verdict gets produced.)
+- Category filtering (`--node-set user_context|project_docs|agent_actions`) is optional and hits the same server.
 
 ## Output
 
-Parse the JSON results. Results with `"_source": "session"` came from the current session; `"_source": "graph"` came from the permanent knowledge graph. Return a concise summary organized by relevance, indicating the source and category.
+Parse the JSON results (`"_source": "session"` = current session; `"_source": "graph"` = permanent graph). Return a concise summary by relevance, noting the source.
 
-If no results are found, suggest:
+If the **server** genuinely returns nothing, then suggest:
 - `/cognee-memory:cognee-sync` to sync session data to the permanent graph
 - `/cognee-memory:cognee-remember` to ingest new data

--- a/integrations/claude-code/scripts/_recall_http.py
+++ b/integrations/claude-code/scripts/_recall_http.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Server-first recall against Cognee's ``/api/v1/recall``.
+
+Standalone, stdlib-only, so it runs under the system ``python3`` without the
+plugin venv (the same constraint ``cognee-search.sh`` already works under).
+
+Contract — what gets printed to stdout:
+  * a JSON **list** on a 2xx response. An **empty list is authoritative**:
+    the server searched and found nothing.
+  * the sentinel ``UNREACHABLE`` on ANY non-2xx status, an error-shaped
+    response body, or a connection failure. A server failure (5xx), a bad
+    request (4xx), or an auth rejection is **not** an authoritative "no
+    results" — the caller must fall back to the CLI and warn the user rather
+    than report a false negative.
+
+Diagnostics go to stderr so the caller can surface them.
+"""
+import json
+import sys
+import urllib.error
+import urllib.request
+
+UNREACHABLE = "UNREACHABLE"
+
+
+def coerce_top_k(value, default=5):
+    """Best-effort positive int; never raises (a bad value must not look like a server failure)."""
+    try:
+        n = int(str(value).strip())
+    except (TypeError, ValueError, AttributeError):
+        return default
+    return n if n > 0 else default
+
+
+def coerce_scope(value, default="auto"):
+    """Parse the JSON scope arg; fall back to "auto" on anything malformed."""
+    if not value:
+        return default
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def do_recall(
+    service_url,
+    api_key,
+    query,
+    session_id,
+    scope,
+    top_k,
+    *,
+    opener=urllib.request.urlopen,
+    timeout=20.0,
+):
+    """Query the server. Return a list of results (possibly empty) or ``UNREACHABLE``."""
+    url = service_url.rstrip("/") + "/api/v1/recall"
+    body = {
+        "query": query,
+        "top_k": coerce_top_k(top_k),
+        "only_context": True,
+        "scope": coerce_scope(scope),
+    }
+    if session_id:
+        body["session_id"] = session_id
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["X-Api-Key"] = api_key
+
+    req = urllib.request.Request(
+        url, data=json.dumps(body).encode("utf-8"), headers=headers, method="POST"
+    )
+    try:
+        with opener(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8") or "[]")
+    except urllib.error.HTTPError as e:
+        # Non-2xx (5xx outage, 4xx bad request, 401/403 auth) is a failure, NOT
+        # an authoritative empty result. Surface it and signal fallback.
+        sys.stderr.write(
+            "[cognee-search] server HTTP %s for /api/v1/recall — not authoritative, falling back\n"
+            % e.code
+        )
+        return UNREACHABLE
+    except Exception as e:  # URLError, timeout, JSON decode, etc.
+        sys.stderr.write(
+            "[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+        )
+        return UNREACHABLE
+
+    # An error-shaped 2xx body is also not a real result set.
+    if isinstance(data, dict) and data.get("error"):
+        sys.stderr.write(
+            "[cognee-search] server returned error: %s\n" % str(data.get("error"))[:160]
+        )
+        return UNREACHABLE
+    if isinstance(data, list):
+        return data
+    return [data]
+
+
+def main(argv):
+    # argv: service_url, api_key, query, session_id, scope, top_k
+    a = list(argv) + [""] * 6
+    result = do_recall(a[0], a[1], a[2], a[3], a[4], a[5])
+    print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/integrations/claude-code/scripts/_recall_http.py
+++ b/integrations/claude-code/scripts/_recall_http.py
@@ -20,6 +20,7 @@ Contract — what gets printed to stdout:
 
 Diagnostics also go to stderr so the caller can surface them.
 """
+
 import json
 import sys
 import urllib.error

--- a/integrations/claude-code/scripts/_recall_http.py
+++ b/integrations/claude-code/scripts/_recall_http.py
@@ -7,13 +7,18 @@ plugin venv (the same constraint ``cognee-search.sh`` already works under).
 Contract — what gets printed to stdout:
   * a JSON **list** on a 2xx response. An **empty list is authoritative**:
     the server searched and found nothing.
-  * the sentinel ``UNREACHABLE`` on ANY non-2xx status, an error-shaped
-    response body, or a connection failure. A server failure (5xx), a bad
-    request (4xx), or an auth rejection is **not** an authoritative "no
-    results" — the caller must fall back to the CLI and warn the user rather
-    than report a false negative.
+  * the sentinel ``UNREACHABLE`` ONLY when the server cannot be reached
+    (connection refused, timeout, DNS). The caller may then fall back to the
+    local CLI as a degraded path.
+  * a JSON **error object** ``{"error", "status", "authoritative": false}`` on
+    any HTTP error (5xx, 4xx, and especially **401/403** auth rejections) or an
+    error-shaped 2xx body. The caller MUST NOT fall back to the local CLI here:
+    the server was reachable and rejected/failed the request, so falling back to
+    a (possibly different / local) backend would return wrong data or bypass the
+    server-side authorization boundary. It is reported as an error, never as
+    "no results".
 
-Diagnostics go to stderr so the caller can surface them.
+Diagnostics also go to stderr so the caller can surface them.
 """
 import json
 import sys
@@ -42,6 +47,14 @@ def coerce_scope(value, default="auto"):
         return default
 
 
+def _error(status, message):
+    """An error envelope — reachable server, but the request was rejected/failed.
+
+    Distinct from UNREACHABLE so the caller does NOT fall back to the local CLI.
+    """
+    return {"error": message, "status": status, "authoritative": False}
+
+
 def do_recall(
     service_url,
     api_key,
@@ -53,7 +66,7 @@ def do_recall(
     opener=urllib.request.urlopen,
     timeout=20.0,
 ):
-    """Query the server. Return a list of results (possibly empty) or ``UNREACHABLE``."""
+    """Query the server. Return results (list), an error envelope (dict), or ``UNREACHABLE``."""
     url = service_url.rstrip("/") + "/api/v1/recall"
     body = {
         "query": query,
@@ -74,14 +87,15 @@ def do_recall(
         with opener(req, timeout=timeout) as resp:
             data = json.loads(resp.read().decode("utf-8") or "[]")
     except urllib.error.HTTPError as e:
-        # Non-2xx (5xx outage, 4xx bad request, 401/403 auth) is a failure, NOT
-        # an authoritative empty result. Surface it and signal fallback.
-        sys.stderr.write(
-            "[cognee-search] server HTTP %s for /api/v1/recall — not authoritative, falling back\n"
-            % e.code
-        )
-        return UNREACHABLE
-    except Exception as e:  # URLError, timeout, JSON decode, etc.
+        # Reachable but rejected/failed. NOT an authoritative empty, and NOT a
+        # reason to query a different backend via the CLI — report the error.
+        if e.code in (401, 403):
+            msg = "unauthorized (HTTP %s) — check COGNEE_API_KEY / credentials" % e.code
+        else:
+            msg = "server returned HTTP %s for /api/v1/recall" % e.code
+        sys.stderr.write("[cognee-search] %s — NOT falling back to local CLI\n" % msg)
+        return _error(e.code, msg)
+    except Exception as e:  # URLError, timeout, JSON decode, etc. → genuinely unreachable
         sys.stderr.write(
             "[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
         )
@@ -89,10 +103,9 @@ def do_recall(
 
     # An error-shaped 2xx body is also not a real result set.
     if isinstance(data, dict) and data.get("error"):
-        sys.stderr.write(
-            "[cognee-search] server returned error: %s\n" % str(data.get("error"))[:160]
-        )
-        return UNREACHABLE
+        msg = str(data.get("error"))[:200]
+        sys.stderr.write("[cognee-search] server returned error: %s\n" % msg)
+        return _error(200, msg)
     if isinstance(data, list):
         return data
     return [data]
@@ -102,6 +115,8 @@ def main(argv):
     # argv: service_url, api_key, query, session_id, scope, top_k
     a = list(argv) + [""] * 6
     result = do_recall(a[0], a[1], a[2], a[3], a[4], a[5])
+    # UNREACHABLE → caller falls back to CLI; a list (results) or an error
+    # object → caller prints as-is and does NOT fall back.
     print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
 
 

--- a/integrations/claude-code/scripts/cognee-search.sh
+++ b/integrations/claude-code/scripts/cognee-search.sh
@@ -152,39 +152,15 @@ case "$MODE" in
 esac
 
 # Server-first: the running server (/api/v1/recall) is the source of truth.
-# An empty result from the server is authoritative; fall back to cognee-cli ONLY
-# when the server is genuinely unreachable — never to "rescue" an empty result.
-RECALL_JSON="$(python3 - "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$DATASET" "$TOP_K" "$SCOPE" <<'PY' 2>/dev/null || true
-import json, sys, urllib.request, urllib.error
-a = (sys.argv + [""] * 7)
-service_url, api_key, query, session_id, dataset, top_k, scope = a[1], a[2], a[3], a[4], a[5], a[6], a[7]
-url = service_url.rstrip("/") + "/api/v1/recall"
-body = {"query": query, "top_k": int(top_k or 5), "only_context": True, "scope": json.loads(scope or '"auto"')}
-if session_id:
-    body["session_id"] = session_id
-# No `datasets` restriction: search ALL the user's authorized datasets (matches the
-# auto-recall path that ground-truths content). Restricting to the plugin's default
-# dataset is exactly what produced false "not found" verdicts when the content lived
-# in another dataset.
-headers = {"Content-Type": "application/json"}
-if api_key:
-    headers["X-Api-Key"] = api_key
-req = urllib.request.Request(url, data=json.dumps(body).encode("utf-8"), headers=headers, method="POST")
-try:
-    with urllib.request.urlopen(req, timeout=20.0) as resp:
-        data = json.loads(resp.read().decode("utf-8") or "[]")
-    print(json.dumps(data if isinstance(data, list) else [data]))
-except urllib.error.HTTPError as e:
-    if e.code in (401, 403):
-        sys.stderr.write("[cognee-search] auth failed (HTTP %s) — check COGNEE_API_KEY\n" % e.code)
-    else:
-        sys.stderr.write("[cognee-search] server HTTP %s for /api/v1/recall (treating as no results)\n" % e.code)
-    print("[]")
-except Exception as e:
-    sys.stderr.write("[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160]))
-    print("UNREACHABLE")
-PY
-)"
+# Only a 2xx response is authoritative (an empty list = genuinely no hits).
+# Any non-2xx / error / unreachable returns the UNREACHABLE sentinel so we fall
+# back to cognee-cli and warn — never reporting a server failure as "not found".
+# `datasets` is intentionally NOT sent: the server scopes to the caller's
+# read-authorized datasets, so search spans them all (restricting to the plugin
+# default is what produced false "not found" when content lived elsewhere).
+# Logic lives in _recall_http.py (stdlib-only, unit-tested); stderr is surfaced.
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+RECALL_JSON="$(python3 "${SELF_DIR}/_recall_http.py" "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$SCOPE" "$TOP_K" || true)"
 
 if [ -n "$RECALL_JSON" ] && [ "$RECALL_JSON" != "UNREACHABLE" ]; then
     # Server answered — authoritative, even if the result is empty.

--- a/integrations/claude-code/scripts/cognee-search.sh
+++ b/integrations/claude-code/scripts/cognee-search.sh
@@ -86,7 +86,7 @@ if service_url and api_key:
     except (urllib.error.URLError, TimeoutError, OSError, ValueError, json.JSONDecodeError):
         pass
 
-print(json.dumps({"session_id": session_id, "dataset": dataset}))
+print(json.dumps({"session_id": session_id, "dataset": dataset, "service_url": service_url, "api_key": api_key}))
 PY
 )"
 
@@ -106,8 +106,26 @@ except Exception:
     pass
 PY
 )"
+SERVICE_URL="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("service_url") or "").strip())
+except Exception:
+    pass
+PY
+)"
+API_KEY="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("api_key") or "").strip())
+except Exception:
+    pass
+PY
+)"
 [ -z "$DATASET" ] && DATASET="${COGNEE_PLUGIN_DATASET:-claude_sessions}"
 [ -z "$SESSION_ID" ] && SESSION_ID="${COGNEE_SESSION_ID:-claude_session}"
+[ -z "$SERVICE_URL" ] && SERVICE_URL="${COGNEE_BASE_URL:-${COGNEE_LOCAL_API_URL:-http://localhost:8011}}"
+[ -z "$API_KEY" ] && API_KEY="${COGNEE_API_KEY:-}"
 
 QUERY="${1:-}"
 TOP_K="${2:-5}"
@@ -126,16 +144,63 @@ if [ -z "$QUERY" ]; then
     exit 1
 fi
 
-if [ "$MODE" = "graph" ]; then
-    cognee-cli recall "$QUERY" -d "$DATASET" -k "$TOP_K" -f json 2>/dev/null
-elif [ "$MODE" = "session" ]; then
-    cognee-cli recall "$QUERY" -s "$SESSION_ID" -k "$TOP_K" -f json 2>/dev/null
+# Search scope from MODE
+case "$MODE" in
+    session) SCOPE='["session"]' ;;
+    graph)   SCOPE='["graph"]' ;;
+    *)       SCOPE='["session", "graph"]' ;;
+esac
+
+# Server-first: the running server (/api/v1/recall) is the source of truth.
+# An empty result from the server is authoritative; fall back to cognee-cli ONLY
+# when the server is genuinely unreachable — never to "rescue" an empty result.
+RECALL_JSON="$(python3 - "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$DATASET" "$TOP_K" "$SCOPE" <<'PY' 2>/dev/null || true
+import json, sys, urllib.request, urllib.error
+a = (sys.argv + [""] * 7)
+service_url, api_key, query, session_id, dataset, top_k, scope = a[1], a[2], a[3], a[4], a[5], a[6], a[7]
+url = service_url.rstrip("/") + "/api/v1/recall"
+body = {"query": query, "top_k": int(top_k or 5), "only_context": True, "scope": json.loads(scope or '"auto"')}
+if session_id:
+    body["session_id"] = session_id
+# No `datasets` restriction: search ALL the user's authorized datasets (matches the
+# auto-recall path that ground-truths content). Restricting to the plugin's default
+# dataset is exactly what produced false "not found" verdicts when the content lived
+# in another dataset.
+headers = {"Content-Type": "application/json"}
+if api_key:
+    headers["X-Api-Key"] = api_key
+req = urllib.request.Request(url, data=json.dumps(body).encode("utf-8"), headers=headers, method="POST")
+try:
+    with urllib.request.urlopen(req, timeout=20.0) as resp:
+        data = json.loads(resp.read().decode("utf-8") or "[]")
+    print(json.dumps(data if isinstance(data, list) else [data]))
+except urllib.error.HTTPError as e:
+    if e.code in (401, 403):
+        sys.stderr.write("[cognee-search] auth failed (HTTP %s) — check COGNEE_API_KEY\n" % e.code)
+    else:
+        sys.stderr.write("[cognee-search] server HTTP %s for /api/v1/recall (treating as no results)\n" % e.code)
+    print("[]")
+except Exception as e:
+    sys.stderr.write("[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160]))
+    print("UNREACHABLE")
+PY
+)"
+
+if [ -n "$RECALL_JSON" ] && [ "$RECALL_JSON" != "UNREACHABLE" ]; then
+    # Server answered — authoritative, even if the result is empty.
+    printf '%s\n' "$RECALL_JSON"
 else
-    # Auto: try session first, fall back to graph
-    RESULT=$(cognee-cli recall "$QUERY" -s "$SESSION_ID" -k "$TOP_K" -f json 2>/dev/null)
-    if [ -n "$RESULT" ] && [ "$RESULT" != "[]" ]; then
-        echo "$RESULT"
+    echo "[cognee-search] falling back to cognee-cli (degraded — empty CLI output is NOT proof of absence; ground-truth via: curl -X POST \"\$COGNEE_BASE_URL/api/v1/recall\")" >&2
+    if [ "$MODE" = "graph" ]; then
+        cognee-cli recall "$QUERY" -d "$DATASET" -k "$TOP_K" -f json 2>/dev/null || true
+    elif [ "$MODE" = "session" ]; then
+        cognee-cli recall "$QUERY" -s "$SESSION_ID" -k "$TOP_K" -f json 2>/dev/null || true
     else
-        cognee-cli recall "$QUERY" -d "$DATASET" -k "$TOP_K" -f json 2>/dev/null
+        RESULT=$(cognee-cli recall "$QUERY" -s "$SESSION_ID" -k "$TOP_K" -f json 2>/dev/null || true)
+        if [ -n "$RESULT" ] && [ "$RESULT" != "[]" ]; then
+            echo "$RESULT"
+        else
+            cognee-cli recall "$QUERY" -d "$DATASET" -k "$TOP_K" -f json 2>/dev/null || true
+        fi
     fi
 fi

--- a/integrations/claude-code/skills/cognee-search/SKILL.md
+++ b/integrations/claude-code/skills/cognee-search/SKILL.md
@@ -40,10 +40,13 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "$ARGUMENTS" 10 --session
 
 ### Filter by category (optional)
 
-Categories (`user_context` / `project_docs` / `agent_actions`) filter by `node_set`, currently exposed via the CLI (same server backend):
+Categories (`user_context` / `project_docs` / `agent_actions`) filter by node set. `cognee-cli recall` does **not** expose this — pass `node_name` to the server directly:
 
 ```bash
-cognee-cli recall "$ARGUMENTS" --node-set project_docs -k 5 -f json
+curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: ${COGNEE_API_KEY:-}" \
+  -d '{"query": "...", "top_k": 5, "only_context": true, "scope": ["graph"], "node_name": ["project_docs"]}'
 ```
 
 ### Ground-truth a suspicious result (debugging)
@@ -52,9 +55,12 @@ The server is authoritative. If a search returns empty but you expect content, c
 
 ```bash
 curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
-  -H "Content-Type: application/json" ${COGNEE_API_KEY:+-H "X-Api-Key: $COGNEE_API_KEY"} \
-  -d "{\"query\": \"$ARGUMENTS\", \"top_k\": 5, \"only_context\": true, \"scope\": [\"graph\"]}"
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: ${COGNEE_API_KEY:-}" \
+  -d '{"query": "...", "top_k": 5, "only_context": true, "scope": ["graph"]}'
 ```
+
+(An authed/cloud server needs `COGNEE_API_KEY`; a local single-user server ignores an empty key. If the response is an `{"error": ...}` object rather than a list, the server was reachable but rejected/failed the request — that's an error, **not** "no results".)
 
 ### Fallback only — server unreachable
 
@@ -79,6 +85,6 @@ Session entries tagged with `[category:agent]` are automatic tool call logs.
 | Need current session context | Already automatic, no action needed |
 | User explicitly says "search cognee" | `cognee-search.sh "<query>"` (server-first) |
 | "what does the codebase do" / "what did we do last time" | `cognee-search.sh "<query>" 10 --graph` |
-| Need a specific category | add `--node-set {user_context\|project_docs\|agent_actions}` via the CLI form |
+| Need a specific category | use the `node_name` curl form above (`["user_context"\|"project_docs"\|"agent_actions"]`) |
 | Auto context insufficient | `cognee-search.sh "<query>" 10 --session` |
 | **Result empty but you expect content** | **Ground-truth via the `curl` above before concluding "not found"** |

--- a/integrations/claude-code/skills/cognee-search/SKILL.md
+++ b/integrations/claude-code/skills/cognee-search/SKILL.md
@@ -23,35 +23,45 @@ Knowledge is organized into three categories via `node_set`:
 
 ## Instructions
 
-### Search session memory (current session, more results)
+Search goes through the **running Cognee server** (`POST /api/v1/recall`) — the source of truth. Use the wrapper below: it queries the server first, searches **all your authorized datasets** (so a hit isn't missed because it lives in another dataset), and falls back to `cognee-cli` only if the server is unreachable.
+
+### Search (server-first)
 
 ```bash
-cognee-cli recall "$ARGUMENTS" -s "${COGNEE_SESSION_ID:-claude_code_session}" -k 10 -f json
-```
-
-### Search permanent graph (all categories)
-
-```bash
-cognee-cli recall "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" -k 5 -f json
-```
-
-### Search permanent graph (specific category)
-
-```bash
-# User data only
-cognee-cli recall "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set user_context -k 5 -f json
-
-# Project data only
-cognee-cli recall "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set project_docs -k 5 -f json
-
-# Agent data only
-cognee-cli recall "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set agent_actions -k 5 -f json
-```
-
-### Search both (session first, fallback to graph)
-
-```bash
+# session cache + permanent graph (default)
 ${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "$ARGUMENTS"
+
+# permanent graph only
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "$ARGUMENTS" 10 --graph
+
+# current session only
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "$ARGUMENTS" 10 --session
+```
+
+### Filter by category (optional)
+
+Categories (`user_context` / `project_docs` / `agent_actions`) filter by `node_set`, currently exposed via the CLI (same server backend):
+
+```bash
+cognee-cli recall "$ARGUMENTS" --node-set project_docs -k 5 -f json
+```
+
+### Ground-truth a suspicious result (debugging)
+
+The server is authoritative. If a search returns empty but you expect content, confirm directly — **do not** conclude "not found" from empty CLI output:
+
+```bash
+curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
+  -H "Content-Type: application/json" ${COGNEE_API_KEY:+-H "X-Api-Key: $COGNEE_API_KEY"} \
+  -d "{\"query\": \"$ARGUMENTS\", \"top_k\": 5, \"only_context\": true, \"scope\": [\"graph\"]}"
+```
+
+### Fallback only — server unreachable
+
+`cognee-cli` is a thin client over the same server and can print **empty stdout even when content exists**. Use it only when the server is down, and treat empty output as *inconclusive*, never as "no results":
+
+```bash
+cognee-cli recall "$ARGUMENTS" -k 5 -f json
 ```
 
 ## Understanding results
@@ -67,8 +77,8 @@ Session entries tagged with `[category:agent]` are automatic tool call logs.
 | Signal | Action |
 |--------|--------|
 | Need current session context | Already automatic, no action needed |
-| "what are my preferences" | Search graph with `--node-set user_context` |
-| "what does the codebase do" | Search graph with `--node-set project_docs` |
-| "what did we do last time" | Search graph (all categories) with `-d` |
-| User explicitly says "search cognee" | Search graph with `-d` |
-| Auto context insufficient | Search session with `-s -k 10` |
+| User explicitly says "search cognee" | `cognee-search.sh "<query>"` (server-first) |
+| "what does the codebase do" / "what did we do last time" | `cognee-search.sh "<query>" 10 --graph` |
+| Need a specific category | add `--node-set {user_context\|project_docs\|agent_actions}` via the CLI form |
+| Auto context insufficient | `cognee-search.sh "<query>" 10 --session` |
+| **Result empty but you expect content** | **Ground-truth via the `curl` above before concluding "not found"** |

--- a/integrations/claude-code/tests/test_recall_http.py
+++ b/integrations/claude-code/tests/test_recall_http.py
@@ -12,6 +12,7 @@ Covers the contract from the PR reviews:
 Run: `pytest integrations/claude-code/tests/test_recall_http.py`
 (or `python integrations/claude-code/tests/test_recall_http.py` standalone).
 """
+
 import pathlib
 import sys
 import urllib.error
@@ -54,18 +55,21 @@ def test_empty_list_is_authoritative():
 
 
 def test_list_results_passthrough():
-    assert rh.do_recall("http://x", "", "q", "", '["graph"]', "5",
-                        opener=_returns('[{"text": "hit"}]')) == [{"text": "hit"}]
+    assert rh.do_recall(
+        "http://x", "", "q", "", '["graph"]', "5", opener=_returns('[{"text": "hit"}]')
+    ) == [{"text": "hit"}]
 
 
 def test_non_error_dict_is_wrapped():
-    assert rh.do_recall("http://x", "", "q", "", '["graph"]', "5",
-                        opener=_returns('{"answer": "x"}')) == [{"answer": "x"}]
+    assert rh.do_recall(
+        "http://x", "", "q", "", '["graph"]', "5", opener=_returns('{"answer": "x"}')
+    ) == [{"answer": "x"}]
 
 
 def test_error_dict_is_error_envelope_not_fallback():
-    out = rh.do_recall("http://x", "", "q", "", '["graph"]', "5",
-                       opener=_returns('{"error": "bad request"}'))
+    out = rh.do_recall(
+        "http://x", "", "q", "", '["graph"]', "5", opener=_returns('{"error": "bad request"}')
+    )
     assert isinstance(out, dict) and out.get("authoritative") is False
     assert out != rh.UNREACHABLE  # must NOT trigger CLI fallback
 
@@ -82,13 +86,24 @@ def test_http_401_403_auth_is_error_envelope_not_fallback():
         err = urllib.error.HTTPError("http://x", code, "denied", {}, None)
         out = rh.do_recall("http://x", "k", "q", "", '["graph"]', "5", opener=_raises(err))
         assert isinstance(out, dict) and out["status"] == code
-        assert out != rh.UNREACHABLE  # auth failure must NOT fall back (would bypass authz / wrong data)
+        # auth failure must NOT fall back to local CLI (would bypass authz / return wrong data)
+        assert out != rh.UNREACHABLE
 
 
 def test_connection_error_is_unreachable():
     # Only a genuine connection failure may fall back to the local CLI.
-    assert rh.do_recall("http://x", "", "q", "", '["graph"]', "5",
-                        opener=_raises(urllib.error.URLError("refused"))) == rh.UNREACHABLE
+    assert (
+        rh.do_recall(
+            "http://x",
+            "",
+            "q",
+            "",
+            '["graph"]',
+            "5",
+            opener=_raises(urllib.error.URLError("refused")),
+        )
+        == rh.UNREACHABLE
+    )
 
 
 def test_coerce_top_k():

--- a/integrations/claude-code/tests/test_recall_http.py
+++ b/integrations/claude-code/tests/test_recall_http.py
@@ -1,0 +1,106 @@
+"""Unit tests for the server-first recall helper (_recall_http.py).
+
+Covers the contract that the PR review flagged:
+- a 2xx empty list is AUTHORITATIVE (not a fallback trigger);
+- any non-2xx / error body / connection failure -> UNREACHABLE (fallback);
+- top_k / scope coercion never raises.
+
+Run: `pytest integrations/claude-code/tests/test_recall_http.py`
+(or `python integrations/claude-code/tests/test_recall_http.py` standalone).
+"""
+import pathlib
+import sys
+import urllib.error
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+import _recall_http as rh  # noqa: E402
+
+
+class _Resp:
+    def __init__(self, payload):
+        self._payload = payload.encode("utf-8") if isinstance(payload, str) else payload
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _returns(payload):
+    def _opener(req, timeout=None):
+        return _Resp(payload)
+
+    return _opener
+
+
+def _raises(exc):
+    def _opener(req, timeout=None):
+        raise exc
+
+    return _opener
+
+
+def test_empty_list_is_authoritative():
+    # The whole point of the fix: server's empty list is a real answer, not fallback.
+    assert rh.do_recall("http://x", "", "q", "", '["graph"]', "5", opener=_returns("[]")) == []
+
+
+def test_list_results_passthrough():
+    assert rh.do_recall("http://x", "", "q", "", '["graph"]', "5",
+                        opener=_returns('[{"text": "hit"}]')) == [{"text": "hit"}]
+
+
+def test_error_dict_is_unreachable():
+    assert rh.do_recall("http://x", "", "q", "", '["graph"]', "5",
+                        opener=_returns('{"error": "bad request"}')) == rh.UNREACHABLE
+
+
+def test_non_error_dict_is_wrapped():
+    assert rh.do_recall("http://x", "", "q", "", '["graph"]', "5",
+                        opener=_returns('{"answer": "x"}')) == [{"answer": "x"}]
+
+
+def test_http_500_is_unreachable():
+    err = urllib.error.HTTPError("http://x", 500, "boom", {}, None)
+    assert rh.do_recall("http://x", "", "q", "", '["graph"]', "5", opener=_raises(err)) == rh.UNREACHABLE
+
+
+def test_http_403_is_unreachable():
+    err = urllib.error.HTTPError("http://x", 403, "forbidden", {}, None)
+    assert rh.do_recall("http://x", "k", "q", "", '["graph"]', "5", opener=_raises(err)) == rh.UNREACHABLE
+
+
+def test_connection_error_is_unreachable():
+    assert rh.do_recall("http://x", "", "q", "", '["graph"]', "5",
+                        opener=_raises(urllib.error.URLError("refused"))) == rh.UNREACHABLE
+
+
+def test_coerce_top_k():
+    assert rh.coerce_top_k("abc") == 5
+    assert rh.coerce_top_k("0") == 5
+    assert rh.coerce_top_k("") == 5
+    assert rh.coerce_top_k(None) == 5
+    assert rh.coerce_top_k("10") == 10
+
+
+def test_coerce_scope():
+    assert rh.coerce_scope('["graph"]') == ["graph"]
+    assert rh.coerce_scope("not json") == "auto"
+    assert rh.coerce_scope("") == "auto"
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print("PASS", name)
+            except AssertionError as e:
+                failures += 1
+                print("FAIL", name, e)
+    sys.exit(1 if failures else 0)

--- a/integrations/claude-code/tests/test_recall_http.py
+++ b/integrations/claude-code/tests/test_recall_http.py
@@ -1,8 +1,12 @@
 """Unit tests for the server-first recall helper (_recall_http.py).
 
-Covers the contract that the PR review flagged:
+Covers the contract from the PR reviews:
 - a 2xx empty list is AUTHORITATIVE (not a fallback trigger);
-- any non-2xx / error body / connection failure -> UNREACHABLE (fallback);
+- only a genuine connection failure -> UNREACHABLE (the *only* thing that lets
+  cognee-search.sh fall back to the local CLI);
+- any HTTP error (5xx/4xx, and especially 401/403 auth) -> an error envelope
+  (dict, authoritative=False), NOT UNREACHABLE, so the wrapper reports it and
+  does NOT fall back to a possibly-different local backend;
 - top_k / scope coercion never raises.
 
 Run: `pytest integrations/claude-code/tests/test_recall_http.py`
@@ -54,27 +58,35 @@ def test_list_results_passthrough():
                         opener=_returns('[{"text": "hit"}]')) == [{"text": "hit"}]
 
 
-def test_error_dict_is_unreachable():
-    assert rh.do_recall("http://x", "", "q", "", '["graph"]', "5",
-                        opener=_returns('{"error": "bad request"}')) == rh.UNREACHABLE
-
-
 def test_non_error_dict_is_wrapped():
     assert rh.do_recall("http://x", "", "q", "", '["graph"]', "5",
                         opener=_returns('{"answer": "x"}')) == [{"answer": "x"}]
 
 
-def test_http_500_is_unreachable():
+def test_error_dict_is_error_envelope_not_fallback():
+    out = rh.do_recall("http://x", "", "q", "", '["graph"]', "5",
+                       opener=_returns('{"error": "bad request"}'))
+    assert isinstance(out, dict) and out.get("authoritative") is False
+    assert out != rh.UNREACHABLE  # must NOT trigger CLI fallback
+
+
+def test_http_500_is_error_envelope():
     err = urllib.error.HTTPError("http://x", 500, "boom", {}, None)
-    assert rh.do_recall("http://x", "", "q", "", '["graph"]', "5", opener=_raises(err)) == rh.UNREACHABLE
+    out = rh.do_recall("http://x", "", "q", "", '["graph"]', "5", opener=_raises(err))
+    assert isinstance(out, dict) and out["status"] == 500 and out["authoritative"] is False
+    assert out != rh.UNREACHABLE  # reachable-but-erroring must NOT fall back to local CLI
 
 
-def test_http_403_is_unreachable():
-    err = urllib.error.HTTPError("http://x", 403, "forbidden", {}, None)
-    assert rh.do_recall("http://x", "k", "q", "", '["graph"]', "5", opener=_raises(err)) == rh.UNREACHABLE
+def test_http_401_403_auth_is_error_envelope_not_fallback():
+    for code in (401, 403):
+        err = urllib.error.HTTPError("http://x", code, "denied", {}, None)
+        out = rh.do_recall("http://x", "k", "q", "", '["graph"]', "5", opener=_raises(err))
+        assert isinstance(out, dict) and out["status"] == code
+        assert out != rh.UNREACHABLE  # auth failure must NOT fall back (would bypass authz / wrong data)
 
 
 def test_connection_error_is_unreachable():
+    # Only a genuine connection failure may fall back to the local CLI.
     assert rh.do_recall("http://x", "", "q", "", '["graph"]', "5",
                         opener=_raises(urllib.error.URLError("refused"))) == rh.UNREACHABLE
 

--- a/integrations/codex/plugins/cognee/scripts/_recall_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_recall_http.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Server-first recall against Cognee's ``/api/v1/recall``.
+
+Standalone, stdlib-only, so it runs under the system ``python3`` without the
+plugin venv (the same constraint ``cognee-search.sh`` already works under).
+
+Contract — what gets printed to stdout:
+  * a JSON **list** on a 2xx response. An **empty list is authoritative**:
+    the server searched and found nothing.
+  * the sentinel ``UNREACHABLE`` on ANY non-2xx status, an error-shaped
+    response body, or a connection failure. A server failure (5xx), a bad
+    request (4xx), or an auth rejection is **not** an authoritative "no
+    results" — the caller must fall back to the CLI and warn the user rather
+    than report a false negative.
+
+Diagnostics go to stderr so the caller can surface them.
+"""
+import json
+import sys
+import urllib.error
+import urllib.request
+
+UNREACHABLE = "UNREACHABLE"
+
+
+def coerce_top_k(value, default=5):
+    """Best-effort positive int; never raises (a bad value must not look like a server failure)."""
+    try:
+        n = int(str(value).strip())
+    except (TypeError, ValueError, AttributeError):
+        return default
+    return n if n > 0 else default
+
+
+def coerce_scope(value, default="auto"):
+    """Parse the JSON scope arg; fall back to "auto" on anything malformed."""
+    if not value:
+        return default
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def do_recall(
+    service_url,
+    api_key,
+    query,
+    session_id,
+    scope,
+    top_k,
+    *,
+    opener=urllib.request.urlopen,
+    timeout=20.0,
+):
+    """Query the server. Return a list of results (possibly empty) or ``UNREACHABLE``."""
+    url = service_url.rstrip("/") + "/api/v1/recall"
+    body = {
+        "query": query,
+        "top_k": coerce_top_k(top_k),
+        "only_context": True,
+        "scope": coerce_scope(scope),
+    }
+    if session_id:
+        body["session_id"] = session_id
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["X-Api-Key"] = api_key
+
+    req = urllib.request.Request(
+        url, data=json.dumps(body).encode("utf-8"), headers=headers, method="POST"
+    )
+    try:
+        with opener(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8") or "[]")
+    except urllib.error.HTTPError as e:
+        # Non-2xx (5xx outage, 4xx bad request, 401/403 auth) is a failure, NOT
+        # an authoritative empty result. Surface it and signal fallback.
+        sys.stderr.write(
+            "[cognee-search] server HTTP %s for /api/v1/recall — not authoritative, falling back\n"
+            % e.code
+        )
+        return UNREACHABLE
+    except Exception as e:  # URLError, timeout, JSON decode, etc.
+        sys.stderr.write(
+            "[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+        )
+        return UNREACHABLE
+
+    # An error-shaped 2xx body is also not a real result set.
+    if isinstance(data, dict) and data.get("error"):
+        sys.stderr.write(
+            "[cognee-search] server returned error: %s\n" % str(data.get("error"))[:160]
+        )
+        return UNREACHABLE
+    if isinstance(data, list):
+        return data
+    return [data]
+
+
+def main(argv):
+    # argv: service_url, api_key, query, session_id, scope, top_k
+    a = list(argv) + [""] * 6
+    result = do_recall(a[0], a[1], a[2], a[3], a[4], a[5])
+    print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/integrations/codex/plugins/cognee/scripts/_recall_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_recall_http.py
@@ -20,6 +20,7 @@ Contract — what gets printed to stdout:
 
 Diagnostics also go to stderr so the caller can surface them.
 """
+
 import json
 import sys
 import urllib.error

--- a/integrations/codex/plugins/cognee/scripts/_recall_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_recall_http.py
@@ -7,13 +7,18 @@ plugin venv (the same constraint ``cognee-search.sh`` already works under).
 Contract — what gets printed to stdout:
   * a JSON **list** on a 2xx response. An **empty list is authoritative**:
     the server searched and found nothing.
-  * the sentinel ``UNREACHABLE`` on ANY non-2xx status, an error-shaped
-    response body, or a connection failure. A server failure (5xx), a bad
-    request (4xx), or an auth rejection is **not** an authoritative "no
-    results" — the caller must fall back to the CLI and warn the user rather
-    than report a false negative.
+  * the sentinel ``UNREACHABLE`` ONLY when the server cannot be reached
+    (connection refused, timeout, DNS). The caller may then fall back to the
+    local CLI as a degraded path.
+  * a JSON **error object** ``{"error", "status", "authoritative": false}`` on
+    any HTTP error (5xx, 4xx, and especially **401/403** auth rejections) or an
+    error-shaped 2xx body. The caller MUST NOT fall back to the local CLI here:
+    the server was reachable and rejected/failed the request, so falling back to
+    a (possibly different / local) backend would return wrong data or bypass the
+    server-side authorization boundary. It is reported as an error, never as
+    "no results".
 
-Diagnostics go to stderr so the caller can surface them.
+Diagnostics also go to stderr so the caller can surface them.
 """
 import json
 import sys
@@ -42,6 +47,14 @@ def coerce_scope(value, default="auto"):
         return default
 
 
+def _error(status, message):
+    """An error envelope — reachable server, but the request was rejected/failed.
+
+    Distinct from UNREACHABLE so the caller does NOT fall back to the local CLI.
+    """
+    return {"error": message, "status": status, "authoritative": False}
+
+
 def do_recall(
     service_url,
     api_key,
@@ -53,7 +66,7 @@ def do_recall(
     opener=urllib.request.urlopen,
     timeout=20.0,
 ):
-    """Query the server. Return a list of results (possibly empty) or ``UNREACHABLE``."""
+    """Query the server. Return results (list), an error envelope (dict), or ``UNREACHABLE``."""
     url = service_url.rstrip("/") + "/api/v1/recall"
     body = {
         "query": query,
@@ -74,14 +87,15 @@ def do_recall(
         with opener(req, timeout=timeout) as resp:
             data = json.loads(resp.read().decode("utf-8") or "[]")
     except urllib.error.HTTPError as e:
-        # Non-2xx (5xx outage, 4xx bad request, 401/403 auth) is a failure, NOT
-        # an authoritative empty result. Surface it and signal fallback.
-        sys.stderr.write(
-            "[cognee-search] server HTTP %s for /api/v1/recall — not authoritative, falling back\n"
-            % e.code
-        )
-        return UNREACHABLE
-    except Exception as e:  # URLError, timeout, JSON decode, etc.
+        # Reachable but rejected/failed. NOT an authoritative empty, and NOT a
+        # reason to query a different backend via the CLI — report the error.
+        if e.code in (401, 403):
+            msg = "unauthorized (HTTP %s) — check COGNEE_API_KEY / credentials" % e.code
+        else:
+            msg = "server returned HTTP %s for /api/v1/recall" % e.code
+        sys.stderr.write("[cognee-search] %s — NOT falling back to local CLI\n" % msg)
+        return _error(e.code, msg)
+    except Exception as e:  # URLError, timeout, JSON decode, etc. → genuinely unreachable
         sys.stderr.write(
             "[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
         )
@@ -89,10 +103,9 @@ def do_recall(
 
     # An error-shaped 2xx body is also not a real result set.
     if isinstance(data, dict) and data.get("error"):
-        sys.stderr.write(
-            "[cognee-search] server returned error: %s\n" % str(data.get("error"))[:160]
-        )
-        return UNREACHABLE
+        msg = str(data.get("error"))[:200]
+        sys.stderr.write("[cognee-search] server returned error: %s\n" % msg)
+        return _error(200, msg)
     if isinstance(data, list):
         return data
     return [data]
@@ -102,6 +115,8 @@ def main(argv):
     # argv: service_url, api_key, query, session_id, scope, top_k
     a = list(argv) + [""] * 6
     result = do_recall(a[0], a[1], a[2], a[3], a[4], a[5])
+    # UNREACHABLE → caller falls back to CLI; a list (results) or an error
+    # object → caller prints as-is and does NOT fall back.
     print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
 
 

--- a/integrations/codex/plugins/cognee/scripts/cognee-search.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-search.sh
@@ -152,39 +152,15 @@ case "$MODE" in
 esac
 
 # Server-first: the running server (/api/v1/recall) is the source of truth.
-# An empty result from the server is authoritative; fall back to cognee-cli ONLY
-# when the server is genuinely unreachable — never to "rescue" an empty result.
-RECALL_JSON="$(python3 - "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$DATASET" "$TOP_K" "$SCOPE" <<'PY' 2>/dev/null || true
-import json, sys, urllib.request, urllib.error
-a = (sys.argv + [""] * 7)
-service_url, api_key, query, session_id, dataset, top_k, scope = a[1], a[2], a[3], a[4], a[5], a[6], a[7]
-url = service_url.rstrip("/") + "/api/v1/recall"
-body = {"query": query, "top_k": int(top_k or 5), "only_context": True, "scope": json.loads(scope or '"auto"')}
-if session_id:
-    body["session_id"] = session_id
-# No `datasets` restriction: search ALL the user's authorized datasets (matches the
-# auto-recall path that ground-truths content). Restricting to the plugin's default
-# dataset is exactly what produced false "not found" verdicts when the content lived
-# in another dataset.
-headers = {"Content-Type": "application/json"}
-if api_key:
-    headers["X-Api-Key"] = api_key
-req = urllib.request.Request(url, data=json.dumps(body).encode("utf-8"), headers=headers, method="POST")
-try:
-    with urllib.request.urlopen(req, timeout=20.0) as resp:
-        data = json.loads(resp.read().decode("utf-8") or "[]")
-    print(json.dumps(data if isinstance(data, list) else [data]))
-except urllib.error.HTTPError as e:
-    if e.code in (401, 403):
-        sys.stderr.write("[cognee-search] auth failed (HTTP %s) — check COGNEE_API_KEY\n" % e.code)
-    else:
-        sys.stderr.write("[cognee-search] server HTTP %s for /api/v1/recall (treating as no results)\n" % e.code)
-    print("[]")
-except Exception as e:
-    sys.stderr.write("[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160]))
-    print("UNREACHABLE")
-PY
-)"
+# Only a 2xx response is authoritative (an empty list = genuinely no hits).
+# Any non-2xx / error / unreachable returns the UNREACHABLE sentinel so we fall
+# back to cognee-cli and warn — never reporting a server failure as "not found".
+# `datasets` is intentionally NOT sent: the server scopes to the caller's
+# read-authorized datasets, so search spans them all (restricting to the plugin
+# default is what produced false "not found" when content lived elsewhere).
+# Logic lives in _recall_http.py (stdlib-only, unit-tested); stderr is surfaced.
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+RECALL_JSON="$(python3 "${SELF_DIR}/_recall_http.py" "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$SCOPE" "$TOP_K" || true)"
 
 if [ -n "$RECALL_JSON" ] && [ "$RECALL_JSON" != "UNREACHABLE" ]; then
     # Server answered — authoritative, even if the result is empty.

--- a/integrations/codex/plugins/cognee/scripts/cognee-search.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-search.sh
@@ -86,7 +86,7 @@ if service_url and api_key:
     except (urllib.error.URLError, TimeoutError, OSError, ValueError, json.JSONDecodeError):
         pass
 
-print(json.dumps({"session_id": session_id, "dataset": dataset}))
+print(json.dumps({"session_id": session_id, "dataset": dataset, "service_url": service_url, "api_key": api_key}))
 PY
 )"
 
@@ -106,8 +106,26 @@ except Exception:
     pass
 PY
 )"
+SERVICE_URL="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("service_url") or "").strip())
+except Exception:
+    pass
+PY
+)"
+API_KEY="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("api_key") or "").strip())
+except Exception:
+    pass
+PY
+)"
 [ -z "$DATASET" ] && DATASET="${COGNEE_PLUGIN_DATASET:-codex_sessions}"
 [ -z "$SESSION_ID" ] && SESSION_ID="${COGNEE_SESSION_ID:-codex_session}"
+[ -z "$SERVICE_URL" ] && SERVICE_URL="${COGNEE_BASE_URL:-${COGNEE_LOCAL_API_URL:-http://localhost:8011}}"
+[ -z "$API_KEY" ] && API_KEY="${COGNEE_API_KEY:-}"
 
 QUERY="${1:-}"
 TOP_K="${2:-5}"
@@ -126,16 +144,63 @@ if [ -z "$QUERY" ]; then
     exit 1
 fi
 
-if [ "$MODE" = "graph" ]; then
-    cognee-cli recall "$QUERY" -d "$DATASET" -k "$TOP_K" -f json 2>/dev/null
-elif [ "$MODE" = "session" ]; then
-    cognee-cli recall "$QUERY" -s "$SESSION_ID" -k "$TOP_K" -f json 2>/dev/null
+# Search scope from MODE
+case "$MODE" in
+    session) SCOPE='["session"]' ;;
+    graph)   SCOPE='["graph"]' ;;
+    *)       SCOPE='["session", "graph"]' ;;
+esac
+
+# Server-first: the running server (/api/v1/recall) is the source of truth.
+# An empty result from the server is authoritative; fall back to cognee-cli ONLY
+# when the server is genuinely unreachable — never to "rescue" an empty result.
+RECALL_JSON="$(python3 - "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$DATASET" "$TOP_K" "$SCOPE" <<'PY' 2>/dev/null || true
+import json, sys, urllib.request, urllib.error
+a = (sys.argv + [""] * 7)
+service_url, api_key, query, session_id, dataset, top_k, scope = a[1], a[2], a[3], a[4], a[5], a[6], a[7]
+url = service_url.rstrip("/") + "/api/v1/recall"
+body = {"query": query, "top_k": int(top_k or 5), "only_context": True, "scope": json.loads(scope or '"auto"')}
+if session_id:
+    body["session_id"] = session_id
+# No `datasets` restriction: search ALL the user's authorized datasets (matches the
+# auto-recall path that ground-truths content). Restricting to the plugin's default
+# dataset is exactly what produced false "not found" verdicts when the content lived
+# in another dataset.
+headers = {"Content-Type": "application/json"}
+if api_key:
+    headers["X-Api-Key"] = api_key
+req = urllib.request.Request(url, data=json.dumps(body).encode("utf-8"), headers=headers, method="POST")
+try:
+    with urllib.request.urlopen(req, timeout=20.0) as resp:
+        data = json.loads(resp.read().decode("utf-8") or "[]")
+    print(json.dumps(data if isinstance(data, list) else [data]))
+except urllib.error.HTTPError as e:
+    if e.code in (401, 403):
+        sys.stderr.write("[cognee-search] auth failed (HTTP %s) — check COGNEE_API_KEY\n" % e.code)
+    else:
+        sys.stderr.write("[cognee-search] server HTTP %s for /api/v1/recall (treating as no results)\n" % e.code)
+    print("[]")
+except Exception as e:
+    sys.stderr.write("[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160]))
+    print("UNREACHABLE")
+PY
+)"
+
+if [ -n "$RECALL_JSON" ] && [ "$RECALL_JSON" != "UNREACHABLE" ]; then
+    # Server answered — authoritative, even if the result is empty.
+    printf '%s\n' "$RECALL_JSON"
 else
-    # Auto: try session first, fall back to graph
-    RESULT=$(cognee-cli recall "$QUERY" -s "$SESSION_ID" -k "$TOP_K" -f json 2>/dev/null)
-    if [ -n "$RESULT" ] && [ "$RESULT" != "[]" ]; then
-        echo "$RESULT"
+    echo "[cognee-search] falling back to cognee-cli (degraded — empty CLI output is NOT proof of absence; ground-truth via: curl -X POST \"\$COGNEE_BASE_URL/api/v1/recall\")" >&2
+    if [ "$MODE" = "graph" ]; then
+        cognee-cli recall "$QUERY" -d "$DATASET" -k "$TOP_K" -f json 2>/dev/null || true
+    elif [ "$MODE" = "session" ]; then
+        cognee-cli recall "$QUERY" -s "$SESSION_ID" -k "$TOP_K" -f json 2>/dev/null || true
     else
-        cognee-cli recall "$QUERY" -d "$DATASET" -k "$TOP_K" -f json 2>/dev/null
+        RESULT=$(cognee-cli recall "$QUERY" -s "$SESSION_ID" -k "$TOP_K" -f json 2>/dev/null || true)
+        if [ -n "$RESULT" ] && [ "$RESULT" != "[]" ]; then
+            echo "$RESULT"
+        else
+            cognee-cli recall "$QUERY" -d "$DATASET" -k "$TOP_K" -f json 2>/dev/null || true
+        fi
     fi
 fi

--- a/integrations/codex/plugins/cognee/skills/codebase/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/codebase/SKILL.md
@@ -94,6 +94,7 @@ files before editing code.
 
 ```bash
 curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
-  -H "Content-Type: application/json" ${COGNEE_API_KEY:+-H "X-Api-Key: $COGNEE_API_KEY"} \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: ${COGNEE_API_KEY:-}" \
   -d '{"query": "<question>", "top_k": 10, "only_context": true, "scope": ["graph"]}'
 ```

--- a/integrations/codex/plugins/cognee/skills/codebase/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/codebase/SKILL.md
@@ -89,3 +89,11 @@ uv run cognee-cli search "<specific symbol or behavior>" -d <dataset-name> -t CH
 
 Use results as supporting context. Verify important claims against the actual
 files before editing code.
+
+**The server is the source of truth.** `cognee-cli` can print empty stdout even when content exists, so never conclude "not found" from an empty CLI run — confirm against the server directly (authoritative), and omit `-d <dataset>` to search all datasets:
+
+```bash
+curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
+  -H "Content-Type: application/json" ${COGNEE_API_KEY:+-H "X-Api-Key: $COGNEE_API_KEY"} \
+  -d '{"query": "<question>", "top_k": 10, "only_context": true, "scope": ["graph"]}'
+```

--- a/integrations/codex/plugins/cognee/skills/memory/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/memory/SKILL.md
@@ -64,7 +64,8 @@ Use `-f json` when downstream parsing is needed.
 - **Never conclude "not found" from an empty/clean CLI run.** Confirm against the server directly — this is authoritative:
   ```bash
   curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
-    -H "Content-Type: application/json" ${COGNEE_API_KEY:+-H "X-Api-Key: $COGNEE_API_KEY"} \
+    -H "Content-Type: application/json" \
+    -H "X-Api-Key: ${COGNEE_API_KEY:-}" \
     -d '{"query": "<question>", "top_k": 5, "only_context": true, "scope": ["graph"]}'
   ```
 - **Do not re-run the same CLI search to "retry."** One server answer is authoritative.

--- a/integrations/codex/plugins/cognee/skills/memory/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/memory/SKILL.md
@@ -58,6 +58,18 @@ uv run cognee-cli search "<code question>" -d <dataset-name> -t CODE -k 10 -f pr
 
 Use `-f json` when downstream parsing is needed.
 
+### The server is the source of truth
+
+`cognee-cli` is a thin client over the running Cognee server and can print **empty stdout even when content exists** (a serialization quirk). So:
+- **Never conclude "not found" from an empty/clean CLI run.** Confirm against the server directly — this is authoritative:
+  ```bash
+  curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
+    -H "Content-Type: application/json" ${COGNEE_API_KEY:+-H "X-Api-Key: $COGNEE_API_KEY"} \
+    -d '{"query": "<question>", "top_k": 5, "only_context": true, "scope": ["graph"]}'
+  ```
+- **Do not re-run the same CLI search to "retry."** One server answer is authoritative.
+- Omit `-d <dataset>` to search **all** your datasets; restricting to one dataset can miss content that lives in another.
+
 ## Improve Memory
 
 Enrich an existing graph:


### PR DESCRIPTION
## Problem
When asked to search, the plugin reaches for `cognee-cli` as the primary interface. The CLI is a thin client over the same server (`/api/v1/recall`), but it can **exit 0 with empty stdout even when content exists**. When that happened, nothing pivoted to the server to ground-truth — the recall agent re-ran the same CLI shape, chased an async warning, and returned a confident **"no physics found"**, while the auto-inject snapshot (which queries the server directly) proved the content was there (quantum dots, spin qubits, chiral phonons…).

## Fix — server-first
`scripts/cognee-search.sh` (both Claude + Codex):
- **Queries the running server first** — `POST /api/v1/recall`, reusing the script's existing base-URL + API-key resolution — and treats the server's answer (**including an empty list**) as authoritative.
- **Falls back to `cognee-cli` only when the server is genuinely unreachable** (connection error), never to "rescue" an empty result.
- **Drops the single-dataset restriction** so it searches *all* authorized datasets. Restricting to the plugin's default dataset (`claude_sessions`) was a second cause of false "not found" when the content lived in another dataset — the auto-recall path finds it precisely because it doesn't restrict.

## Docs / instructions
- `skills/cognee-search/SKILL.md` + `agents/cognee-recall.md` reframed server-first, document the `curl /api/v1/recall` **ground-truth**, and carry the rule: *empty CLI output is not proof of absence — confirm via the server, and don't re-run the same search to retry.*
- Same ground-truth note added to the Codex `memory` / `codebase` skills.

## Verification
Against a healthy local server (`:8011`):
- `cognee-search.sh "physics" --graph` now returns the real nodes (signal physics, particle physics, mechanics…) instead of `[]`.
- `cognee-search.sh "quantum dots"` (auto) returns quantum dots / spin qubits.
- A bad/unreachable URL falls back to `cognee-cli` with a clear degraded-mode notice.
- Direct `curl POST /api/v1/recall` returns the same payload (no-auth local server → HTTP 200).
