### PR TITLE
feat(recall): resilient cohesive client — circuit breaker + bounded timeout

### DIFF
--- a/integrations/claude-code/scripts/_cognee_client.py
+++ b/integrations/claude-code/scripts/_cognee_client.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Cohesive, resilient cognee recall client for the plugin.
+
+This is the single layer the recall paths route through — the explicit
+`cognee-search.sh` wrapper and (via a shared breaker) the auto-recall hook — so a
+repeatedly-failing backend trips one **circuit breaker** instead of being hammered
+on every call, and every call gets a bounded, named **timeout**.
+
+The recall transport itself lives in `_recall_http.do_recall` (server-first, with
+the list / error-envelope / UNREACHABLE contract); this module adds the breaker +
+timeout policy around it.
+
+The breaker is **file-based** on purpose: each plugin hook/script runs as a
+short-lived process, so in-memory state (as a long-lived provider like Hermes
+uses) would not survive between calls. State lives in the plugin state dir.
+"""
+
+import json
+import os
+import pathlib
+import sys
+import time
+
+from _recall_http import UNREACHABLE, _error, do_recall
+
+# Tunables (mirror Hermes's provider defaults).
+_THRESHOLD = int(os.environ.get("COGNEE_BREAKER_THRESHOLD", "5"))
+_COOLDOWN = float(os.environ.get("COGNEE_BREAKER_COOLDOWN", "120"))
+_RECALL_TIMEOUT = float(os.environ.get("COGNEE_RECALL_TIMEOUT", "20"))
+
+
+def _state_path():
+    base = os.environ.get("COGNEE_PLUGIN_STATE_DIR") or os.path.expanduser("~/.cognee-plugin")
+    return pathlib.Path(base) / "recall-breaker.json"
+
+
+def _read():
+    try:
+        data = json.loads(_state_path().read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _write(state):
+    try:
+        path = _state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def breaker_open(now=None):
+    """Return (is_open, retry_in_seconds). Open while we're inside the cooldown window."""
+    now = time.time() if now is None else now
+    until = float(_read().get("cooldown_until") or 0.0)
+    return (True, int(until - now)) if now < until else (False, 0)
+
+
+def record_failure(error="", now=None):
+    """Count a backend failure; open the breaker once we hit the threshold."""
+    now = time.time() if now is None else now
+    state = _read()
+    failures = int(state.get("failures") or 0) + 1
+    state["failures"] = failures
+    state["last_error"] = str(error)[:200]
+    if failures >= _THRESHOLD:
+        state["cooldown_until"] = now + _COOLDOWN
+    _write(state)
+
+
+def record_success():
+    """Backend answered — clear the breaker."""
+    _write({"failures": 0, "cooldown_until": 0.0})
+
+
+def recall(service_url, api_key, query, session_id, scope, top_k, *, timeout=None):
+    """Breaker-wrapped recall. Returns a list, an error-envelope dict, or UNREACHABLE.
+
+    Only genuine backend trouble trips the breaker: UNREACHABLE (connection
+    failure) or a 5xx. A reachable 4xx (e.g. 401/403 auth) is a config problem —
+    surfaced, but it does NOT open the breaker (waiting wouldn't fix it).
+    """
+    is_open, retry = breaker_open()
+    if is_open:
+        # We're in cooldown: surface a clear message and do NOT call (and, since
+        # this isn't UNREACHABLE, the wrapper won't fall back to the CLI either —
+        # which would just hammer the same down server).
+        return _error(503, "cognee temporarily unavailable (circuit open, retry in ~%ds)" % retry)
+
+    result = do_recall(
+        service_url,
+        api_key,
+        query,
+        session_id,
+        scope,
+        top_k,
+        timeout=timeout or _RECALL_TIMEOUT,
+    )
+    if result == UNREACHABLE:
+        record_failure("unreachable")
+    elif isinstance(result, dict) and int(result.get("status") or 0) >= 500:
+        record_failure("http %s" % result.get("status"))
+    else:
+        record_success()
+    return result
+
+
+def main(argv):
+    # argv: service_url, api_key, query, session_id, scope, top_k
+    a = list(argv) + [""] * 6
+    result = recall(a[0], a[1], a[2], a[3], a[4], a[5])
+    print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/integrations/claude-code/scripts/cognee-search.sh
+++ b/integrations/claude-code/scripts/cognee-search.sh
@@ -140,9 +140,11 @@ esac
 # `datasets` is intentionally NOT sent: the server scopes to the caller's
 # read-authorized datasets, so search spans them all (restricting to the plugin
 # default is what produced false "not found" when content lived elsewhere).
-# Logic lives in _recall_http.py (stdlib-only, unit-tested); stderr is surfaced.
+# Logic lives in _cognee_client.py (stdlib-only, unit-tested): server-first recall
+# wrapped by a shared file-based circuit breaker + a bounded timeout. stderr surfaced.
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
-RECALL_JSON="$(python3 "${SELF_DIR}/_recall_http.py" "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$SCOPE" "$TOP_K" || true)"
+export COGNEE_PLUGIN_STATE_DIR="$PLUGIN_DIR"
+RECALL_JSON="$(python3 "${SELF_DIR}/_cognee_client.py" "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$SCOPE" "$TOP_K" || true)"
 
 if [ -n "$RECALL_JSON" ] && [ "$RECALL_JSON" != "UNREACHABLE" ]; then
     # Server answered — authoritative, even if the result is empty.

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -209,6 +209,19 @@ async def _run(prompt: str) -> dict | None:
     # whole loop stops once the overall budget is spent. Partial results are fine.
     recall_timeout = _float_env("COGNEE_RECALL_TIMEOUT", 2.5)
     budget_deadline = time.monotonic() + _float_env("COGNEE_RECALL_BUDGET", 4.0)
+    # Respect the shared circuit breaker: when the server has been failing (tripped
+    # by the explicit recall path), skip this per-prompt recall rather than hammering
+    # a down backend on every keystroke. HTTP/cloud mode only.
+    if cloud_mode:
+        try:
+            from _cognee_client import breaker_open
+
+            _bopen, _bretry = breaker_open()
+        except Exception:
+            _bopen, _bretry = False, 0
+        if _bopen:
+            hook_log("recall_breaker_open", {"retry_in": _bretry})
+            scope_specs = []
     for scope_list, qtype in scope_specs:
         if time.monotonic() >= budget_deadline:
             hook_log("recall_budget_exceeded", {"collected": len(results)})

--- a/integrations/claude-code/tests/test_cognee_client.py
+++ b/integrations/claude-code/tests/test_cognee_client.py
@@ -1,0 +1,113 @@
+"""Unit tests for the cohesive recall client + circuit breaker (_cognee_client.py).
+
+The breaker is file-based (each plugin hook is a short-lived process), so these
+tests point COGNEE_PLUGIN_STATE_DIR at a temp dir and patch the transport
+(`do_recall`) to drive each branch.
+
+Run: `pytest integrations/claude-code/tests/test_cognee_client.py`
+(or `python integrations/claude-code/tests/test_cognee_client.py` standalone).
+"""
+
+import pathlib
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import os  # noqa: E402
+
+_TMP = tempfile.mkdtemp(prefix="cognee-breaker-test-")
+os.environ["COGNEE_PLUGIN_STATE_DIR"] = _TMP
+
+import _cognee_client as cc  # noqa: E402
+from _recall_http import UNREACHABLE  # noqa: E402
+
+
+def _reset():
+    p = pathlib.Path(_TMP) / "recall-breaker.json"
+    if p.exists():
+        p.unlink()
+
+
+def _stub(value):
+    """Make the transport return a fixed value."""
+    cc.do_recall = lambda *a, **k: value
+
+
+def test_closed_passes_results_through():
+    _reset()
+    _stub([{"text": "hit"}])
+    assert cc.recall("http://x", "", "q", "", '["graph"]', "5") == [{"text": "hit"}]
+    assert cc.breaker_open()[0] is False
+
+
+def test_opens_after_threshold_unreachable_then_short_circuits():
+    _reset()
+    _stub(UNREACHABLE)
+    for _ in range(cc._THRESHOLD):
+        cc.recall("http://x", "", "q", "", '["graph"]', "5")
+    is_open, retry = cc.breaker_open()
+    assert is_open and retry > 0
+
+    # While open, recall must NOT call the transport and must surface a 503 envelope.
+    def _boom(*a, **k):
+        raise AssertionError("transport must not be called while breaker is open")
+
+    cc.do_recall = _boom
+    out = cc.recall("http://x", "", "q", "", '["graph"]', "5")
+    assert isinstance(out, dict) and out["status"] == 503 and out["authoritative"] is False
+
+
+def test_5xx_trips_breaker():
+    _reset()
+    _stub({"error": "boom", "status": 503, "authoritative": False})
+    for _ in range(cc._THRESHOLD):
+        cc.recall("http://x", "", "q", "", '["graph"]', "5")
+    assert cc.breaker_open()[0] is True
+
+
+def test_auth_4xx_does_not_trip():
+    _reset()
+    _stub({"error": "unauthorized", "status": 403, "authoritative": False})
+    for _ in range(cc._THRESHOLD + 2):
+        cc.recall("http://x", "k", "q", "", '["graph"]', "5")
+    assert cc.breaker_open()[0] is False  # config problem, not a backend outage
+
+
+def test_empty_list_is_success_not_failure():
+    _reset()
+    _stub([])
+    for _ in range(cc._THRESHOLD + 2):
+        cc.recall("http://x", "", "q", "", '["graph"]', "5")
+    assert cc.breaker_open()[0] is False
+
+
+def test_resets_after_cooldown():
+    _reset()
+    now = 1000.0
+    for _ in range(cc._THRESHOLD):
+        cc.record_failure("x", now=now)
+    assert cc.breaker_open(now=now)[0] is True
+    assert cc.breaker_open(now=now + cc._COOLDOWN + 1)[0] is False
+
+
+def test_record_success_clears():
+    _reset()
+    for _ in range(cc._THRESHOLD):
+        cc.record_failure("x")
+    assert cc.breaker_open()[0] is True
+    cc.record_success()
+    assert cc.breaker_open()[0] is False
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print("PASS", name)
+            except AssertionError as e:
+                failures += 1
+                print("FAIL", name, e)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/scripts/_cognee_client.py
+++ b/integrations/codex/plugins/cognee/scripts/_cognee_client.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Cohesive, resilient cognee recall client for the plugin.
+
+This is the single layer the recall paths route through — the explicit
+`cognee-search.sh` wrapper and (via a shared breaker) the auto-recall hook — so a
+repeatedly-failing backend trips one **circuit breaker** instead of being hammered
+on every call, and every call gets a bounded, named **timeout**.
+
+The recall transport itself lives in `_recall_http.do_recall` (server-first, with
+the list / error-envelope / UNREACHABLE contract); this module adds the breaker +
+timeout policy around it.
+
+The breaker is **file-based** on purpose: each plugin hook/script runs as a
+short-lived process, so in-memory state (as a long-lived provider like Hermes
+uses) would not survive between calls. State lives in the plugin state dir.
+"""
+
+import json
+import os
+import pathlib
+import sys
+import time
+
+from _recall_http import UNREACHABLE, _error, do_recall
+
+# Tunables (mirror Hermes's provider defaults).
+_THRESHOLD = int(os.environ.get("COGNEE_BREAKER_THRESHOLD", "5"))
+_COOLDOWN = float(os.environ.get("COGNEE_BREAKER_COOLDOWN", "120"))
+_RECALL_TIMEOUT = float(os.environ.get("COGNEE_RECALL_TIMEOUT", "20"))
+
+
+def _state_path():
+    base = os.environ.get("COGNEE_PLUGIN_STATE_DIR") or os.path.expanduser("~/.cognee-plugin")
+    return pathlib.Path(base) / "recall-breaker.json"
+
+
+def _read():
+    try:
+        data = json.loads(_state_path().read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _write(state):
+    try:
+        path = _state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def breaker_open(now=None):
+    """Return (is_open, retry_in_seconds). Open while we're inside the cooldown window."""
+    now = time.time() if now is None else now
+    until = float(_read().get("cooldown_until") or 0.0)
+    return (True, int(until - now)) if now < until else (False, 0)
+
+
+def record_failure(error="", now=None):
+    """Count a backend failure; open the breaker once we hit the threshold."""
+    now = time.time() if now is None else now
+    state = _read()
+    failures = int(state.get("failures") or 0) + 1
+    state["failures"] = failures
+    state["last_error"] = str(error)[:200]
+    if failures >= _THRESHOLD:
+        state["cooldown_until"] = now + _COOLDOWN
+    _write(state)
+
+
+def record_success():
+    """Backend answered — clear the breaker."""
+    _write({"failures": 0, "cooldown_until": 0.0})
+
+
+def recall(service_url, api_key, query, session_id, scope, top_k, *, timeout=None):
+    """Breaker-wrapped recall. Returns a list, an error-envelope dict, or UNREACHABLE.
+
+    Only genuine backend trouble trips the breaker: UNREACHABLE (connection
+    failure) or a 5xx. A reachable 4xx (e.g. 401/403 auth) is a config problem —
+    surfaced, but it does NOT open the breaker (waiting wouldn't fix it).
+    """
+    is_open, retry = breaker_open()
+    if is_open:
+        # We're in cooldown: surface a clear message and do NOT call (and, since
+        # this isn't UNREACHABLE, the wrapper won't fall back to the CLI either —
+        # which would just hammer the same down server).
+        return _error(503, "cognee temporarily unavailable (circuit open, retry in ~%ds)" % retry)
+
+    result = do_recall(
+        service_url,
+        api_key,
+        query,
+        session_id,
+        scope,
+        top_k,
+        timeout=timeout or _RECALL_TIMEOUT,
+    )
+    if result == UNREACHABLE:
+        record_failure("unreachable")
+    elif isinstance(result, dict) and int(result.get("status") or 0) >= 500:
+        record_failure("http %s" % result.get("status"))
+    else:
+        record_success()
+    return result
+
+
+def main(argv):
+    # argv: service_url, api_key, query, session_id, scope, top_k
+    a = list(argv) + [""] * 6
+    result = recall(a[0], a[1], a[2], a[3], a[4], a[5])
+    print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/integrations/codex/plugins/cognee/scripts/cognee-search.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-search.sh
@@ -140,9 +140,11 @@ esac
 # `datasets` is intentionally NOT sent: the server scopes to the caller's
 # read-authorized datasets, so search spans them all (restricting to the plugin
 # default is what produced false "not found" when content lived elsewhere).
-# Logic lives in _recall_http.py (stdlib-only, unit-tested); stderr is surfaced.
+# Logic lives in _cognee_client.py (stdlib-only, unit-tested): server-first recall
+# wrapped by a shared file-based circuit breaker + a bounded timeout. stderr surfaced.
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
-RECALL_JSON="$(python3 "${SELF_DIR}/_recall_http.py" "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$SCOPE" "$TOP_K" || true)"
+export COGNEE_PLUGIN_STATE_DIR="$PLUGIN_DIR"
+RECALL_JSON="$(python3 "${SELF_DIR}/_cognee_client.py" "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$SCOPE" "$TOP_K" || true)"
 
 if [ -n "$RECALL_JSON" ] && [ "$RECALL_JSON" != "UNREACHABLE" ]; then
     # Server answered — authoritative, even if the result is empty.

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -199,6 +199,19 @@ async def _run(prompt: str) -> dict | None:
     # whole loop stops once the overall budget is spent. Partial results are fine.
     recall_timeout = _float_env("COGNEE_RECALL_TIMEOUT", 2.5)
     budget_deadline = time.monotonic() + _float_env("COGNEE_RECALL_BUDGET", 4.0)
+    # Respect the shared circuit breaker: when the server has been failing (tripped
+    # by the explicit recall path), skip this per-prompt recall rather than hammering
+    # a down backend on every keystroke. HTTP/cloud mode only.
+    if cloud_mode:
+        try:
+            from _cognee_client import breaker_open
+
+            _bopen, _bretry = breaker_open()
+        except Exception:
+            _bopen, _bretry = False, 0
+        if _bopen:
+            hook_log("recall_breaker_open", {"retry_in": _bretry})
+            scope_specs = []
     for scope_list, qtype in scope_specs:
         if time.monotonic() >= budget_deadline:
             hook_log("recall_budget_exceeded", {"collected": len(results)})


### PR DESCRIPTION
Brings the resilience patterns Hermes already has to the Claude/Codex recall path — the integrations' weakest layer (this session it hammered a broken backend with no backoff and gave repeated silent failures).

## What
New **`_cognee_client.py`** (both plugins) — the single module both recall paths route through. It wraps the existing `_recall_http.do_recall` transport with:

- **Circuit breaker (#1), file-based.** Each plugin hook/script is a *short-lived process*, so in-memory state (as Hermes uses) can't persist — state lives in `~/.cognee-plugin[/codex]/recall-breaker.json`. Trips only on genuine backend trouble (**UNREACHABLE / 5xx**), **not** on a reachable **401/403** (a config problem — surfaced, not looped). Threshold 5, cooldown 120s (mirrors Hermes). While open it returns one clear *"temporarily unavailable (retry in ~Ns)"* and does **not** fall back to the CLI (which would just hammer the same down server).
- **Bounded timeout (#2)**, env-configurable (`COGNEE_RECALL_TIMEOUT`).
- **Cohesion (#5):** `cognee-search.sh` routes through the client, and the auto-recall hot path (`session-context-lookup.py`) **respects the shared breaker** (skips the per-prompt recall while open) instead of hammering on every keystroke.

## Tests
`tests/test_cognee_client.py` (7): breaker open/close/reset, 5xx-trips vs 401-doesn't, empty-is-success (not a trip), short-circuit-while-open. Existing recall tests unchanged & green.

## Verified
- Unit tests green; `ruff format --check` + `ruff check` clean over `integrations/`.
- Live unreachable path: 6 failed calls → breaker opens → returns the 503 envelope, no further calls.
- The recall *transport* (`do_recall`) is unchanged from #87 (the content-return path is unaffected; the local server happened to be down during this verification).

Companion to the Hermes "move onto the local server" PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)