### PR TITLE
feat(claude-code): prefer Cognee as the default memory over native MEMORY.md

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -118,6 +118,26 @@ Claude-specific contracts are preserved:
 - `hookSpecificOutput` payload format
 - async hook behavior for write hooks
 
+## Memory preference
+
+With the plugin active, Cognee is the **preferred** memory system: relevant memory is
+auto-recalled into context on every `UserPromptSubmit` and writes are captured
+automatically, so Claude consults Cognee first when answering. To reinforce this, the
+`SessionStart` hook injects an `additionalContext` instruction telling Claude to treat
+Cognee as authoritative and prefer the Cognee tools/skills over Claude Code's built-in
+file memory (`MEMORY.md`).
+
+Note: a plugin **cannot reliably disable** Claude Code's native auto memory
+(`MEMORY.md` is injected as context, not a tool call that hooks can intercept). This
+feature steers the model toward Cognee rather than hard-disabling native memory. To
+turn the steer off, set `COGNEE_PREFER_MEMORY=false`. To additionally suppress native
+auto memory yourself, disable it in Claude Code (e.g. `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1`
+in the launching shell, if your Claude Code version supports it).
+
+| Env var | Default | Effect |
+|---|---|---|
+| `COGNEE_PREFER_MEMORY` | `true` | Inject SessionStart steer asserting Cognee as the preferred memory |
+
 ## Session sync and watchers
 
 An idle watcher runs in the background for the lifetime of each launch. It polls activity every `COGNEE_IDLE_POLL` seconds and persists the session cache when the session has been quiet for `COGNEE_IDLE_THRESHOLD` seconds, then waits at least `COGNEE_IMPROVE_COOLDOWN` seconds before the next run.

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -42,6 +42,9 @@ _DEFAULTS = {
     # Local mode
     "llm_api_key": "",
     "llm_model": "",
+    # Memory steering: assert Cognee as the preferred memory over Claude Code's
+    # built-in auto memory (MEMORY.md). Opt out with COGNEE_PREFER_MEMORY=false.
+    "prefer_cognee_memory": True,
 }
 
 
@@ -77,6 +80,7 @@ _ENV_MAP = {
     "COGNEE_USER_PASSWORD": "user_password",
     "LLM_API_KEY": "llm_api_key",
     "LLM_MODEL": "llm_model",
+    "COGNEE_PREFER_MEMORY": "prefer_cognee_memory",
     # Legacy compat
     "COGNEE_SESSION_ID": "_static_session_id",
 }

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -1160,6 +1160,44 @@ def _ensure_statusline_configured() -> None:
         hook_log("statusline_setup_failed", {"error": str(exc)[:200]})
 
 
+_MEMORY_PREFERENCE_STEER = (
+    "Memory policy for this session: Cognee is the preferred, authoritative long-term "
+    "memory. On every user request, Cognee memory relevant to the prompt is "
+    "automatically recalled and injected into your context before you answer — consult "
+    "that recalled Cognee context FIRST. When you need to look up or store durable "
+    "information, use the Cognee tools/skills (cognee-search, cognee-remember) in "
+    "preference to Claude Code's built-in file memory (MEMORY.md), and do not duplicate "
+    "durable knowledge into MEMORY.md. Cognee is the source of truth for memory."
+)
+
+
+def _apply_memory_preference(output: dict) -> dict:
+    """Steer Claude to treat Cognee as the preferred memory over native auto-memory.
+
+    Claude Code's built-in auto memory (MEMORY.md) can't be reliably disabled by a
+    plugin, so instead we assert Cognee as the authoritative memory via a SessionStart
+    ``additionalContext`` instruction (injected into the model's context, not shown to
+    the user). Applied across all SessionStart branches. Opt out with
+    ``COGNEE_PREFER_MEMORY=false``.
+    """
+    try:
+        val = load_config().get("prefer_cognee_memory", True)
+    except Exception:
+        val = True
+    if str(val).strip().lower() in {"0", "false", "no", "off"}:
+        return output
+
+    result = dict(output or {})
+    hso = dict(result.get("hookSpecificOutput") or {})
+    hso.setdefault("hookEventName", "SessionStart")
+    existing = str(hso.get("additionalContext") or "").strip()
+    hso["additionalContext"] = (
+        f"{existing}\n\n{_MEMORY_PREFERENCE_STEER}" if existing else _MEMORY_PREFERENCE_STEER
+    )
+    result["hookSpecificOutput"] = hso
+    return result
+
+
 async def _start(payload: dict | None = None) -> dict:
     _ensure_statusline_configured()
     config = load_config()
@@ -1319,6 +1357,7 @@ def main():
             output = asyncio.run(_start(payload))
     except Exception as exc:
         hook_log("session_start_exception", {"error": str(exc)[:200]})
+    output = _apply_memory_preference(output)
     print(json.dumps(output or {}))
 
 

--- a/integrations/claude-code/tests/test_memory_preference.py
+++ b/integrations/claude-code/tests/test_memory_preference.py
@@ -1,0 +1,86 @@
+"""Tests for the 'prefer Cognee memory' SessionStart steer (session-start.py).
+
+Claude Code's native auto-memory (MEMORY.md) can't be reliably disabled by a
+plugin, so session-start injects a SessionStart ``additionalContext`` instruction
+asserting Cognee as the preferred memory. These drive ``_apply_memory_preference``
+directly. The session-start module pulls in hook helpers; if it can't import in
+this environment the tests skip (return) rather than fail.
+
+Run: python integrations/claude-code/tests/test_memory_preference.py
+(or via pytest).
+"""
+
+import importlib.util
+import os
+import pathlib
+import sys
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "session_start_mod", _SCRIPTS / "session-start.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+try:
+    ss = _load()
+except Exception:  # pragma: no cover - hook deps not importable in this environment
+    ss = None
+
+
+def test_steer_injected_by_default():
+    if ss is None:
+        return
+    os.environ.pop("COGNEE_PREFER_MEMORY", None)
+    out = ss._apply_memory_preference(
+        {"hookSpecificOutput": {"hookEventName": "SessionStart", "systemMessage": "hi"}}
+    )
+    hso = out["hookSpecificOutput"]
+    assert "Cognee" in hso["additionalContext"]
+    assert "FIRST" in hso["additionalContext"]  # "consult Cognee FIRST"
+    assert hso["systemMessage"] == "hi"  # existing fields preserved
+    assert hso["hookEventName"] == "SessionStart"
+
+
+def test_empty_output_gets_session_start_block():
+    if ss is None:
+        return
+    os.environ.pop("COGNEE_PREFER_MEMORY", None)
+    out = ss._apply_memory_preference({})
+    hso = out["hookSpecificOutput"]
+    assert hso["hookEventName"] == "SessionStart"
+    assert "memory" in hso["additionalContext"].lower()
+
+
+def test_opt_out_disables_steer():
+    if ss is None:
+        return
+    os.environ["COGNEE_PREFER_MEMORY"] = "false"
+    try:
+        out = ss._apply_memory_preference({"hookSpecificOutput": {"hookEventName": "SessionStart"}})
+        assert "additionalContext" not in out["hookSpecificOutput"]
+    finally:
+        os.environ.pop("COGNEE_PREFER_MEMORY", None)
+
+
+if __name__ == "__main__":
+    if ss is None:
+        print("SKIP: session-start.py not importable in this environment")
+        sys.exit(0)
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Why
With the cognee plugin active, the user's intent is that **Claude uses Cognee as its memory and consults it first** — not Claude Code's built-in auto memory (`MEMORY.md`). The plugin already auto-recalls Cognee on every `UserPromptSubmit` and captures writes, so Cognee *is* consulted first; this PR makes that preference **explicit to the model** so it doesn't lean on `MEMORY.md`.

## What changed
- **`session-start.py`** — `_apply_memory_preference()` augments the `SessionStart` output with an `additionalContext` instruction: treat Cognee as authoritative, consult the auto-recalled Cognee context **FIRST**, and prefer the Cognee tools/skills over `MEMORY.md`. Wired in `main()` so it applies across **all** SessionStart branches (including the empty/exception path), preserving any existing `systemMessage`.
- **`config.py`** — `prefer_cognee_memory` (default `true`) + `COGNEE_PREFER_MEMORY` env to opt out.
- **`tests/test_memory_preference.py`** — default-injects the steer, preserves existing fields, empty output gets a proper `SessionStart` block, and `COGNEE_PREFER_MEMORY=false` disables it. Standalone-runnable (matches the other claude-code tests); skips if the hook module can't be imported in the environment.
- **`README`** — documents the behavior, the toggle, and the limitation.

## Honest scope (important)
A plugin **cannot reliably disable** Claude Code's native auto memory: `MEMORY.md` is injected as *context*, not a tool call a `PreToolUse` hook could intercept, and a plugin can't override settings precedence. So this **steers** the model to prefer Cognee rather than hard-disabling native memory. Users who want native memory fully off can set `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` in the launching shell (version-dependent) — noted in the README.

This is Claude-specific; Codex has no equivalent native auto-memory, so the steer is not mirrored into the codex copy.

## Verification
`COGNEE_PREFER_MEMORY` default/opt-out paths covered by the new test (3/3 pass standalone on 3.12); `ruff format --check` + `ruff check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)