### PR TITLE
fix(recall): finish review items + smooth the recall UX

### DIFF
--- a/integrations/claude-code/agents/cognee-recall.md
+++ b/integrations/claude-code/agents/cognee-recall.md
@@ -23,29 +23,24 @@ Cognee organizes knowledge into three categories:
 | **project** | `project_docs` | Repository docs, code context, architecture decisions |
 | **agent** | `agent_actions` | Tool call logs, reasoning traces, generated artifacts |
 
-## Search commands
+## Search command
 
-Always search via the wrapper — it queries the **running server first** (`/api/v1/recall`, the source of truth), searches **all authorized datasets** (so a hit isn't missed because it's in another dataset), and falls back to `cognee-cli` only if the server is unreachable.
+Run **one** broad search via the wrapper and answer from it. It queries the **running server** (`/api/v1/recall`, the source of truth), spans **all authorized datasets**, and falls back to `cognee-cli` only if the server is unreachable:
 
-**Session context:**
 ```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "<query>" 10 --session
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "<query>" 10
 ```
 
-**Permanent graph:**
-```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/cognee-search.sh "<query>" 10 --graph
-```
+**Do not fan out into many targeted calls.** One broad search plus the context the `UserPromptSubmit` hook already injects on every turn is enough — multiple calls just add latency and (un-allowlisted) permission prompts for the user. Use `--graph` or `--session` only when you specifically need to narrow scope.
 
-**Ground-truth (if a result is empty but you expect content) — authoritative:**
+**Manual ground-truth only (not part of the normal flow):** if a result is empty and you genuinely doubt it, you may confirm directly. Category filtering uses `node_name` (the CLI doesn't expose it):
 ```bash
 curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
   -H "Content-Type: application/json" \
   -H "X-Api-Key: ${COGNEE_API_KEY:-}" \
-  -d '{"query": "<query>", "top_k": 10, "only_context": true, "scope": ["graph"]}'
+  -d '{"query": "<query>", "top_k": 10, "only_context": true, "scope": ["graph"], "node_name": ["project_docs"]}'
 ```
-
-Category filtering uses `node_name` on the same call (the CLI doesn't expose it): add `"node_name": ["project_docs"]` (or `user_context` / `agent_actions`).
+(For a local server `COGNEE_API_KEY` is unused; an empty value is fine.)
 
 ## The server is the source of truth (read this before reporting "not found")
 

--- a/integrations/claude-code/scripts/_recall_http.py
+++ b/integrations/claude-code/scripts/_recall_http.py
@@ -24,9 +24,16 @@ Diagnostics also go to stderr so the caller can surface them.
 import json
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 UNREACHABLE = "UNREACHABLE"
+
+
+def _is_local(url):
+    """True for a localhost/loopback target (where a cloud API key is meaningless)."""
+    host = (urllib.parse.urlparse(url).hostname or "").lower()
+    return host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
 
 
 def coerce_top_k(value, default=5):
@@ -77,8 +84,17 @@ def do_recall(
     }
     if session_id:
         body["session_id"] = session_id
+    # `datasets` is intentionally omitted. With no datasets, the server scopes the
+    # search to the caller's *read-authorized* datasets server-side (recall.py:
+    # get_specific_user_permission_datasets / get_authorized_existing_datasets, behind
+    # get_authenticated_user) — so it spans ALL authorized datasets with no cross-tenant
+    # leak. Restricting to one dataset client-side would reintroduce the false-negative
+    # where content lives in a different dataset than the plugin's default.
     headers = {"Content-Type": "application/json"}
-    if api_key:
+    # COGNEE_API_KEY is a *cloud* credential; the local single-user server needs no
+    # auth and ignores it. Only attach it for a remote/cloud target, so we don't send
+    # a meaningless (and confusing) cloud key to localhost.
+    if api_key and not _is_local(service_url):
         headers["X-Api-Key"] = api_key
 
     req = urllib.request.Request(
@@ -86,7 +102,7 @@ def do_recall(
     )
     try:
         with opener(req, timeout=timeout) as resp:
-            data = json.loads(resp.read().decode("utf-8") or "[]")
+            raw = resp.read().decode("utf-8")
     except urllib.error.HTTPError as e:
         # Reachable but rejected/failed. NOT an authoritative empty, and NOT a
         # reason to query a different backend via the CLI — report the error.
@@ -96,11 +112,19 @@ def do_recall(
             msg = "server returned HTTP %s for /api/v1/recall" % e.code
         sys.stderr.write("[cognee-search] %s — NOT falling back to local CLI\n" % msg)
         return _error(e.code, msg)
-    except Exception as e:  # URLError, timeout, JSON decode, etc. → genuinely unreachable
+    except Exception as e:  # URLError / timeout / OSError → genuinely unreachable
         sys.stderr.write(
             "[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
         )
         return UNREACHABLE
+
+    # The server responded. A body we can't parse is a SERVER-side bug, not an
+    # unreachable server — report it as an error (do NOT trigger the CLI fallback).
+    try:
+        data = json.loads(raw or "[]")
+    except (json.JSONDecodeError, ValueError) as e:
+        sys.stderr.write("[cognee-search] malformed JSON from /api/v1/recall: %s\n" % str(e)[:160])
+        return _error(200, "malformed JSON response from /api/v1/recall")
 
     # An error-shaped 2xx body is also not a real result set.
     if isinstance(data, dict) and data.get("error"):

--- a/integrations/claude-code/skills/cognee-search/SKILL.md
+++ b/integrations/claude-code/skills/cognee-search/SKILL.md
@@ -25,6 +25,8 @@ Knowledge is organized into three categories via `node_set`:
 
 Search goes through the **running Cognee server** (`POST /api/v1/recall`) — the source of truth. Use the wrapper below: it queries the server first, searches **all your authorized datasets** (so a hit isn't missed because it lives in another dataset), and falls back to `cognee-cli` only if the server is unreachable.
 
+**One broad search is usually enough** — the `UserPromptSubmit` hook already injects session/trace/graph context every turn, so avoid running many targeted searches (each is an extra permission prompt for the user).
+
 ### Search (server-first)
 
 ```bash

--- a/integrations/claude-code/tests/test_recall_http.py
+++ b/integrations/claude-code/tests/test_recall_http.py
@@ -106,6 +106,31 @@ def test_connection_error_is_unreachable():
     )
 
 
+def test_malformed_json_is_error_not_unreachable():
+    # A reachable server returning garbage is a SERVER bug → error envelope,
+    # NOT UNREACHABLE (which would wrongly trigger the CLI fallback).
+    out = rh.do_recall("http://x", "", "q", "", '["graph"]', "5", opener=_returns("not json{"))
+    assert isinstance(out, dict) and out["authoritative"] is False
+    assert out != rh.UNREACHABLE
+
+
+def test_no_cloud_key_sent_to_localhost():
+    captured = {}
+
+    def _capture(req, timeout=None):
+        captured["xapikey"] = req.get_header("X-api-key")  # urllib title-cases header names
+        return _Resp("[]")
+
+    # localhost target → cloud key must NOT be attached
+    rh.do_recall("http://localhost:8011", "cloud-key", "q", "", '["graph"]', "5", opener=_capture)
+    assert captured["xapikey"] is None
+    # remote target → key IS attached
+    rh.do_recall(
+        "https://tenant.cognee.ai", "cloud-key", "q", "", '["graph"]', "5", opener=_capture
+    )
+    assert captured["xapikey"] == "cloud-key"
+
+
 def test_coerce_top_k():
     assert rh.coerce_top_k("abc") == 5
     assert rh.coerce_top_k("0") == 5

--- a/integrations/codex/plugins/cognee/scripts/_recall_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_recall_http.py
@@ -24,9 +24,16 @@ Diagnostics also go to stderr so the caller can surface them.
 import json
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 UNREACHABLE = "UNREACHABLE"
+
+
+def _is_local(url):
+    """True for a localhost/loopback target (where a cloud API key is meaningless)."""
+    host = (urllib.parse.urlparse(url).hostname or "").lower()
+    return host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
 
 
 def coerce_top_k(value, default=5):
@@ -77,8 +84,17 @@ def do_recall(
     }
     if session_id:
         body["session_id"] = session_id
+    # `datasets` is intentionally omitted. With no datasets, the server scopes the
+    # search to the caller's *read-authorized* datasets server-side (recall.py:
+    # get_specific_user_permission_datasets / get_authorized_existing_datasets, behind
+    # get_authenticated_user) — so it spans ALL authorized datasets with no cross-tenant
+    # leak. Restricting to one dataset client-side would reintroduce the false-negative
+    # where content lives in a different dataset than the plugin's default.
     headers = {"Content-Type": "application/json"}
-    if api_key:
+    # COGNEE_API_KEY is a *cloud* credential; the local single-user server needs no
+    # auth and ignores it. Only attach it for a remote/cloud target, so we don't send
+    # a meaningless (and confusing) cloud key to localhost.
+    if api_key and not _is_local(service_url):
         headers["X-Api-Key"] = api_key
 
     req = urllib.request.Request(
@@ -86,7 +102,7 @@ def do_recall(
     )
     try:
         with opener(req, timeout=timeout) as resp:
-            data = json.loads(resp.read().decode("utf-8") or "[]")
+            raw = resp.read().decode("utf-8")
     except urllib.error.HTTPError as e:
         # Reachable but rejected/failed. NOT an authoritative empty, and NOT a
         # reason to query a different backend via the CLI — report the error.
@@ -96,11 +112,19 @@ def do_recall(
             msg = "server returned HTTP %s for /api/v1/recall" % e.code
         sys.stderr.write("[cognee-search] %s — NOT falling back to local CLI\n" % msg)
         return _error(e.code, msg)
-    except Exception as e:  # URLError, timeout, JSON decode, etc. → genuinely unreachable
+    except Exception as e:  # URLError / timeout / OSError → genuinely unreachable
         sys.stderr.write(
             "[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
         )
         return UNREACHABLE
+
+    # The server responded. A body we can't parse is a SERVER-side bug, not an
+    # unreachable server — report it as an error (do NOT trigger the CLI fallback).
+    try:
+        data = json.loads(raw or "[]")
+    except (json.JSONDecodeError, ValueError) as e:
+        sys.stderr.write("[cognee-search] malformed JSON from /api/v1/recall: %s\n" % str(e)[:160])
+        return _error(200, "malformed JSON response from /api/v1/recall")
 
     # An error-shaped 2xx body is also not a real result set.
     if isinstance(data, dict) and data.get("error"):


### PR DESCRIPTION
Follow-up to #85 — closes the remaining review findings and the UX feedback.

## Review findings
- **(minor) JSON-decode → error, not fallback.** A reachable server returning unparseable JSON is a *server bug*, not "unreachable" — it now returns an error envelope instead of `UNREACHABLE`, so it no longer wrongly triggers the CLI fallback. The network call and the JSON parse are now separated; connection failures still → `UNREACHABLE`.
- **(minor) test for malformed JSON** added.
- **(major ×2 — `datasets`)** Resolved as *keep-broad-and-document*. Re-adding a single-dataset restriction would reintroduce the false-negative #85 fixed (content lived in a different dataset). Omitting `datasets` is functionally "search all my authorized datasets" — the server scopes + authorizes that itself (`get_specific_user_permission_datasets` / `get_authorized_existing_datasets` behind `get_authenticated_user`), so there's no cross-tenant leak and no meaningful client-side defense-in-depth to add. Documented inline.

## UX
- **No cloud key on localhost.** `COGNEE_API_KEY` is a cloud credential; the local server ignores it and seeing it on a local call was confusing. It's now attached only for remote/cloud targets. (Test included.)
- **One search, not a fan-out.** The recall agent/skill now does one broad `cognee-search.sh` call and answers from it (+ the context the `UserPromptSubmit` hook already injects every turn). The previous 5-curl fan-out was the source of repeated permission prompts. `curl` is demoted to manual ground-truth only.

## Verified
- `ruff format --check integrations/` + `ruff check integrations/` clean
- 11 unit tests pass (incl. new malformed-JSON + localhost-no-key cases)
- live local recall still returns content

🤖 Generated with [Claude Code](https://claude.com/claude-code)