### PR TITLE
docs: add end-user header, integration table, and quickstart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,113 @@
+<div align="center">
+  <a href="https://github.com/topoteretes/cognee">
+    <img src="https://raw.githubusercontent.com/topoteretes/cognee/refs/heads/dev/assets/cognee-logo-transparent.png" alt="Cognee Logo" height="60">
+  </a>
+
+  <br />
+
+  Cognee Integrations - AI Memory for Your Agent Framework
+
+  <p align="center">
+  <a href="https://www.youtube.com/watch?v=8hmqS2Y5RVQ&t=13s">Demo</a>
+  .
+  <a href="https://docs.cognee.ai/">Docs</a>
+  .
+  <a href="https://cognee.ai">Learn More</a>
+  ·
+  <a href="https://discord.gg/NQPKmU5CCg">Join Discord</a>
+  ·
+  <a href="https://www.reddit.com/r/AIMemory/">Join r/AIMemory</a>
+  .
+  <a href="https://github.com/topoteretes/cognee">Core Repo</a>
+  </p>
+
+  [![GitHub forks](https://img.shields.io/github/forks/topoteretes/cognee-integrations.svg?style=social&label=Fork&maxAge=2592000)](https://GitHub.com/topoteretes/cognee-integrations/network/)
+  [![GitHub stars](https://img.shields.io/github/stars/topoteretes/cognee-integrations.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/topoteretes/cognee-integrations/stargazers/)
+  [![Downloads](https://static.pepy.tech/badge/cognee)](https://pepy.tech/project/cognee)
+  [![License](https://img.shields.io/github/license/topoteretes/cognee-integrations?colorA=00C586&colorB=000000)](https://github.com/topoteretes/cognee-integrations/blob/main/LICENSE)
+  [![Contributors](https://img.shields.io/github/contributors/topoteretes/cognee-integrations?colorA=00C586&colorB=000000)](https://github.com/topoteretes/cognee-integrations/graphs/contributors)
+  <a href="https://github.com/sponsors/topoteretes"><img src="https://img.shields.io/badge/Sponsor-❤️-ff69b4.svg" alt="Sponsor"></a>
+
+</div>
+
 # Cognee Integrations
 
-Monorepo for all Cognee-owned integration packages.
+Monorepo for all Cognee-owned integration packages. Each integration gives an agent
+framework (Strands, CrewAI, LangGraph, Google ADK, …) a persistent **memory layer**
+backed by [cognee](https://github.com/topoteretes/cognee): a permanent knowledge graph
+plus a fast session cache.
+
+## Available Integrations
+
+Install these from their public registries — you do **not** need to clone this monorepo to use them.
+
+| Framework | Package | Install |
+|---|---|---|
+| Strands | `cognee-integration-strands` | `pip install cognee-integration-strands` |
+| CrewAI | `cognee-integration-crewai` | `pip install cognee-integration-crewai` |
+| LangGraph | `cognee-integration-langgraph` | `pip install cognee-integration-langgraph` |
+| Google ADK | `cognee-integration-google-adk` | `pip install cognee-integration-google-adk` |
+| Claude Agent SDK | `cognee-integration-claude` | `pip install cognee-integration-claude` |
+| Hermes Agent | `cognee-integration-hermes-agent` | `pip install cognee-integration-hermes-agent` |
+| OpenClaw | `@cognee/cognee-openclaw` | `npm install @cognee/cognee-openclaw` |
+| n8n | `n8n-nodes-cognee` | install via n8n community nodes |
+| Dify (Cloud) | `cognee` | install from the Dify marketplace |
+| Dify (self-hosted) | `cognee-sdk` | install from the Dify marketplace |
+
+Each integration has its own `README.md` under `integrations/<name>/` with the full tool
+reference and runnable examples. The table above is generated from
+[`integrations/inventory.yml`](integrations/inventory.yml) — see it for ownership,
+versions, and compatible cognee ranges.
+
+## Quickstart
+
+The Python SDK integrations (Strands, CrewAI, LangGraph, Google ADK, Claude) share the
+same three steps. Example using Strands:
+
+**1. Install**
+
+```bash
+pip install cognee-integration-strands
+pip install "strands-agents[openai]"   # the examples drive an OpenAI model
+```
+
+**2. Configure your LLM key**
+
+Cognee extracts knowledge with an LLM, so set `LLM_API_KEY` (e.g. in a `.env` file):
+
+```env
+LLM_API_KEY=your-openai-api-key-here
+```
+
+**3. Attach the cognee tools to your agent**
+
+```python
+import os
+from cognee_integration_strands import cognee_tools
+from strands import Agent
+from strands.models.openai import OpenAIModel
+
+model = OpenAIModel(client_args={"api_key": os.getenv("LLM_API_KEY")}, model_id="gpt-4o")
+agent = Agent(model=model, tools=cognee_tools())
+
+# Store information in the persistent knowledge graph
+agent("Remember that we signed a contract with Meditech Solutions for £1.2M.")
+
+# A fresh agent has no chat history — it answers purely from cognee's memory
+fresh = Agent(model=model, tools=cognee_tools())
+print(fresh("What is the value of the Meditech Solutions contract?"))
+```
+
+### Two memory tiers
+
+Built on cognee v1.0, every SDK integration exposes the same two tiers:
+
+- **Permanent knowledge graph** (default) — `cognee_tools()` writes go straight to the graph.
+- **Session cache** — `cognee_tools(session_id="chat_1")` routes writes to a cheap per-session
+  cache (no graph extraction). Promote a session into the permanent graph later with
+  `cognee.improve(session_ids=["chat_1"])`.
+
+See the per-integration README for the exact tool names and the session-management flow.
 
 ## Structure
 


### PR DESCRIPTION
## What

The top-level README was entirely maintainer-facing (structure, version pinning, publishing, CI) — nothing told an end user which integrations exist, how to install one, or the common usage pattern. This adds an end-user front section, modeled on the core [cognee](https://github.com/topoteretes/cognee) README.

## Changes

- **Elegant header** — centered cognee logo, tagline, social links (Demo · Docs · Learn More · Discord · r/AIMemory · Core Repo), and badges. Repo-specific badges (forks/stars/license/contributors) point at `cognee-integrations`; the downloads badge tracks the `cognee` PyPI package.
- **Available Integrations table** — package names + install commands, sourced from `integrations/inventory.yml`. Notes that you install from PyPI/npm without cloning the monorepo.
- **Quickstart** — the shared 3-step SDK pattern (install → set `LLM_API_KEY` → attach `cognee_tools()`), with a runnable Strands example, plus the two memory tiers (permanent graph vs `session_id` cache + `cognee.improve(...)`).

All existing maintainer sections are preserved below the new content.

## Notes

- LangGraph's example still uses the older `get_sessionized_cognee_tools()` / `add_tool`/`search_tool` API; the quickstart documents the v1.0 `cognee_tools()` pattern used by the majority of SDK integrations.
- Badges assume a root `LICENSE` file exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)