### PR TITLE
Standardize Cognee session names to {agent}_{native_session_id}

### DIFF
--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -121,17 +121,24 @@ def set_session_key(session_key: str) -> str:
     return normalized
 
 
-def _generate_session_id(cwd: str = "") -> str:
-    """Mint a fresh Cognee session id for a new launch.
+def _generate_session_id(cwd: str = "", host_key: str = "") -> str:
+    """Mint the Cognee session id for a launch: ``{agent}_{host_session_id}``.
 
-    Shape ``{prefix}_{dirname}_{token}`` keeps it human-readable in logs while
-    the random token guarantees a new session per launch. No host/Claude session
-    id is embedded — the host id is only a local correlation key (see below).
+    The host (Claude) session id maps 1:1 to the conversation, so embedding it
+    makes the Cognee session id deterministic per conversation (a new conversation
+    / ``/clear`` -> new id; resume -> same id) and self-describing in the Cognee
+    dashboard. Falls back to ``{agent}_{dirname}_{token}`` only when no host session
+    id is available.
     """
-    prefix = _sanitize_session_key(os.environ.get("COGNEE_SESSION_PREFIX", "") or "cc") or "cc"
+    agent = (
+        _sanitize_session_key(os.environ.get("COGNEE_SESSION_PREFIX", "") or "claude") or "claude"
+    )
+    host = _sanitize_session_key(host_key)
+    if host:
+        return f"{agent}_{host}"
     cwd = cwd or os.environ.get("CLAUDE_CWD") or os.getcwd()
     dir_name = _sanitize_session_key(Path(cwd).name) or "session"
-    return f"{prefix}_{dir_name}_{uuid.uuid4().hex[:12]}"
+    return f"{agent}_{dir_name}_{uuid.uuid4().hex[:12]}"
 
 
 def _new_conn_uuid() -> str:
@@ -213,7 +220,7 @@ def resolve_cognee_session_id(host_key: str = "", cwd: str = "") -> str:
     if rec.get("session_id"):
         return _sanitize_session_key(str(rec["session_id"]))
 
-    new_id = _generate_session_id(cwd)
+    new_id = _generate_session_id(cwd, host_key)
     if not host_key:
         return new_id
     winner = _create_map_record_if_absent(
@@ -240,7 +247,7 @@ def ensure_launch_record(host_key: str = "", cwd: str = "") -> tuple[str, str]:
         return str(rec["session_id"]), str(rec["conn_uuid"])
 
     explicit = _sanitize_session_key(str(os.environ.get("COGNEE_SESSION_ID", "") or "").strip())
-    session_id = explicit or str(rec.get("session_id") or "") or _generate_session_id(cwd)
+    session_id = explicit or str(rec.get("session_id") or "") or _generate_session_id(cwd, host_key)
     conn_uuid = str(rec.get("conn_uuid") or "") or _new_conn_uuid()
     record = {
         "session_id": session_id,

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -31,7 +31,7 @@ _DEFAULTS = {
     "dataset": "agent_sessions",
     "agent_name": "claude-code-agent",
     "session_strategy": "per-directory",  # per-directory | git-branch | static
-    "session_prefix": "cc",
+    "session_prefix": "claude",  # agent name; session id is "{agent}_{host_session_id}"
     "top_k": 3,
     "backend": "auto",
     "user_email": "default_user@example.com",

--- a/integrations/claude-code/tests/test_session_id.py
+++ b/integrations/claude-code/tests/test_session_id.py
@@ -29,9 +29,9 @@ def test_fallback_without_host_id_uses_agent_and_dir():
 
 
 def test_prefix_env_override():
-    os.environ["COGNEE_SESSION_PREFIX"] = "claude"
+    os.environ["COGNEE_SESSION_PREFIX"] = "custom"  # a non-default value, to prove override
     try:
-        assert pc._generate_session_id("/x", "abc123").startswith("claude_abc123")
+        assert pc._generate_session_id("/x", "abc123") == "custom_abc123"
     finally:
         os.environ.pop("COGNEE_SESSION_PREFIX", None)
 

--- a/integrations/claude-code/tests/test_session_id.py
+++ b/integrations/claude-code/tests/test_session_id.py
@@ -1,0 +1,49 @@
+"""Tests for the `{agent}_{host_session_id}` Cognee session-id convention.
+
+The host (Claude) session id is embedded so the Cognee session maps 1:1 to the
+conversation and is self-describing in the dashboard (no working-directory coupling).
+
+Run: python integrations/claude-code/tests/test_session_id.py
+"""
+
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+
+def test_embeds_host_session_id():
+    os.environ.pop("COGNEE_SESSION_PREFIX", None)
+    assert pc._generate_session_id("/tmp/whatever", "c92cc618-cc37-42ac") == (
+        "claude_c92cc618-cc37-42ac"
+    )
+
+
+def test_fallback_without_host_id_uses_agent_and_dir():
+    os.environ.pop("COGNEE_SESSION_PREFIX", None)
+    sid = pc._generate_session_id("/tmp/myproj", "")
+    assert sid.startswith("claude_myproj_")  # agent + dir + random token
+
+
+def test_prefix_env_override():
+    os.environ["COGNEE_SESSION_PREFIX"] = "claude"
+    try:
+        assert pc._generate_session_id("/x", "abc123").startswith("claude_abc123")
+    finally:
+        os.environ.pop("COGNEE_SESSION_PREFIX", None)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -122,19 +122,21 @@ def set_session_key(session_key: str) -> str:
     return normalized
 
 
-def _generate_session_id(cwd: str = "") -> str:
-    """Mint a fresh Cognee session id for a new launch.
+def _generate_session_id(cwd: str = "", host_key: str = "") -> str:
+    """Mint the Cognee session id for a launch: ``{agent}_{host_session_id}``.
 
-    Shape ``{prefix}_{dirname}_{token}`` keeps it human-readable in logs while
-    the random token guarantees a new session per launch. No host/Codex session
-    id is embedded — the host id is only a local correlation key (see below).
+    The host (Codex) session id maps 1:1 to the conversation, so embedding it
+    makes the Cognee session id deterministic per conversation and self-describing
+    in the Cognee dashboard. Falls back to ``{agent}_{dirname}_{token}`` only when
+    no host session id is available.
     """
-    prefix = (
-        _sanitize_session_key(os.environ.get("COGNEE_SESSION_PREFIX", "") or "codex") or "codex"
-    )
+    agent = _sanitize_session_key(os.environ.get("COGNEE_SESSION_PREFIX", "") or "codex") or "codex"
+    host = _sanitize_session_key(host_key)
+    if host:
+        return f"{agent}_{host}"
     cwd = cwd or os.environ.get("CODEX_CWD") or os.getcwd()
     dir_name = _sanitize_session_key(Path(cwd).name) or "session"
-    return f"{prefix}_{dir_name}_{uuid.uuid4().hex[:12]}"
+    return f"{agent}_{dir_name}_{uuid.uuid4().hex[:12]}"
 
 
 def _new_conn_uuid() -> str:
@@ -216,7 +218,7 @@ def resolve_cognee_session_id(host_key: str = "", cwd: str = "") -> str:
     if rec.get("session_id"):
         return _sanitize_session_key(str(rec["session_id"]))
 
-    new_id = _generate_session_id(cwd)
+    new_id = _generate_session_id(cwd, host_key)
     if not host_key:
         return new_id
     winner = _create_map_record_if_absent(
@@ -243,7 +245,7 @@ def ensure_launch_record(host_key: str = "", cwd: str = "") -> tuple[str, str]:
         return str(rec["session_id"]), str(rec["conn_uuid"])
 
     explicit = _sanitize_session_key(str(os.environ.get("COGNEE_SESSION_ID", "") or "").strip())
-    session_id = explicit or str(rec.get("session_id") or "") or _generate_session_id(cwd)
+    session_id = explicit or str(rec.get("session_id") or "") or _generate_session_id(cwd, host_key)
     conn_uuid = str(rec.get("conn_uuid") or "") or _new_conn_uuid()
     record = {
         "session_id": session_id,

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -535,16 +535,11 @@ class CogneeMemoryProvider(MemoryProvider):
         self._bridge.shutdown()
 
     def _build_cognee_session_id(self, session_id: str, **kwargs) -> str:
+        # Convention across integrations: "{agent}_{native_session_id}" —
+        # e.g. hermes_<hermes-session-id>. (kwargs like agent_workspace/user_id are
+        # accepted for call-site compatibility but no longer embedded in the name.)
         prefix = str(self._config.get("session_prefix") or "hermes")
-        workspace = str(kwargs.get("agent_workspace") or "")
-        user_id = str(kwargs.get("user_id") or "")
-        parts = [prefix]
-        if workspace:
-            parts.append(_safe_session_component(workspace))
-        if user_id:
-            parts.append(_safe_session_component(user_id))
-        parts.append(_safe_session_component(session_id))
-        return "_".join(parts)
+        return f"{prefix}_{_safe_session_component(session_id)}"
 
     def _session_cognee_id_for(self, session_id: str) -> str:
         if not session_id or session_id == self._session_id:

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -80,8 +80,12 @@ def _has_cognee() -> bool:
 
 
 def _safe_session_component(value: str) -> str:
-    cleaned = "".join(ch if ch.isalnum() or ch in {"_", "-"} else "_" for ch in value)
-    return cleaned.strip("_") or "session"
+    # Sanitization kept consistent with the other integrations' session-id helpers
+    # (claude-code/codex `_sanitize_session_key`, openclaw `sanitizeSessionKey`):
+    # keep alphanumerics plus `-` `_` `.`, replace others with `_`, trim `._` ends,
+    # cap length at 120.
+    safe = "".join(ch if ch.isalnum() or ch in ("-", "_", ".") else "_" for ch in value)
+    return safe.strip("._")[:120] or "session"
 
 
 def _format_turn(user_content: str, assistant_content: str) -> str:

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -966,7 +966,9 @@ const memoryCogneePlugin = {
         await Promise.all([stateReady, serviceReady]);
 
         const endAgentId = ctx?.agentId ?? lastAgentId;
-        const endSessionId = ctx?.sessionId ?? event.sessionId;
+        // Wrap to the same {agent}_{id} form data was saved under, so improve()
+        // looks up the right session (must match the session_start/hook wrapping).
+        const endSessionId = cogneeSessionId(ctx?.sessionId ?? event.sessionId);
         if (!ctx?.agentId) {
           api.logger.debug?.(`cognee-openclaw: session_end without ctx.agentId; falling back to lastAgentId="${endAgentId ?? "(none)"}"`);
         }

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -21,7 +21,7 @@ import {
   migrateAgentScopeToPerAgent,
   SYNC_INDEX_PATH,
 } from "./persistence.js";
-import { datasetNameForScope, isMultiScopeEnabled, normalizeAgentId, routeFileToScope } from "./scope.js";
+import { cogneeSessionId, datasetNameForScope, isMultiScopeEnabled, normalizeAgentId, routeFileToScope } from "./scope.js";
 import { syncFiles, syncFilesScoped } from "./sync.js";
 
 /** Expand a leading `~` in a workspace path to the user's home directory. */
@@ -747,7 +747,7 @@ const memoryCogneePlugin = {
         await stateReady;
 
         // session_start isn't fired in every openclaw flow; sync from ctx on every hook.
-        if (cfg.enableSessions && ctx.sessionId) sessionId = ctx.sessionId;
+        if (cfg.enableSessions && ctx.sessionId) sessionId = cogneeSessionId(ctx.sessionId);
 
         if (!event.prompt || event.prompt.length < 5) {
           api.logger.debug?.("cognee-openclaw: skipping recall (prompt too short)");
@@ -873,7 +873,7 @@ const memoryCogneePlugin = {
 
         lastAgentId = ctx.agentId;
         lastWorkspaceDir = ctx.workspaceDir || resolvedWorkspaceDir;
-        if (cfg.enableSessions && ctx.sessionId) sessionId = ctx.sessionId;
+        if (cfg.enableSessions && ctx.sessionId) sessionId = cogneeSessionId(ctx.sessionId);
 
         const workspaceDir = ctx.workspaceDir || resolvedWorkspaceDir!;
         // Remember this agent's workspace so session_end can sweep the right one.
@@ -951,7 +951,7 @@ const memoryCogneePlugin = {
       });
 
       api.on("session_start", async (event) => {
-        if (cfg.enableSessions) sessionId = event.sessionId;
+        if (cfg.enableSessions) sessionId = cogneeSessionId(event.sessionId);
       });
 
       // Final sweep when the openclaw session closes. Catches memory file

--- a/integrations/openclaw/src/scope.ts
+++ b/integrations/openclaw/src/scope.ts
@@ -123,6 +123,17 @@ export function normalizeAgentId(agentId: string | undefined, cfg: Required<Cogn
 }
 
 /**
+ * Sanitize a host session id to the same character set the Python integrations use
+ * (`_sanitize_session_key`): keep alphanumerics plus `-` `_` `.`, replace anything
+ * else with `_`, trim leading/trailing `.`/`_`, and cap length at 120.
+ */
+function sanitizeSessionKey(value: string): string {
+  let safe = "";
+  for (const ch of value) safe += /[A-Za-z0-9\-_.]/.test(ch) ? ch : "_";
+  return safe.replace(/^[._]+/, "").replace(/[._]+$/, "").slice(0, 120);
+}
+
+/**
  * Build the Cognee session id from the host (OpenClaw) session id, following the
  * cross-integration convention `{agent}_{native_session_id}` —
  * e.g. `open_claw_<openclaw-session-id>`. Keeps the session self-describing in the
@@ -130,7 +141,7 @@ export function normalizeAgentId(agentId: string | undefined, cfg: Required<Cogn
  * an empty input so downstream truthy checks still skip an absent session id.
  */
 export function cogneeSessionId(nativeSessionId: string | undefined): string {
-  const native = (nativeSessionId ?? "").trim();
+  const native = sanitizeSessionKey((nativeSessionId ?? "").trim());
   return native ? `open_claw_${native}` : "";
 }
 

--- a/integrations/openclaw/src/scope.ts
+++ b/integrations/openclaw/src/scope.ts
@@ -123,6 +123,18 @@ export function normalizeAgentId(agentId: string | undefined, cfg: Required<Cogn
 }
 
 /**
+ * Build the Cognee session id from the host (OpenClaw) session id, following the
+ * cross-integration convention `{agent}_{native_session_id}` —
+ * e.g. `open_claw_<openclaw-session-id>`. Keeps the session self-describing in the
+ * Cognee dashboard and decoupled from working-directory/agent naming. Returns "" for
+ * an empty input so downstream truthy checks still skip an absent session id.
+ */
+export function cogneeSessionId(nativeSessionId: string | undefined): string {
+  const native = (nativeSessionId ?? "").trim();
+  return native ? `open_claw_${native}` : "";
+}
+
+/**
  * Resolve the Cognee dataset name for a given memory scope.
  *
  * `runtimeAgentId` lets multi-agent gateways pass the active agent's identity


### PR DESCRIPTION
## Problem
Cognee session names were derived from the **working directory** — e.g. `cc_hermes-agent_<rand>` just because Claude Code was launched in a folder named `hermes-agent`. That's confusing in the Cognee dashboard and couples the session identity to cwd.

## Change
Standardize **all four integrations** to **`{agent}_{native_session_id}`**, so each Cognee session maps 1:1 to the host conversation and is self-describing:

| Integration | Now |
|---|---|
| claude-code | `claude_<claude-session-id>` |
| codex | `codex_<codex-session-id>` |
| hermes | `hermes_<hermes-session-id>` |
| openclaw | `open_claw_<openclaw-session-id>` |

- **claude-code** `_plugin_common._generate_session_id`: embed the host (Claude) session id; agent default `cc`→`claude`; callers pass `host_key`. Falls back to `{agent}_{dir}_{token}` only when no host id is available.
- **codex**: same; agent already `codex`.
- **hermes** `_build_cognee_session_id`: `hermes_<session-id>` — dropped the optional `workspace`/`user_id` name parts per the agreed spec (kwargs still accepted for call-site compatibility).
- **openclaw**: new `scope.cogneeSessionId()` helper + 3 call sites.

## Behavior
- **Deterministic per conversation**: `/clear` → new conversation id → new session; resume → same id → same session.
- **Existing cloud sessions keep their old names** — this only affects *new* sessions.
- The `COGNEE_SESSION_ID` env override still wins; the host-keyed map still provides cross-hook stability.

## Tests
`integrations/claude-code/tests/test_session_id.py`: embeds host id, dir fallback, prefix override — **3/3 pass**. `ruff check` + `ruff format --check` clean across `integrations/`.

⚠️ The **openclaw** change is TypeScript (pure string helper + 3 call sites + import). It was **not built locally** (no node in this environment) — relying on the `test-typescript` CI job to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)