### PR TITLE
fix(remember): background graph build + don't treat write timeouts as unreachable

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -136,6 +136,24 @@ Final sync on session end is triggered by the `SessionEnd` detached worker, with
 - `/cognee-memory:cognee-search`
 - `/cognee-memory:cognee-sync`
 
+## Remember (write) behavior
+
+`cognee-remember` and the auto-capture hooks POST to the server's `/api/v1/remember`
+and ask it to build the graph **in the background** (`run_in_background=true`), so the
+write returns as soon as it's enqueued instead of blocking the turn on a synchronous
+cognify. A synchronous build can take tens of seconds, exceed the client timeout, and be
+misread as "server unreachable" — which then triggers a `cognee-cli` fallback that can
+double-write. The graph populates shortly after the call, so a recall in the same breath
+may not see the new entry yet.
+
+| Env var | Default | Effect |
+|---|---|---|
+| `COGNEE_REMEMBER_BACKGROUND` | `true` | Build the graph in the background; set `false` for a synchronous, immediately-queryable write |
+
+A write that *times out* is reported as "submitted; timed out waiting for confirmation"
+and does **not** fall back to `cognee-cli` (the write likely landed — a fallback would
+risk a duplicate). Only a genuine connection failure falls back.
+
 ## Status line
 
 The status line displays `cognee: <dataset> · <mode>`, for example:

--- a/integrations/claude-code/scripts/_remember_http.py
+++ b/integrations/claude-code/scripts/_remember_http.py
@@ -19,6 +19,8 @@ Diagnostics also go to stderr so the caller can surface them.
 """
 
 import json
+import os
+import socket
 import sys
 import urllib.error
 import urllib.parse
@@ -64,6 +66,32 @@ def _error(status, message):
     return {"error": message, "status": status, "authoritative": False}
 
 
+def _background_flag():
+    """Whether the server should cognify in the background (default: yes).
+
+    A synchronous cognify (run_in_background=false) can take tens of seconds: it
+    blocks the agent's turn and risks the client read-timeout that gets misread as
+    "server unreachable" (then a CLI fallback that can double-write). Background lets
+    the POST return as soon as the work is enqueued. Set COGNEE_REMEMBER_BACKGROUND=false
+    for a synchronous, immediately-queryable write.
+    """
+    val = os.environ.get("COGNEE_REMEMBER_BACKGROUND", "").strip().lower()
+    return "false" if val in {"0", "false", "no", "off"} else "true"
+
+
+def _timeout_result(timeout):
+    """A write timeout is NOT 'unreachable': the request likely reached the server and
+    the write may have landed. Returning UNREACHABLE would make the caller re-write via
+    the CLI and risk a duplicate, so surface a non-fatal note instead — the caller
+    prints it and does NOT fall back. Background writes make this path rare.
+    """
+    sys.stderr.write(
+        "[cognee-remember] timed out after %ss waiting for confirmation; the write may "
+        "have succeeded — NOT falling back to local CLI\n" % timeout
+    )
+    return _error(0, "remember submitted; timed out after %ss waiting for confirmation" % timeout)
+
+
 def do_remember(
     service_url,
     api_key,
@@ -81,7 +109,7 @@ def do_remember(
         {
             "datasetName": dataset,
             "node_set": node_set,
-            "run_in_background": "false",
+            "run_in_background": _background_flag(),
         },
         [("data", filename, content.encode("utf-8") if isinstance(content, str) else content)],
     )
@@ -102,6 +130,17 @@ def do_remember(
             msg = "server returned HTTP %s for /api/v1/remember" % e.code
         sys.stderr.write("[cognee-remember] %s — NOT falling back to local CLI\n" % msg)
         return _error(e.code, msg)
+    except (TimeoutError, socket.timeout):
+        return _timeout_result(timeout)
+    except urllib.error.URLError as e:
+        # A read timeout arrives wrapped in URLError on some platforms — treat it as
+        # a timeout, not "unreachable" (the request likely reached the server).
+        if isinstance(getattr(e, "reason", None), (TimeoutError, socket.timeout)):
+            return _timeout_result(timeout)
+        sys.stderr.write(
+            "[cognee-remember] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+        )
+        return UNREACHABLE
     except Exception as e:
         sys.stderr.write(
             "[cognee-remember] server unreachable at %s: %s\n" % (service_url, str(e)[:160])

--- a/integrations/claude-code/tests/test_remember_http.py
+++ b/integrations/claude-code/tests/test_remember_http.py
@@ -1,0 +1,109 @@
+"""Unit tests for the server-first remember client (_remember_http.py).
+
+Covers the two fixes:
+  * remember posts with run_in_background=true by default (opt out via
+    COGNEE_REMEMBER_BACKGROUND=false) so the agent turn isn't blocked on a
+    synchronous cognify;
+  * a write *timeout* is surfaced as a non-fatal note (NOT UNREACHABLE), so the
+    caller does not fall back to the CLI and risk a duplicate write — while a real
+    connection failure still returns UNREACHABLE.
+
+Run: python integrations/claude-code/tests/test_remember_http.py (or via pytest).
+"""
+
+import os
+import pathlib
+import sys
+import urllib.error
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _remember_http as rh  # noqa: E402
+
+
+class _Resp:
+    def __init__(self, body=b"{}"):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def _capturing_opener(captured, body=b"{}"):
+    def _open(req, timeout=None):
+        captured["req"] = req
+        return _Resp(body)
+
+    return _open
+
+
+def test_background_flag_default_true():
+    os.environ.pop("COGNEE_REMEMBER_BACKGROUND", None)
+    assert rh._background_flag() == "true"
+
+
+def test_background_flag_opt_out():
+    try:
+        for v in ("false", "0", "no", "off", "FALSE"):
+            os.environ["COGNEE_REMEMBER_BACKGROUND"] = v
+            assert rh._background_flag() == "false"
+    finally:
+        os.environ.pop("COGNEE_REMEMBER_BACKGROUND", None)
+
+
+def test_payload_sends_run_in_background_true():
+    os.environ.pop("COGNEE_REMEMBER_BACKGROUND", None)
+    cap = {}
+    rh.do_remember("http://x", "", "content", "ds", "user_context", opener=_capturing_opener(cap))
+    body = cap["req"].data
+    assert b'name="run_in_background"\r\n\r\ntrue' in body
+
+
+def test_timeout_does_not_fall_back():
+    def _timeout_opener(req, timeout=None):
+        raise TimeoutError("timed out")
+
+    res = rh.do_remember("http://x", "", "c", "ds", "user_context", opener=_timeout_opener)
+    assert res != rh.UNREACHABLE  # caller must NOT fall back to the CLI
+    assert isinstance(res, dict) and "error" in res
+
+
+def test_timeout_wrapped_in_urlerror_does_not_fall_back():
+    def _wrapped(req, timeout=None):
+        raise urllib.error.URLError(TimeoutError("timed out"))
+
+    res = rh.do_remember("http://x", "", "c", "ds", "user_context", opener=_wrapped)
+    assert res != rh.UNREACHABLE
+    assert isinstance(res, dict) and "error" in res
+
+
+def test_connection_failure_is_unreachable():
+    def _refused(req, timeout=None):
+        raise urllib.error.URLError("Connection refused")
+
+    res = rh.do_remember("http://x", "", "c", "ds", "user_context", opener=_refused)
+    assert res == rh.UNREACHABLE
+
+
+def test_2xx_returns_ok():
+    res = rh.do_remember("http://x", "", "c", "ds", "user_context", opener=_capturing_opener({}))
+    assert res == {"ok": True}
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/scripts/_remember_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_remember_http.py
@@ -19,6 +19,8 @@ Diagnostics also go to stderr so the caller can surface them.
 """
 
 import json
+import os
+import socket
 import sys
 import urllib.error
 import urllib.parse
@@ -64,6 +66,32 @@ def _error(status, message):
     return {"error": message, "status": status, "authoritative": False}
 
 
+def _background_flag():
+    """Whether the server should cognify in the background (default: yes).
+
+    A synchronous cognify (run_in_background=false) can take tens of seconds: it
+    blocks the agent's turn and risks the client read-timeout that gets misread as
+    "server unreachable" (then a CLI fallback that can double-write). Background lets
+    the POST return as soon as the work is enqueued. Set COGNEE_REMEMBER_BACKGROUND=false
+    for a synchronous, immediately-queryable write.
+    """
+    val = os.environ.get("COGNEE_REMEMBER_BACKGROUND", "").strip().lower()
+    return "false" if val in {"0", "false", "no", "off"} else "true"
+
+
+def _timeout_result(timeout):
+    """A write timeout is NOT 'unreachable': the request likely reached the server and
+    the write may have landed. Returning UNREACHABLE would make the caller re-write via
+    the CLI and risk a duplicate, so surface a non-fatal note instead — the caller
+    prints it and does NOT fall back. Background writes make this path rare.
+    """
+    sys.stderr.write(
+        "[cognee-remember] timed out after %ss waiting for confirmation; the write may "
+        "have succeeded — NOT falling back to local CLI\n" % timeout
+    )
+    return _error(0, "remember submitted; timed out after %ss waiting for confirmation" % timeout)
+
+
 def do_remember(
     service_url,
     api_key,
@@ -81,7 +109,7 @@ def do_remember(
         {
             "datasetName": dataset,
             "node_set": node_set,
-            "run_in_background": "false",
+            "run_in_background": _background_flag(),
         },
         [("data", filename, content.encode("utf-8") if isinstance(content, str) else content)],
     )
@@ -102,6 +130,17 @@ def do_remember(
             msg = "server returned HTTP %s for /api/v1/remember" % e.code
         sys.stderr.write("[cognee-remember] %s — NOT falling back to local CLI\n" % msg)
         return _error(e.code, msg)
+    except (TimeoutError, socket.timeout):
+        return _timeout_result(timeout)
+    except urllib.error.URLError as e:
+        # A read timeout arrives wrapped in URLError on some platforms — treat it as
+        # a timeout, not "unreachable" (the request likely reached the server).
+        if isinstance(getattr(e, "reason", None), (TimeoutError, socket.timeout)):
+            return _timeout_result(timeout)
+        sys.stderr.write(
+            "[cognee-remember] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+        )
+        return UNREACHABLE
     except Exception as e:
         sys.stderr.write(
             "[cognee-remember] server unreachable at %s: %s\n" % (service_url, str(e)[:160])


### PR DESCRIPTION
## Symptom
On a cloud-connected session, `cognee-remember` "stored to the cloud **only after falling back to `cognee-cli`**, not via the direct API call" — and the call hung ~30s+.

## Root cause
`_remember_http.py` POSTed to `/api/v1/remember` with **`run_in_background=false`**, so the server ran a **full synchronous cognify** (LLM entity-extraction + embeddings) while the stdlib client waited. That can exceed the client timeout, and the client **can't distinguish a read-timeout from a dead server** → it returned `UNREACHABLE` → the script fell back to `cognee-cli`, which then wrote to the cloud. Net effects: a 30s+ blocked turn, a misleading "unreachable", and a **possible duplicate** (the original request may also have landed server-side).

Confirmed the fallback was connection-level, not an HTTP error: a direct POST that gets any HTTP status (e.g. `409`) returns an error envelope and explicitly does **not** fall back — only `UNREACHABLE` does.

## Fix (`_remember_http.py`, claude-code + codex copies kept identical)
1. **`run_in_background=true` by default** — the POST returns once the build is enqueued instead of blocking on a synchronous cognify. Opt out with `COGNEE_REMEMBER_BACKGROUND=false` for a synchronous, immediately-queryable write.
2. **A write *timeout* is no longer `UNREACHABLE`** — it's surfaced as a non-fatal `"submitted; timed out waiting for confirmation"` envelope, so the caller does **not** fall back to the CLI and risk a duplicate. A genuine connection failure still returns `UNREACHABLE`; HTTP 4xx/5xx still return error envelopes (no fallback) as before.

## Tests
`tests/test_remember_http.py` (standalone-runnable, stdlib-only): default-background, opt-out, payload carries `run_in_background=true`, timeout (direct **and** `URLError`-wrapped) does not fall back, connection failure stays `UNREACHABLE`, 2xx → `{"ok": true}`. **7/7 pass; `ruff` clean.**

## Notes
- Eventual-consistency tradeoff: a recall immediately after a background remember may not see the entry yet (documented in the README).
- Worth a quick check for a **duplicate** of any entry written via the old fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)