### PR TITLE
fix: fix remember and sync skills similar to search. split directories

### DIFF
--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -18,13 +18,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-_PLUGIN_DIR = Path.home() / ".cognee-plugin"
+_PLUGIN_DIR = Path.home() / ".cognee-plugin" / "claude-code"
+_SHARED_PLUGIN_ROOT = Path.home() / ".cognee-plugin"
 _HOOK_LOG = _PLUGIN_DIR / "hook.log"
 _COUNTER_FILE = _PLUGIN_DIR / "counter.json"
 _ACTIVITY_FILE = _PLUGIN_DIR / "activity.ts"
 _ACTIVITY_LOG = _PLUGIN_DIR / "activity.log"
 _SAVE_COUNTER = _PLUGIN_DIR / "save_counter.json"
-_SERVER_READY_MARKER = Path.home() / ".cognee-plugin" / "server-ready.json"
+_SERVER_READY_MARKER = _SHARED_PLUGIN_ROOT / "server-ready.json"
 _SERVER_READY_TTL_SECONDS = 30
 _SYNC_LOCK = _PLUGIN_DIR / "sync.lock"
 # Per-agent-session buffer dirs. Each agent session (one Claude/Codex terminal)
@@ -35,7 +36,7 @@ _PENDING_DIR = _PLUGIN_DIR / "pending"
 _SUBPROCESS_LOG = _PLUGIN_DIR / "subprocess.log"
 # Single-principal model: one API key (user-provided COGNEE_API_KEY or one minted
 # from the default user) is cached here. Replaces the old per-agent agent_keys.json.
-_API_KEY_CACHE = _PLUGIN_DIR / "api_key.json"
+_API_KEY_CACHE = _SHARED_PLUGIN_ROOT / "api_key.json"
 # Host-session-id -> generated Cognee session-id map. The host (Claude/Codex)
 # session id is used ONLY as a local correlation key so every hook process of a
 # single launch resolves the SAME Cognee session id; it is never sent to Cognee
@@ -58,9 +59,9 @@ _DEFAULT_LOCAL_SERVICE_URL = "http://localhost:8011"
 # The plugin owns an isolated virtualenv for cognee under ~/.cognee-plugin/venv
 # (disposable: rebuilt/upgraded freely), while all persistent data lives under
 # ~/.cognee (the "safe space" that survives venv rebuilds and cognee upgrades).
-_VENV_DIR = _PLUGIN_DIR / "venv"
+_VENV_DIR = _SHARED_PLUGIN_ROOT / "venv"
 _VENV_PYTHON = _VENV_DIR / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
-_VENV_READY_MARKER = _PLUGIN_DIR / "venv-ready.json"
+_VENV_READY_MARKER = _SHARED_PLUGIN_ROOT / "venv-ready.json"
 
 # cognee's own default puts its databases INSIDE the install dir (the venv), so
 # they would be wiped on every venv rebuild/upgrade. Pin them to ~/.cognee.

--- a/integrations/claude-code/scripts/_remember_http.py
+++ b/integrations/claude-code/scripts/_remember_http.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Server-first remember against Cognee's ``/api/v1/remember``.
+
+Standalone, stdlib-only, so it runs under the system ``python3`` without the
+plugin venv (the same constraint ``cognee-search.sh`` already works under).
+
+Contract — what gets printed to stdout:
+  * ``{"ok": true}`` on a 2xx response.
+  * the sentinel ``UNREACHABLE`` ONLY when the server cannot be reached
+    (connection refused, timeout, DNS). The caller may then fall back to the
+    local CLI as a degraded path.
+  * a JSON **error object** ``{"error", "status", "authoritative": false}`` on
+    any HTTP error (5xx, 4xx, and especially **401/403** auth rejections). The
+    caller MUST NOT fall back to the local CLI here: the server was reachable and
+    rejected/failed the request, so falling back could bypass auth boundaries
+    or silently double-write to a different backend.
+
+Diagnostics also go to stderr so the caller can surface them.
+"""
+
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+
+UNREACHABLE = "UNREACHABLE"
+
+
+def _is_local(url):
+    """True for a localhost/loopback target (where a cloud API key is meaningless)."""
+    host = (urllib.parse.urlparse(url).hostname or "").lower()
+    return host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
+
+
+def _multipart_body(fields, files):
+    boundary = f"----cogneeRemember{uuid.uuid4().hex}"
+    chunks = []
+    for name, value in fields.items():
+        chunks.append(f"--{boundary}\r\n".encode("utf-8"))
+        chunks.append(f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode("utf-8"))
+        chunks.append(str(value).encode("utf-8"))
+        chunks.append(b"\r\n")
+    for field_name, filename, content in files:
+        chunks.append(f"--{boundary}\r\n".encode("utf-8"))
+        chunks.append(
+            (
+                f'Content-Disposition: form-data; name="{field_name}"; filename="{filename}"\r\n'
+                "Content-Type: text/plain; charset=utf-8\r\n\r\n"
+            ).encode("utf-8")
+        )
+        chunks.append(content if isinstance(content, bytes) else content.encode("utf-8"))
+        chunks.append(b"\r\n")
+    chunks.append(f"--{boundary}--\r\n".encode("utf-8"))
+    return b"".join(chunks), boundary
+
+
+def _error(status, message):
+    """An error envelope — reachable server, but the request was rejected/failed.
+
+    Distinct from UNREACHABLE so the caller does NOT fall back to the local CLI.
+    """
+    return {"error": message, "status": status, "authoritative": False}
+
+
+def do_remember(
+    service_url,
+    api_key,
+    content,
+    dataset,
+    node_set,
+    *,
+    opener=urllib.request.urlopen,
+    timeout=60.0,
+):
+    """POST content to the server. Return {"ok": true}, an error envelope, or UNREACHABLE."""
+    url = service_url.rstrip("/") + "/api/v1/remember"
+    filename = f"{node_set or 'content'}.txt"
+    body, boundary = _multipart_body(
+        {
+            "datasetName": dataset,
+            "node_set": node_set,
+            "run_in_background": "false",
+        },
+        [("data", filename, content.encode("utf-8") if isinstance(content, str) else content)],
+    )
+    headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
+    # COGNEE_API_KEY is a cloud credential; local single-user servers need no
+    # auth and ignore it. Only attach it for a remote/cloud target.
+    if api_key and not _is_local(service_url):
+        headers["X-Api-Key"] = api_key
+
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with opener(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        if e.code in (401, 403):
+            msg = "unauthorized (HTTP %s) — check COGNEE_API_KEY / credentials" % e.code
+        else:
+            msg = "server returned HTTP %s for /api/v1/remember" % e.code
+        sys.stderr.write("[cognee-remember] %s — NOT falling back to local CLI\n" % msg)
+        return _error(e.code, msg)
+    except Exception as e:
+        sys.stderr.write(
+            "[cognee-remember] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+        )
+        return UNREACHABLE
+
+    # The server responded with 2xx. A body we can't parse is fine —
+    # the important thing is the server accepted the request.
+    try:
+        data = json.loads(raw or "{}")
+    except (json.JSONDecodeError, ValueError):
+        return {"ok": True}
+
+    if isinstance(data, dict) and data.get("error"):
+        msg = str(data.get("error"))[:200]
+        sys.stderr.write("[cognee-remember] server returned error: %s\n" % msg)
+        return _error(200, msg)
+    return {"ok": True}
+
+
+def main(argv):
+    # argv: service_url, api_key, content, dataset, node_set
+    a = list(argv) + [""] * 5
+    result = do_remember(a[0], a[1], a[2], a[3], a[4])
+    print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/integrations/claude-code/scripts/clear-transcript-context.py
+++ b/integrations/claude-code/scripts/clear-transcript-context.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 ENV_NAME = "COGNEE_CLAUDE_CLEAR_AFTER_MESSAGE"
 TRUTHY = {"1", "true", "yes", "on"}
-PLUGIN_DIR = Path.home() / ".cognee-plugin"
+PLUGIN_DIR = Path.home() / ".cognee-plugin" / "claude-code"
 LOG_FILE = PLUGIN_DIR / "hook.log"
 
 

--- a/integrations/claude-code/scripts/cognee-remember.sh
+++ b/integrations/claude-code/scripts/cognee-remember.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Store text in Cognee's permanent knowledge graph.
+#
+# Usage:
+#   cognee-remember.sh <content> [--node-set <node_set>] [--dataset <dataset>]
+#
+# --node-set: node set for categorization (default: user_context)
+#             user_context | project_docs | agent_actions
+# --dataset:  dataset name (default: from env or connection lookup)
+#
+# Configuration:
+#   Resolves auth and dataset from api_key.json and Cognee endpoints.
+#   Falls back to cognee-cli only if the server is unreachable.
+
+set -euo pipefail
+
+PLUGIN_DIR="${HOME}/.cognee-plugin/claude-code"
+runtime_json="$(python3 - <<'PY' "${PLUGIN_DIR}" 2>/dev/null || true
+import json
+import pathlib
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+plugin_dir = pathlib.Path(sys.argv[1])
+import os
+service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
+api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
+
+if not api_key:
+    cache_path = plugin_dir.parent / "api_key.json"
+    if cache_path.exists():
+        try:
+            cache = json.loads(cache_path.read_text())
+            if isinstance(cache, dict):
+                key = str(cache.get("api_key") or "").strip()
+                cached_url = str(cache.get("base_url") or "").strip().rstrip("/")
+                if key and (not cached_url or cached_url == service_url.rstrip("/")):
+                    api_key = key
+        except Exception:
+            pass
+
+dataset = ""
+if service_url and api_key:
+    try:
+        session_key = (os.environ.get("COGNEE_SESSION_KEY") or "").strip()
+        query = ""
+        if session_key:
+            query = "?agent_session_name=" + urllib.parse.quote(session_key, safe="")
+        req = urllib.request.Request(
+            service_url.rstrip("/") + "/api/v1/agents/connections/me" + query,
+            headers={"X-Api-Key": api_key},
+        )
+        with urllib.request.urlopen(req, timeout=3.0) as resp:
+            payload = json.loads(resp.read().decode("utf-8") or "{}")
+        if isinstance(payload, dict):
+            agent = payload.get("agent") if isinstance(payload.get("agent"), dict) else {}
+            if isinstance(agent, dict):
+                datasets = agent.get("datasets") if isinstance(agent.get("datasets"), list) else []
+                for item in datasets:
+                    if isinstance(item, dict):
+                        name = str(item.get("name") or "").strip()
+                        if name:
+                            dataset = name
+                            break
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError, json.JSONDecodeError):
+        pass
+
+print(json.dumps({"service_url": service_url, "api_key": api_key, "dataset": dataset}))
+PY
+)"
+
+SERVICE_URL="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("service_url") or "").strip())
+except Exception:
+    pass
+PY
+)"
+API_KEY="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("api_key") or "").strip())
+except Exception:
+    pass
+PY
+)"
+DATASET="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("dataset") or "").strip())
+except Exception:
+    pass
+PY
+)"
+
+[ -z "$SERVICE_URL" ] && SERVICE_URL="${COGNEE_BASE_URL:-${COGNEE_LOCAL_API_URL:-http://localhost:8011}}"
+[ -z "$API_KEY" ] && API_KEY="${COGNEE_API_KEY:-}"
+[ -z "$DATASET" ] && DATASET="${COGNEE_PLUGIN_DATASET:-claude_sessions}"
+
+# Parse arguments: content is first positional; flags follow
+CONTENT="${1:-}"
+NODE_SET="user_context"
+
+shift || true
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --node-set)
+            shift
+            NODE_SET="${1:-user_context}"
+            ;;
+        --dataset|-d)
+            shift
+            DATASET="${1:-$DATASET}"
+            ;;
+        *)
+            ;;
+    esac
+    shift || true
+done
+
+if [ -z "$CONTENT" ]; then
+    echo "Error: no content provided" >&2
+    exit 1
+fi
+
+# Server-first: POST to /api/v1/remember via _remember_http.py.
+# UNREACHABLE → fall back to cognee-cli and warn.
+# Any other result (ok or error) → authoritative; do not fall back.
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+RESULT="$(python3 "${SELF_DIR}/_remember_http.py" "$SERVICE_URL" "$API_KEY" "$CONTENT" "$DATASET" "$NODE_SET" || true)"
+
+if [ -n "$RESULT" ] && [ "$RESULT" != "UNREACHABLE" ]; then
+    printf '%s\n' "$RESULT"
+else
+    echo "[cognee-remember] falling back to cognee-cli (degraded — server unreachable; verify the store succeeded once the server is back)" >&2
+    cognee-cli remember "$CONTENT" -d "$DATASET" --node-set "$NODE_SET" 2>/dev/null || true
+fi

--- a/integrations/claude-code/scripts/cognee-search.sh
+++ b/integrations/claude-code/scripts/cognee-search.sh
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-PLUGIN_DIR="${HOME}/.cognee-plugin"
+PLUGIN_DIR="${HOME}/.cognee-plugin/claude-code"
 runtime_json="$(python3 - <<'PY' "${PLUGIN_DIR}" 2>/dev/null || true
 import json
 import pathlib
@@ -27,34 +27,16 @@ plugin_dir = pathlib.Path(sys.argv[1])
 import os
 service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
 api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
-agent_name = (os.environ.get("COGNEE_AGENT_NAME") or "").strip()
-if agent_name:
-    if agent_name.endswith("@cognee.agent"):
-        agent_name = agent_name[: -len("@cognee.agent")]
-    if not agent_name.endswith("_claude"):
-        agent_name = f"{agent_name}_claude"
-
-if not api_key and service_url and agent_name:
-    cache_path = plugin_dir / "agent_keys.json"
+if not api_key:
+    cache_path = plugin_dir.parent / "api_key.json"
     if cache_path.exists():
         try:
             cache = json.loads(cache_path.read_text())
-            entries = cache.get("entries", {}) if isinstance(cache, dict) else {}
-            if isinstance(entries, dict):
-                normalized_url = service_url.rstrip("/")
-                key = f"{normalized_url}::{agent_name}"
-                chosen = entries.get(key)
-                if isinstance(chosen, dict):
-                    api_key = str(chosen.get("api_key") or "").strip()
-                else:
-                    for entry in entries.values():
-                        if not isinstance(entry, dict):
-                            continue
-                        name = str(entry.get("agent_name") or "").strip()
-                        url = str(entry.get("base_url") or "").strip().rstrip("/")
-                        if name == agent_name and url == normalized_url:
-                            api_key = str(entry.get("api_key") or "").strip()
-                            break
+            if isinstance(cache, dict):
+                key = str(cache.get("api_key") or "").strip()
+                cached_url = str(cache.get("base_url") or "").strip().rstrip("/")
+                if key and (not cached_url or cached_url == service_url.rstrip("/")):
+                    api_key = key
         except Exception:
             pass
 

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -14,7 +14,7 @@ import os
 import sys
 from pathlib import Path
 
-_CONFIG_PATH = Path.home() / ".cognee-plugin" / "config.json"
+_CONFIG_PATH = Path.home() / ".cognee-plugin" / "claude-code" / "config.json"
 _DEFAULT_DATASET = "cognee_sessions"
 
 

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -21,7 +21,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-_CONFIG_DIR = Path.home() / ".cognee-plugin"
+_CONFIG_DIR = Path.home() / ".cognee-plugin" / "claude-code"
 _STATE_DIR = _CONFIG_DIR
 _CONFIG_FILE = _CONFIG_DIR / "config.json"
 _BRIDGE_STATE_FILE = _STATE_DIR / "bridge_state.json"

--- a/integrations/claude-code/scripts/exit-watcher.py
+++ b/integrations/claude-code/scripts/exit-watcher.py
@@ -14,7 +14,7 @@ import sys
 import time
 from pathlib import Path
 
-_PLUGIN_DIR = Path.home() / ".cognee-plugin"
+_PLUGIN_DIR = Path.home() / ".cognee-plugin" / "claude-code"
 _EXIT_WATCHERS_DIR = _PLUGIN_DIR / "exit-watchers"
 _PIDFILE = _PLUGIN_DIR / "exit-watcher.pid"
 _LOGFILE = _PLUGIN_DIR / "exit-watcher.log"

--- a/integrations/claude-code/scripts/idle-watcher.py
+++ b/integrations/claude-code/scripts/idle-watcher.py
@@ -31,7 +31,7 @@ POLL_SECONDS = float(os.environ.get("COGNEE_IDLE_POLL", "10"))
 IDLE_SECONDS = float(os.environ.get("COGNEE_IDLE_THRESHOLD", "60"))
 IMPROVE_COOLDOWN = float(os.environ.get("COGNEE_IMPROVE_COOLDOWN", "120"))
 
-_PLUGIN_DIR = Path.home() / ".cognee-plugin"
+_PLUGIN_DIR = Path.home() / ".cognee-plugin" / "claude-code"
 _ACTIVITY = _PLUGIN_DIR / "activity.ts"
 _PIDFILE = _PLUGIN_DIR / "watcher.pid"
 _STOPFILE = _PLUGIN_DIR / "watcher.stop"

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -280,7 +280,7 @@ async def _run(prompt: str) -> dict | None:
     try:
         from pathlib import Path as _Path
 
-        _state = _Path.home() / ".cognee-plugin" / "last_recall.json"
+        _state = _Path.home() / ".cognee-plugin" / "claude-code" / "last_recall.json"
         _state.parent.mkdir(parents=True, exist_ok=True)
         _state.write_text(
             json.dumps(
@@ -345,7 +345,7 @@ async def _run(prompt: str) -> dict | None:
         from datetime import timezone as _tz
         from pathlib import Path as _Path
 
-        _audit = _Path.home() / ".cognee-plugin" / "recall-audit.log"
+        _audit = _Path.home() / ".cognee-plugin" / "claude-code" / "recall-audit.log"
         _audit.parent.mkdir(parents=True, exist_ok=True)
         with _audit.open("a", encoding="utf-8") as fh:
             fh.write(

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -57,7 +57,7 @@ from config import (
     save_config,
 )
 
-_STATE_DIR = Path.home() / ".cognee-plugin"
+_STATE_DIR = Path.home() / ".cognee-plugin" / "claude-code"
 _GLOBAL_STATE_DIR = Path.home() / ".cognee-plugin"
 _WATCHER_PID = _STATE_DIR / "watcher.pid"
 _WATCHER_STOP = _STATE_DIR / "watcher.stop"
@@ -279,7 +279,14 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
                     timeout=timeout,
                 )
                 subprocess.run(
-                    [str(_VENV_PYTHON), "-m", "pip", "install", "--upgrade", f"cognee=={_PINNED_COGNEE_VERSION}"],
+                    [
+                        str(_VENV_PYTHON),
+                        "-m",
+                        "pip",
+                        "install",
+                        "--upgrade",
+                        f"cognee=={_PINNED_COGNEE_VERSION}",
+                    ],
                     check=True,
                     capture_output=True,
                     text=True,
@@ -1245,7 +1252,7 @@ async def _start(payload: dict | None = None) -> dict:
     _purge_legacy_resolved_files()
 
     # Create config file on first run if it doesn't exist
-    config_file = Path.home() / ".cognee-plugin" / "config.json"
+    config_file = _STATE_DIR / "config.json"
     if not config_file.exists():
         save_config(config)
 

--- a/integrations/claude-code/scripts/store-user-prompt.py
+++ b/integrations/claude-code/scripts/store-user-prompt.py
@@ -36,7 +36,7 @@ from _plugin_common import (
 from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
 
 MAX_TEXT = 4000
-_STATE_DIR = Path.home() / ".cognee-plugin"
+_STATE_DIR = Path.home() / ".cognee-plugin" / "claude-code"
 _WATCHER_PID = _STATE_DIR / "watcher.pid"
 _WATCHER_STOP = _STATE_DIR / "watcher.stop"
 _WATCHER_SCRIPT = Path(__file__).with_name("idle-watcher.py")

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -45,7 +45,7 @@ from config import (
     sync_graph_context_to_session,
 )
 
-_STATE_DIR = Path.home() / ".cognee-plugin"
+_STATE_DIR = Path.home() / ".cognee-plugin" / "claude-code"
 _WATCHER_PID = _STATE_DIR / "watcher.pid"
 _WATCHER_STOP = _STATE_DIR / "watcher.stop"
 _DETACHED_ARG = "--detached-final"

--- a/integrations/claude-code/skills/cognee-remember/SKILL.md
+++ b/integrations/claude-code/skills/cognee-remember/SKILL.md
@@ -23,32 +23,32 @@ Determine the category from the user's intent, then run:
 
 **User data** (preferences, corrections, personal context):
 ```bash
-cognee-cli remember "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set user_context
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-remember.sh "$ARGUMENTS" --node-set user_context
 ```
 
 **Project data** (docs, code, company knowledge):
 ```bash
-cognee-cli remember "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set project_docs
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-remember.sh "$ARGUMENTS" --node-set project_docs
 ```
 
 **Agent data** (explicit agent notes — routine tool logs are automatic):
 ```bash
-cognee-cli remember "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set agent_actions
+${CLAUDE_PLUGIN_ROOT}/scripts/cognee-remember.sh "$ARGUMENTS" --node-set agent_actions
 ```
 
-If the category is unclear, default to **project**.
+The wrapper POSTs to the running Cognee server (`/api/v1/remember`). A `{"ok": true}` response means the server accepted the data. An error response means the server rejected or failed the request — check `COGNEE_API_KEY` and server logs; do **not** re-run or conclude the data wasn't stored without confirming against the server.
 
-The command outputs a summary after completion:
+**IMPORTANT**: The wrapper always runs in the foreground (`run_in_background=false`) to ensure the full pipeline completes before returning.
 
+## Fallback only — server unreachable
+
+`cognee-cli` is a thin client over the same server. Use it only when the server is genuinely down:
+
+```bash
+cognee-cli remember "$ARGUMENTS" -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" --node-set user_context
 ```
-Data ingested and knowledge graph built successfully!
-  Dataset ID: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
-  Items processed: 1
-  Content hash: a1b2c3d4...
-  Elapsed: 4.2s
-```
 
-**IMPORTANT**: Do NOT use the `-b` (background) flag. Always run in the foreground to ensure the full pipeline completes.
+**Empty or clean CLI output does NOT confirm the data was stored.** Verify via the server directly once it is back up.
 
 ## When to use
 

--- a/integrations/claude-code/skills/cognee-sync/SKILL.md
+++ b/integrations/claude-code/skills/cognee-sync/SKILL.md
@@ -15,12 +15,6 @@ Run the sync script:
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/sync-session-to-graph.py
 ```
 
-Or equivalently via CLI:
-
-```bash
-cognee-cli improve -d "${COGNEE_PLUGIN_DATASET:-claude_sessions}" -s "${COGNEE_SESSION_ID:-claude_code_session}"
-```
-
 ## What this does
 
 1. **Apply feedback weights** -- session entries with feedback scores update graph node/edge weights

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -19,12 +19,13 @@ from pathlib import Path
 from typing import Optional
 
 _PLUGIN_DIR = Path.home() / ".cognee-plugin" / "codex"
+_SHARED_PLUGIN_ROOT = Path.home() / ".cognee-plugin"
 _HOOK_LOG = _PLUGIN_DIR / "hook.log"
 _COUNTER_FILE = _PLUGIN_DIR / "counter.json"
 _ACTIVITY_FILE = _PLUGIN_DIR / "activity.ts"
 _ACTIVITY_LOG = _PLUGIN_DIR / "activity.log"
 _SAVE_COUNTER = _PLUGIN_DIR / "save_counter.json"
-_SERVER_READY_MARKER = Path.home() / ".cognee-plugin" / "server-ready.json"
+_SERVER_READY_MARKER = _SHARED_PLUGIN_ROOT / "server-ready.json"
 _SERVER_READY_TTL_SECONDS = 30
 _SYNC_LOCK = _PLUGIN_DIR / "sync.lock"
 # Per-agent-session buffer dirs. Each agent session (one Claude/Codex terminal)
@@ -35,7 +36,7 @@ _PENDING_DIR = _PLUGIN_DIR / "pending"
 _SUBPROCESS_LOG = _PLUGIN_DIR / "subprocess.log"
 # Single-principal model: one API key (user-provided COGNEE_API_KEY or one minted
 # from the default user) is cached here. Replaces the old per-agent agent_keys.json.
-_API_KEY_CACHE = _PLUGIN_DIR / "api_key.json"
+_API_KEY_CACHE = _SHARED_PLUGIN_ROOT / "api_key.json"
 # Host-session-id -> generated Cognee session-id map. The host (Claude/Codex)
 # session id is used ONLY as a local correlation key so every hook process of a
 # single launch resolves the SAME Cognee session id; it is never sent to Cognee
@@ -59,7 +60,6 @@ _DEFAULT_LOCAL_SERVICE_URL = "http://localhost:8011"
 # cognee server, and the data store are shared with the Claude Code plugin so
 # cognee is installed once and a single server serves both. Only per-plugin
 # state (logs, buffers) stays under _PLUGIN_DIR; the runtime lives at the root.
-_SHARED_PLUGIN_ROOT = Path.home() / ".cognee-plugin"
 _VENV_DIR = _SHARED_PLUGIN_ROOT / "venv"
 _VENV_PYTHON = _VENV_DIR / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
 _VENV_READY_MARKER = _SHARED_PLUGIN_ROOT / "venv-ready.json"

--- a/integrations/codex/plugins/cognee/scripts/_remember_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_remember_http.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Server-first remember against Cognee's ``/api/v1/remember``.
+
+Standalone, stdlib-only, so it runs under the system ``python3`` without the
+plugin venv (the same constraint ``cognee-search.sh`` already works under).
+
+Contract — what gets printed to stdout:
+  * ``{"ok": true}`` on a 2xx response.
+  * the sentinel ``UNREACHABLE`` ONLY when the server cannot be reached
+    (connection refused, timeout, DNS). The caller may then fall back to the
+    local CLI as a degraded path.
+  * a JSON **error object** ``{"error", "status", "authoritative": false}`` on
+    any HTTP error (5xx, 4xx, and especially **401/403** auth rejections). The
+    caller MUST NOT fall back to the local CLI here: the server was reachable and
+    rejected/failed the request, so falling back could bypass auth boundaries
+    or silently double-write to a different backend.
+
+Diagnostics also go to stderr so the caller can surface them.
+"""
+
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+
+UNREACHABLE = "UNREACHABLE"
+
+
+def _is_local(url):
+    """True for a localhost/loopback target (where a cloud API key is meaningless)."""
+    host = (urllib.parse.urlparse(url).hostname or "").lower()
+    return host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
+
+
+def _multipart_body(fields, files):
+    boundary = f"----cogneeRemember{uuid.uuid4().hex}"
+    chunks = []
+    for name, value in fields.items():
+        chunks.append(f"--{boundary}\r\n".encode("utf-8"))
+        chunks.append(f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode("utf-8"))
+        chunks.append(str(value).encode("utf-8"))
+        chunks.append(b"\r\n")
+    for field_name, filename, content in files:
+        chunks.append(f"--{boundary}\r\n".encode("utf-8"))
+        chunks.append(
+            (
+                f'Content-Disposition: form-data; name="{field_name}"; filename="{filename}"\r\n'
+                "Content-Type: text/plain; charset=utf-8\r\n\r\n"
+            ).encode("utf-8")
+        )
+        chunks.append(content if isinstance(content, bytes) else content.encode("utf-8"))
+        chunks.append(b"\r\n")
+    chunks.append(f"--{boundary}--\r\n".encode("utf-8"))
+    return b"".join(chunks), boundary
+
+
+def _error(status, message):
+    """An error envelope — reachable server, but the request was rejected/failed.
+
+    Distinct from UNREACHABLE so the caller does NOT fall back to the local CLI.
+    """
+    return {"error": message, "status": status, "authoritative": False}
+
+
+def do_remember(
+    service_url,
+    api_key,
+    content,
+    dataset,
+    node_set,
+    *,
+    opener=urllib.request.urlopen,
+    timeout=60.0,
+):
+    """POST content to the server. Return {"ok": true}, an error envelope, or UNREACHABLE."""
+    url = service_url.rstrip("/") + "/api/v1/remember"
+    filename = f"{node_set or 'content'}.txt"
+    body, boundary = _multipart_body(
+        {
+            "datasetName": dataset,
+            "node_set": node_set,
+            "run_in_background": "false",
+        },
+        [("data", filename, content.encode("utf-8") if isinstance(content, str) else content)],
+    )
+    headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
+    # COGNEE_API_KEY is a cloud credential; local single-user servers need no
+    # auth and ignore it. Only attach it for a remote/cloud target.
+    if api_key and not _is_local(service_url):
+        headers["X-Api-Key"] = api_key
+
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with opener(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        if e.code in (401, 403):
+            msg = "unauthorized (HTTP %s) — check COGNEE_API_KEY / credentials" % e.code
+        else:
+            msg = "server returned HTTP %s for /api/v1/remember" % e.code
+        sys.stderr.write("[cognee-remember] %s — NOT falling back to local CLI\n" % msg)
+        return _error(e.code, msg)
+    except Exception as e:
+        sys.stderr.write(
+            "[cognee-remember] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+        )
+        return UNREACHABLE
+
+    # The server responded with 2xx. A body we can't parse is fine —
+    # the important thing is the server accepted the request.
+    try:
+        data = json.loads(raw or "{}")
+    except (json.JSONDecodeError, ValueError):
+        return {"ok": True}
+
+    if isinstance(data, dict) and data.get("error"):
+        msg = str(data.get("error"))[:200]
+        sys.stderr.write("[cognee-remember] server returned error: %s\n" % msg)
+        return _error(200, msg)
+    return {"ok": True}
+
+
+def main(argv):
+    # argv: service_url, api_key, content, dataset, node_set
+    a = list(argv) + [""] * 5
+    result = do_remember(a[0], a[1], a[2], a[3], a[4])
+    print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/integrations/codex/plugins/cognee/scripts/cognee-remember.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-remember.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Store text in Cognee's permanent knowledge graph.
+#
+# Usage:
+#   cognee-remember.sh <content> [--node-set <node_set>] [--dataset <dataset>]
+#
+# --node-set: node set for categorization (default: user_context)
+#             user_context | project_docs | agent_actions
+# --dataset:  dataset name (default: from env or connection lookup)
+#
+# Configuration:
+#   Resolves auth and dataset from api_key.json and Cognee endpoints.
+#   Falls back to cognee-cli only if the server is unreachable.
+
+set -euo pipefail
+
+PLUGIN_DIR="${HOME}/.cognee-plugin/codex"
+runtime_json="$(python3 - <<'PY' "${PLUGIN_DIR}" 2>/dev/null || true
+import json
+import pathlib
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+plugin_dir = pathlib.Path(sys.argv[1])
+import os
+service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
+api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
+
+if not api_key:
+    cache_path = plugin_dir.parent / "api_key.json"
+    if cache_path.exists():
+        try:
+            cache = json.loads(cache_path.read_text())
+            if isinstance(cache, dict):
+                key = str(cache.get("api_key") or "").strip()
+                cached_url = str(cache.get("base_url") or "").strip().rstrip("/")
+                if key and (not cached_url or cached_url == service_url.rstrip("/")):
+                    api_key = key
+        except Exception:
+            pass
+
+dataset = ""
+if service_url and api_key:
+    try:
+        session_key = (os.environ.get("COGNEE_SESSION_KEY") or "").strip()
+        query = ""
+        if session_key:
+            query = "?agent_session_name=" + urllib.parse.quote(session_key, safe="")
+        req = urllib.request.Request(
+            service_url.rstrip("/") + "/api/v1/agents/connections/me" + query,
+            headers={"X-Api-Key": api_key},
+        )
+        with urllib.request.urlopen(req, timeout=3.0) as resp:
+            payload = json.loads(resp.read().decode("utf-8") or "{}")
+        if isinstance(payload, dict):
+            agent = payload.get("agent") if isinstance(payload.get("agent"), dict) else {}
+            if isinstance(agent, dict):
+                datasets = agent.get("datasets") if isinstance(agent.get("datasets"), list) else []
+                for item in datasets:
+                    if isinstance(item, dict):
+                        name = str(item.get("name") or "").strip()
+                        if name:
+                            dataset = name
+                            break
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError, json.JSONDecodeError):
+        pass
+
+print(json.dumps({"service_url": service_url, "api_key": api_key, "dataset": dataset}))
+PY
+)"
+
+SERVICE_URL="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("service_url") or "").strip())
+except Exception:
+    pass
+PY
+)"
+API_KEY="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("api_key") or "").strip())
+except Exception:
+    pass
+PY
+)"
+DATASET="$(python3 - <<'PY' "${runtime_json}" 2>/dev/null || true
+import json, sys
+try:
+    print((json.loads(sys.argv[1] or "{}").get("dataset") or "").strip())
+except Exception:
+    pass
+PY
+)"
+
+[ -z "$SERVICE_URL" ] && SERVICE_URL="${COGNEE_BASE_URL:-${COGNEE_LOCAL_API_URL:-http://localhost:8011}}"
+[ -z "$API_KEY" ] && API_KEY="${COGNEE_API_KEY:-}"
+[ -z "$DATASET" ] && DATASET="${COGNEE_PLUGIN_DATASET:-codex_sessions}"
+
+# Parse arguments: content is first positional; flags follow
+CONTENT="${1:-}"
+NODE_SET="user_context"
+
+shift || true
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --node-set)
+            shift
+            NODE_SET="${1:-user_context}"
+            ;;
+        --dataset|-d)
+            shift
+            DATASET="${1:-$DATASET}"
+            ;;
+        *)
+            ;;
+    esac
+    shift || true
+done
+
+if [ -z "$CONTENT" ]; then
+    echo "Error: no content provided" >&2
+    exit 1
+fi
+
+# Server-first: POST to /api/v1/remember via _remember_http.py.
+# UNREACHABLE → fall back to cognee-cli and warn.
+# Any other result (ok or error) → authoritative; do not fall back.
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+RESULT="$(python3 "${SELF_DIR}/_remember_http.py" "$SERVICE_URL" "$API_KEY" "$CONTENT" "$DATASET" "$NODE_SET" || true)"
+
+if [ -n "$RESULT" ] && [ "$RESULT" != "UNREACHABLE" ]; then
+    printf '%s\n' "$RESULT"
+else
+    echo "[cognee-remember] falling back to cognee-cli (degraded — server unreachable; verify the store succeeded once the server is back)" >&2
+    uv run cognee-cli remember "$CONTENT" -d "$DATASET" --node-set "$NODE_SET" 2>/dev/null || true
+fi

--- a/integrations/codex/plugins/cognee/scripts/cognee-search.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-search.sh
@@ -27,34 +27,16 @@ plugin_dir = pathlib.Path(sys.argv[1])
 import os
 service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
 api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
-agent_name = (os.environ.get("COGNEE_AGENT_NAME") or "").strip()
-if agent_name:
-    if agent_name.endswith("@cognee.agent"):
-        agent_name = agent_name[: -len("@cognee.agent")]
-    if not agent_name.endswith("_codex"):
-        agent_name = f"{agent_name}_codex"
-
-if not api_key and service_url and agent_name:
-    cache_path = plugin_dir / "agent_keys.json"
+if not api_key:
+    cache_path = plugin_dir.parent / "api_key.json"
     if cache_path.exists():
         try:
             cache = json.loads(cache_path.read_text())
-            entries = cache.get("entries", {}) if isinstance(cache, dict) else {}
-            if isinstance(entries, dict):
-                normalized_url = service_url.rstrip("/")
-                key = f"{normalized_url}::{agent_name}"
-                chosen = entries.get(key)
-                if isinstance(chosen, dict):
-                    api_key = str(chosen.get("api_key") or "").strip()
-                else:
-                    for entry in entries.values():
-                        if not isinstance(entry, dict):
-                            continue
-                        name = str(entry.get("agent_name") or "").strip()
-                        url = str(entry.get("base_url") or "").strip().rstrip("/")
-                        if name == agent_name and url == normalized_url:
-                            api_key = str(entry.get("api_key") or "").strip()
-                            break
+            if isinstance(cache, dict):
+                key = str(cache.get("api_key") or "").strip()
+                cached_url = str(cache.get("base_url") or "").strip().rstrip("/")
+                if key and (not cached_url or cached_url == service_url.rstrip("/")):
+                    api_key = key
         except Exception:
             pass
 

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -278,7 +278,14 @@ def ensure_cognee_installed(timeout: float = _INSTALL_TIMEOUT_SECONDS) -> bool:
                     timeout=timeout,
                 )
                 subprocess.run(
-                    [str(_VENV_PYTHON), "-m", "pip", "install", "--upgrade", f"cognee=={_PINNED_COGNEE_VERSION}"],
+                    [
+                        str(_VENV_PYTHON),
+                        "-m",
+                        "pip",
+                        "install",
+                        "--upgrade",
+                        f"cognee=={_PINNED_COGNEE_VERSION}",
+                    ],
                     check=True,
                     capture_output=True,
                     text=True,

--- a/integrations/codex/plugins/cognee/skills/memory/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/memory/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: memory
-description: Use when Codex should remember, recall, search, improve, or forget information using the Cognee CLI.
+description: Use when Codex should remember, recall, search, improve, or forget information using Cognee.
 ---
 
-# Cognee CLI Memory
+# Cognee Memory
 
 Use this skill when the user asks Codex to use Cognee as memory, add facts or
 documents, search a knowledge graph, recall prior context, or improve existing
@@ -11,22 +11,29 @@ memory.
 
 ## Rules
 
-- Use `uv run cognee-cli ...`; do not use MCP.
-- Prefer `remember` for one-step ingestion and graph construction.
-- Use `add` plus `cognify` when ingestion and processing should be staged.
+- Prefer the server-first paths below (HTTP to the running Cognee server).
+- Use `uv run cognee-cli ...` only when the server is genuinely unreachable.
 - Choose a clear dataset name with `-d` or `--dataset-name`; ask only if the dataset boundary is genuinely ambiguous.
 - Do not ingest secrets, credentials, `.env` files, private keys, token dumps, or unrelated generated artifacts.
 - Before destructive commands such as `forget`, `delete`, or `--everything`, get explicit user confirmation.
 
 ## Add And Build
 
-One-step ingestion:
+**Server-first (one-step ingestion):**
+
+```bash
+${CODEX_PLUGIN_ROOT}/scripts/cognee-remember.sh "<text>" --node-set user_context
+```
+
+Use `--node-set project_docs` for project/code content, `--node-set agent_actions` for agent notes. The script POSTs directly to `/api/v1/remember` and returns `{"ok": true}` on success.
+
+**Fallback only — server unreachable:**
 
 ```bash
 uv run cognee-cli remember <text-or-path> -d <dataset-name>
 ```
 
-For larger or staged work:
+For staged work (no HTTP equivalent — CLI only):
 
 ```bash
 uv run cognee-cli add <text-or-path> -d <dataset-name>
@@ -42,13 +49,24 @@ uv run cognee-cli cognify -d <dataset-name> --background
 
 ## Recall And Search
 
-Memory-oriented recall:
+**Server-first (authoritative):**
+
+```bash
+curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: ${COGNEE_API_KEY:-}" \
+  -d '{"query": "<question>", "top_k": 10, "only_context": true, "scope": ["graph"]}'
+```
+
+Omit `-H "X-Api-Key: ..."` for a local single-user server (auth is optional). An empty list `[]` from the server is authoritative — the server searched and found nothing.
+
+**Fallback only — server unreachable:**
 
 ```bash
 uv run cognee-cli recall "<question>" -d <dataset-name> -f pretty
 ```
 
-Search modes:
+Search modes (CLI only):
 
 ```bash
 uv run cognee-cli search "<question>" -d <dataset-name> -t GRAPH_COMPLETION -f pretty
@@ -56,24 +74,22 @@ uv run cognee-cli search "<exact passage or citation need>" -d <dataset-name> -t
 uv run cognee-cli search "<code question>" -d <dataset-name> -t CODE -k 10 -f pretty
 ```
 
-Use `-f json` when downstream parsing is needed.
-
 ### The server is the source of truth
 
 `cognee-cli` is a thin client over the running Cognee server and can print **empty stdout even when content exists** (a serialization quirk). So:
-- **Never conclude "not found" from an empty/clean CLI run.** Confirm against the server directly — this is authoritative:
-  ```bash
-  curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
-    -H "Content-Type: application/json" \
-    -H "X-Api-Key: ${COGNEE_API_KEY:-}" \
-    -d '{"query": "<question>", "top_k": 5, "only_context": true, "scope": ["graph"]}'
-  ```
+- **Never conclude "not found" from an empty/clean CLI run.** Confirm against the server directly — this is authoritative.
 - **Do not re-run the same CLI search to "retry."** One server answer is authoritative.
 - Omit `-d <dataset>` to search **all** your datasets; restricting to one dataset can miss content that lives in another.
 
 ## Improve Memory
 
-Enrich an existing graph:
+**Server-first (session → graph sync):**
+
+```bash
+python3 "${CODEX_PLUGIN_ROOT}/scripts/sync-session-to-graph.py"
+```
+
+**Fallback only — server unreachable:**
 
 ```bash
 uv run cognee-cli improve -d <dataset-name>


### PR DESCRIPTION
This PR makes sure cli is not used via remember and sync skills, similar to what was done for search. 
This PR also splits claude-code files into a separate directory, so the file organization is cleaner.