### PR TITLE
Fix cognee-remember 401 on localhost (send X-Api-Key to loopback server)

### DIFF
--- a/integrations/claude-code/scripts/_remember_http.py
+++ b/integrations/claude-code/scripts/_remember_http.py
@@ -114,9 +114,10 @@ def do_remember(
         [("data", filename, content.encode("utf-8") if isinstance(content, str) else content)],
     )
     headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
-    # COGNEE_API_KEY is a cloud credential; local single-user servers need no
-    # auth and ignore it. Only attach it for a remote/cloud target.
-    if api_key and not _is_local(service_url):
+    # Attach the key whenever present. The bundled local server requires
+    # X-Api-Key and returns 401 without it; a server that ignores auth won't
+    # mind the extra header. (Stripping it for loopback broke localhost remember.)
+    if api_key:
         headers["X-Api-Key"] = api_key
 
     req = urllib.request.Request(url, data=body, headers=headers, method="POST")


### PR DESCRIPTION
## What

`integrations/claude-code/scripts/_remember_http.py` stripped the `X-Api-Key` header for loopback targets, on the assumption that local single-user servers need no auth:

```python
if api_key and not _is_local(service_url):
    headers["X-Api-Key"] = api_key
```

The bundled local server (`http://localhost:8011`) **does** require the header and returns **401** without it. So every `cognee-remember` call fails on localhost, while `cognee-search` and `cognee-sync` work fine.

## Fix

Attach the key whenever it is present. A server that ignores auth won't mind the extra header; the local one that requires it now works.

## Verification

Direct curl against the local server confirms the header is the only difference:

- multipart **without** `X-Api-Key` → `401 {"detail":"Unauthorized"}`
- multipart **with** `X-Api-Key` → `200 {"status":"running","dataset_name":"agent_sessions",...}`

After the change, `cognee-remember.sh "..." --node-set project_docs` returns `{"ok": true}`.

Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)