### PR TITLE
Don't overwrite a user's existing custom statusLine

### DIFF
--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -1110,17 +1110,66 @@ def _session_start_guidance(mode: str, dataset: str, session_id: str, ready: boo
     }
 
 
+# Namespaced keys Cognee adds to the user's global settings.json.
+#   _MANAGED: the exact ``command`` string Cognee last installed. Ownership is
+#             tracked explicitly (not guessed from the path) so a user's own
+#             script is never mistaken for ours, and so our own line can be
+#             self-healed to a new path across plugin upgrades.
+#   _BACKUP:  a user status line displaced by COGNEE_FORCE_STATUSLINE, restored
+#             when the override is later cleared.
+_STATUSLINE_MANAGED_KEY = "statusLineCogneeManaged"
+_STATUSLINE_BACKUP_KEY = "statusLineCogneeBackup"
+_STATUSLINE_SCRIPT = "cognee-statusline.sh"
+
+
+def _looks_like_cognee_install(command: object) -> bool:
+    """True if a status-line command path was installed by some Cognee plugin version.
+
+    Used only to recognise a *pre-marker* (legacy) install so it can be adopted
+    and self-healed. Requires both the script basename and the ``cognee-memory``
+    package directory in the path — a stable segment across plugin versions — so a
+    user's own script that merely shares the basename (but lives elsewhere) is
+    never mistaken for ours.
+    """
+    return (
+        isinstance(command, str)
+        and command.endswith("/" + _STATUSLINE_SCRIPT)
+        and "cognee-memory" in Path(command).parts
+    )
+
+
 def _ensure_statusline_configured() -> None:
-    """Write the statusLine entry to ~/.claude/settings.json if not already set.
+    """Install Cognee's statusLine in ~/.claude/settings.json without clobbering a user's own.
+
+    ``~/.claude/settings.json`` is global, shared Claude Code config, so the
+    ``statusLine`` key may already hold a status line the user wrote themselves
+    (path / branch / model / context, etc.). Seizing it unconditionally would
+    destroy that with no backup, and — since this runs on every SessionStart —
+    a restored custom status line would just be clobbered again.
+
+    Ownership is tracked explicitly via ``statusLineCogneeManaged`` (the command
+    Cognee last wrote); a pre-marker install is recognised as ours only when its
+    path is exactly the current one or clearly inside a Cognee plugin dir (see
+    ``_looks_like_cognee_install``). Policy (default):
+      * no/empty statusLine               -> install Cognee's;
+      * our own statusLine, stale path      -> self-heal to the current path;
+      * any other (user-owned) statusLine   -> preserve it, do nothing.
+
+    Override: ``COGNEE_FORCE_STATUSLINE`` (1/true/yes/on) forces Cognee's status
+    line, stashing any displaced user value under ``statusLineCogneeBackup``. The
+    override is reversible: clear the env var and the next SessionStart restores
+    the stashed value — but only from a slot Cognee still owns, so a status line
+    the user has since taken over or deliberately cleared is never resurrected.
+    Non-dict / unrecognised statusLine values are left untouched (user-owned).
 
     Claude Code hot-reloads settings.json, so the status line becomes active on
     the next status refresh without requiring a restart.
     """
     plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", "")
     if plugin_root:
-        statusline_sh = Path(plugin_root) / "scripts" / "cognee-statusline.sh"
+        statusline_sh = Path(plugin_root) / "scripts" / _STATUSLINE_SCRIPT
     else:
-        statusline_sh = Path(__file__).resolve().parent / "cognee-statusline.sh"
+        statusline_sh = Path(__file__).resolve().parent / _STATUSLINE_SCRIPT
 
     if not statusline_sh.exists():
         hook_log(
@@ -1130,25 +1179,103 @@ def _ensure_statusline_configured() -> None:
 
     settings_path = Path.home() / ".claude" / "settings.json"
     desired = {"type": "command", "command": str(statusline_sh)}
+    force = os.environ.get("COGNEE_FORCE_STATUSLINE", "").strip().lower() in ("1", "true", "yes", "on")
 
     try:
+        # Read inline (not via _load_json_file) so corrupt JSON raises into the
+        # except below and we touch nothing, rather than silently overwriting a
+        # settings file we failed to parse.
         settings: dict = {}
+        original_mode = None
         if settings_path.exists():
+            original_mode = settings_path.stat().st_mode & 0o777  # capture once, pre-write
             text = settings_path.read_text(encoding="utf-8").strip()
             if text:
-                settings = json.loads(text)
+                loaded = json.loads(text)
+                if not isinstance(loaded, dict):
+                    # Valid JSON but not an object — not something we can safely
+                    # merge into; leave it alone (fail closed).
+                    hook_log("statusline_setup_skipped", {"reason": "settings_not_object"})
+                    return
+                settings = loaded
 
-        if settings.get("statusLine") == desired:
-            return
+        def _install():
+            settings["statusLine"] = desired
+            settings[_STATUSLINE_MANAGED_KEY] = desired["command"]
 
-        settings["statusLine"] = desired
-        settings_path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=settings_path.parent, prefix=".settings-", suffix=".json")
+        def _drop_bookkeeping():
+            settings.pop(_STATUSLINE_BACKUP_KEY, None)
+            settings.pop(_STATUSLINE_MANAGED_KEY, None)
+
+        # Snapshot to detect whether we actually change anything (avoids a
+        # needless rewrite — and its mtime churn — on every SessionStart).
+        before = json.dumps(settings, sort_keys=True)
+
+        existing = settings.get("statusLine")
+        managed_cmd = settings.get(_STATUSLINE_MANAGED_KEY)
+        existing_cmd = existing.get("command") if isinstance(existing, dict) else None
+
+        is_ours = isinstance(existing, dict) and (
+            (isinstance(managed_cmd, str) and existing_cmd == managed_cmd)
+            # Pre-marker install: recognise our own line by exact path or by a
+            # clearly-Cognee path, so upgrades self-heal it (and it gets a marker).
+            or (
+                managed_cmd is None
+                and (existing_cmd == desired["command"] or _looks_like_cognee_install(existing_cmd))
+            )
+        )
+        is_user_statusline = bool(existing) and not is_ours
+        backup = settings.get(_STATUSLINE_BACKUP_KEY)
+
+        if force:
+            if is_user_statusline:
+                # Stash the displaced user value (newest wins — not setdefault).
+                settings[_STATUSLINE_BACKUP_KEY] = existing
+            _install()
+        elif is_user_statusline:
+            # The user owns the slot — never clobber it. Drop any stale Cognee
+            # bookkeeping so an old backup can't be resurrected later.
+            _drop_bookkeeping()
+        elif is_ours and backup is not None:
+            # A forced override is being lifted from a slot we still own — restore
+            # the user's stashed value. (Gated on is_ours so a slot the user has
+            # cleared or taken over is never resurrected.)
+            settings["statusLine"] = backup
+            _drop_bookkeeping()
+        else:
+            # Absent, empty, or our own stale-path line, with no override to lift.
+            _drop_bookkeeping()  # never resurrect an orphaned backup
+            _install()
+
+        if json.dumps(settings, sort_keys=True) == before:
+            return  # nothing changed
+
+        # Follow a symlinked settings.json (e.g. a dotfiles repo) so we rewrite
+        # its target in place rather than replacing the symlink with a plain file.
+        write_path = settings_path
+        try:
+            if settings_path.is_symlink():
+                write_path = settings_path.resolve()
+        except OSError:
+            pass
+
+        write_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=write_path.parent, prefix=".settings-", suffix=".json")
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(settings, f, indent=2)
                 f.write("\n")
-            os.replace(tmp, settings_path)
+            # Best-effort: preserve the original file's permissions. mkstemp creates
+            # a private 0600 file; for a brand-new settings.json we keep that, since
+            # it can hold secrets and shouldn't be broadened. chmod is best-effort so
+            # a filesystem that doesn't support it (some FAT/network mounts) can't
+            # abort an otherwise-successful write.
+            if original_mode is not None:
+                try:
+                    os.chmod(tmp, original_mode)
+                except OSError:
+                    pass
+            os.replace(tmp, write_path)
         except Exception:
             try:
                 os.unlink(tmp)

--- a/integrations/claude-code/tests/test_statusline_no_clobber.py
+++ b/integrations/claude-code/tests/test_statusline_no_clobber.py
@@ -1,0 +1,309 @@
+"""Tests for `_ensure_statusline_configured` not clobbering a user's status line.
+
+`~/.claude/settings.json` is global, shared Claude Code config. The SessionStart
+hook must install Cognee's status line only when none exists, self-heal *its own*
+entry across plugin versions (tracked explicitly via statusLineCogneeManaged),
+never destroy a user's own custom `statusLine`, fail closed on corrupt JSON, and
+honour the reversible `COGNEE_FORCE_STATUSLINE` override.
+
+Run: python integrations/claude-code/tests/test_statusline_no_clobber.py
+"""
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+# session-start.py has a hyphen, so it can't be imported by name — load by path.
+# Guarded like the sibling tests: if the hook's deps aren't importable in this
+# environment, skip rather than erroring at collection time.
+try:
+    _spec = importlib.util.spec_from_file_location("session_start", _SCRIPTS / "session-start.py")
+    session_start = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(session_start)
+except Exception as exc:  # pragma: no cover - environment-dependent
+    print("SKIP test_statusline_no_clobber:", exc)
+    session_start = None
+
+MANAGED = "statusLineCogneeManaged"
+BACKUP = "statusLineCogneeBackup"
+COGNEE_CMD_SUFFIX = "cognee-statusline.sh"
+CUSTOM = {"type": "command", "command": "/my/custom/statusline.sh"}
+# The exact command the script installs when CLAUDE_PLUGIN_ROOT is unset (local
+# fallback): the cognee-statusline.sh next to session-start.py.
+EXPECTED_CMD = str((_SCRIPTS / "session-start.py").resolve().parent / "cognee-statusline.sh")
+
+
+def _settings_path(home):
+    return pathlib.Path(home) / ".claude" / "settings.json"
+
+
+def _write_raw(home, raw_text):
+    p = _settings_path(home)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(raw_text, encoding="utf-8")
+
+
+def _run_with_home(tmp_home, initial_settings=None, force=False):
+    """Invoke the function with HOME pointed at a temp dir; return the resulting settings dict.
+
+    Neutralizes CLAUDE_PLUGIN_ROOT so the script resolves its status-line path via
+    the local fallback (next to the script, which exists) rather than an inherited
+    plugin root that would not exist under the temp HOME. When initial_settings is
+    None the existing file (if any) is left as-is.
+    """
+    settings_path = _settings_path(tmp_home)
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    if initial_settings is not None:
+        settings_path.write_text(json.dumps(initial_settings), encoding="utf-8")
+
+    saved = {k: os.environ.get(k) for k in ("HOME", "COGNEE_FORCE_STATUSLINE", "CLAUDE_PLUGIN_ROOT")}
+    os.environ["HOME"] = str(tmp_home)
+    os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+    if force:
+        os.environ["COGNEE_FORCE_STATUSLINE"] = "1"
+    else:
+        os.environ.pop("COGNEE_FORCE_STATUSLINE", None)
+    try:
+        session_start._ensure_statusline_configured()
+    finally:
+        for k, v in saved.items():
+            if v is not None:
+                os.environ[k] = v
+            else:
+                os.environ.pop(k, None)
+
+    if settings_path.exists():
+        try:
+            return json.loads(settings_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return None  # corrupt file left intact
+    return None
+
+
+def test_installs_when_absent():
+    with tempfile.TemporaryDirectory() as home:
+        settings = _run_with_home(home, initial_settings={})
+        assert settings["statusLine"]["command"].endswith(COGNEE_CMD_SUFFIX)
+        assert settings[MANAGED] == settings["statusLine"]["command"]
+
+
+def test_preserves_user_statusline():
+    with tempfile.TemporaryDirectory() as home:
+        settings = _run_with_home(home, initial_settings={"statusLine": CUSTOM})
+        assert settings["statusLine"] == CUSTOM
+        assert MANAGED not in settings and BACKUP not in settings
+
+
+def test_preserves_user_statusline_with_matching_basename():
+    # A user's *own* script that merely shares the basename must not be adopted:
+    # ownership is by recorded marker, not by filename.
+    lookalike = {"type": "command", "command": "/home/me/bin/cognee-statusline.sh"}
+    with tempfile.TemporaryDirectory() as home:
+        settings = _run_with_home(home, initial_settings={"statusLine": lookalike})
+        assert settings["statusLine"] == lookalike
+        assert MANAGED not in settings
+
+
+def test_noop_when_already_cognee():
+    with tempfile.TemporaryDirectory() as home:
+        first = _run_with_home(home, initial_settings={})
+        second = _run_with_home(home)  # idempotent — no churn
+        assert second["statusLine"] == first["statusLine"]
+        assert second[MANAGED] == first[MANAGED]
+        assert BACKUP not in second
+
+
+def test_adopts_unmarked_current_install():
+    # An install from older code (no marker) whose path already equals the current
+    # one is adopted: marker recorded, status line unchanged.
+    with tempfile.TemporaryDirectory() as home:
+        settings = _run_with_home(home, initial_settings={"statusLine": {"type": "command", "command": EXPECTED_CMD}})
+        assert settings["statusLine"]["command"] == EXPECTED_CMD
+        assert settings[MANAGED] == EXPECTED_CMD
+
+
+def test_self_heals_stale_cognee_path_when_marked():
+    # A marked Cognee line from an older install (different path) is repathed.
+    stale_cmd = "/old/plugin/v0.1.0/scripts/cognee-statusline.sh"
+    with tempfile.TemporaryDirectory() as home:
+        settings = _run_with_home(
+            home,
+            initial_settings={"statusLine": {"type": "command", "command": stale_cmd}, MANAGED: stale_cmd},
+        )
+        assert settings["statusLine"]["command"] == EXPECTED_CMD
+        assert settings[MANAGED] == EXPECTED_CMD
+
+
+def test_unmarked_stale_lookalike_is_preserved():
+    # Without a marker, a stale cognee-named line at a different path is treated as
+    # the user's and left alone (conservative — never destroys).
+    stale = {"type": "command", "command": "/old/plugin/v0.1.0/scripts/cognee-statusline.sh"}
+    with tempfile.TemporaryDirectory() as home:
+        settings = _run_with_home(home, initial_settings={"statusLine": stale})
+        assert settings["statusLine"] == stale
+        assert MANAGED not in settings
+
+
+def test_empty_statusline_is_replaced():
+    with tempfile.TemporaryDirectory() as home:
+        settings = _run_with_home(home, initial_settings={"statusLine": {}})
+        assert settings["statusLine"]["command"].endswith(COGNEE_CMD_SUFFIX)
+
+
+def test_non_dict_statusline_is_preserved():
+    with tempfile.TemporaryDirectory() as home:
+        settings = _run_with_home(home, initial_settings={"statusLine": "legacy-string-value"})
+        assert settings["statusLine"] == "legacy-string-value"
+        assert MANAGED not in settings
+
+
+def test_corrupt_json_is_left_untouched():
+    # Fail closed: an unparseable settings.json must never be overwritten.
+    garbage = "{ this is not valid json "
+    with tempfile.TemporaryDirectory() as home:
+        _write_raw(home, garbage)
+        _run_with_home(home)  # initial_settings=None -> don't rewrite our garbage
+        assert _settings_path(home).read_text(encoding="utf-8") == garbage
+
+
+def test_force_override_backs_up_user_statusline():
+    with tempfile.TemporaryDirectory() as home:
+        settings = _run_with_home(home, initial_settings={"statusLine": CUSTOM}, force=True)
+        assert settings["statusLine"]["command"].endswith(COGNEE_CMD_SUFFIX)
+        assert settings[BACKUP] == CUSTOM
+        assert settings[MANAGED] == settings["statusLine"]["command"]
+
+
+def test_force_override_is_reversible():
+    with tempfile.TemporaryDirectory() as home:
+        forced = _run_with_home(home, initial_settings={"statusLine": CUSTOM}, force=True)
+        assert forced["statusLine"]["command"].endswith(COGNEE_CMD_SUFFIX)
+        restored = _run_with_home(home)  # force unset
+        assert restored["statusLine"] == CUSTOM
+        assert BACKUP not in restored and MANAGED not in restored
+
+
+def test_force_backup_keeps_newest_displaced_value():
+    # A pre-existing backup must be overwritten with the newly displaced value
+    # (proves direct assignment, not setdefault).
+    other = {"type": "command", "command": "/another/statusline.sh"}
+    stale_backup = {"type": "command", "command": "/stale/old.sh"}
+    with tempfile.TemporaryDirectory() as home:
+        settings = _run_with_home(
+            home, initial_settings={"statusLine": other, BACKUP: stale_backup}, force=True
+        )
+        assert settings["statusLine"]["command"].endswith(COGNEE_CMD_SUFFIX)
+        assert settings[BACKUP] == other  # newest wins, not the stale backup
+
+
+def test_orphan_backup_is_cleaned_not_resurrected():
+    # User took ownership while an orphaned backup/marker lingered: clean them so a
+    # later statusLine removal can't resurrect the dead value.
+    user_c = {"type": "command", "command": "/user/c.sh"}
+    dead_a = {"type": "command", "command": "/dead/a.sh"}
+    with tempfile.TemporaryDirectory() as home:
+        cleaned = _run_with_home(
+            home, initial_settings={"statusLine": user_c, BACKUP: dead_a, MANAGED: EXPECTED_CMD}
+        )
+        assert cleaned["statusLine"] == user_c
+        assert BACKUP not in cleaned and MANAGED not in cleaned
+        # Now the user removes their status line entirely: fresh install, not A.
+        _write_raw(home, json.dumps({}))
+        after = _run_with_home(home)
+        assert after["statusLine"]["command"].endswith(COGNEE_CMD_SUFFIX)
+        assert after["statusLine"] != dead_a
+
+
+def test_self_heals_unmarked_cognee_memory_install():
+    # A legacy (no-marker) line inside the cognee-memory plugin dir is recognised
+    # as ours by path and self-healed to the current install.
+    legacy = {
+        "type": "command",
+        "command": "/u/.claude/plugins/cache/cognee/cognee-memory/0.1.0/scripts/cognee-statusline.sh",
+    }
+    with tempfile.TemporaryDirectory() as home:
+        settings = _run_with_home(home, initial_settings={"statusLine": legacy})
+        assert settings["statusLine"]["command"] == EXPECTED_CMD
+        assert settings[MANAGED] == EXPECTED_CMD
+
+
+def test_no_resurrect_after_user_clears_statusline():
+    # Force displaces the user's line, then the user unsets the env var AND removes
+    # the statusLine entirely (unaware of the backup key). It must NOT reappear.
+    with tempfile.TemporaryDirectory() as home:
+        forced = _run_with_home(home, initial_settings={"statusLine": CUSTOM}, force=True)
+        assert forced[BACKUP] == CUSTOM
+        cur = json.loads(_settings_path(home).read_text(encoding="utf-8"))
+        cur.pop("statusLine", None)  # user deletes the slot, leaves bookkeeping behind
+        _write_raw(home, json.dumps(cur))
+        after = _run_with_home(home)  # force off
+        assert after["statusLine"]["command"].endswith(COGNEE_CMD_SUFFIX)
+        assert after["statusLine"] != CUSTOM
+        assert BACKUP not in after
+
+
+def test_non_object_json_is_left_untouched():
+    # Valid JSON that isn't an object must be left alone (fail closed).
+    raw = '["not", "an", "object"]'
+    with tempfile.TemporaryDirectory() as home:
+        _write_raw(home, raw)
+        _run_with_home(home)
+        assert _settings_path(home).read_text(encoding="utf-8") == raw
+
+
+def test_symlinked_settings_is_followed_not_replaced():
+    # A symlinked settings.json (dotfiles pattern) must be edited through the link,
+    # not replaced by a regular file.
+    with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as dots:
+        target = pathlib.Path(dots) / "settings.json"
+        target.write_text("{}", encoding="utf-8")
+        link = _settings_path(home)
+        link.parent.mkdir(parents=True, exist_ok=True)
+        link.symlink_to(target)
+        _run_with_home(home)
+        assert link.is_symlink()  # link preserved
+        assert not target.is_symlink()
+        data = json.loads(target.read_text(encoding="utf-8"))
+        assert data["statusLine"]["command"].endswith(COGNEE_CMD_SUFFIX)
+
+
+def test_preserves_file_permissions():
+    with tempfile.TemporaryDirectory() as home:
+        path = _settings_path(home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}", encoding="utf-8")
+        os.chmod(path, 0o644)
+        _run_with_home(home)  # initial_settings=None: keep the file we set up
+        assert (path.stat().st_mode & 0o777) == 0o644
+
+
+def test_new_file_is_private():
+    # A settings.json created from scratch stays owner-only (0600) — it can hold
+    # secrets, so creation must not broaden permissions.
+    with tempfile.TemporaryDirectory() as home:
+        _run_with_home(home)  # no file exists yet
+        path = _settings_path(home)
+        assert path.exists()
+        assert (path.stat().st_mode & 0o777) == 0o600
+
+
+if __name__ == "__main__":
+    if session_start is None:
+        print("SKIP: session-start module unavailable")
+        sys.exit(0)
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except Exception as exc:  # catch all so one failure doesn't abort the run
+                failures += 1
+                print("FAIL", _name, repr(exc))
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
Fixes #109.

## Problem

On every `SessionStart`, `scripts/session-start.py:_ensure_statusline_configured()` wrote Cognee's status-line command into the **global** `~/.claude/settings.json`, replacing any value that wasn't already exactly Cognee's:

```python
if settings.get("statusLine") == desired:
    return
settings["statusLine"] = desired   # unconditional overwrite, no backup
```

A user with their own custom `statusLine` (path / branch / model / context, etc.) lost it silently, with no backup, and — because this runs every session — a restored custom line was clobbered again.

## Fix

Ownership is tracked **explicitly** via a `statusLineCogneeManaged` marker (the command Cognee last installed), rather than seizing the key. Default policy:

| Current `statusLine` | Action |
|---|---|
| absent / empty | install Cognee's |
| our own, but a stale path | self-heal to the current path |
| anything else (user-owned) | **preserve it, do nothing** |

Legacy installs that predate the marker are recognised as ours by exact path **or** by the stable `cognee-memory` package-dir segment, so plugin upgrades self-heal the path — while a user's coincidentally-named script (e.g. `~/bin/cognee-statusline.sh` elsewhere) is never mistaken for ours.

### Opt-in override
`COGNEE_FORCE_STATUSLINE` (`1`/`true`/`yes`/`on`) forces Cognee's status line and stashes any displaced user value under `statusLineCogneeBackup`. The override is **reversible** — clear the env var and the next session restores the stashed value — and restores only from a slot Cognee still owns, so a line the user has since taken over or deliberately cleared is never resurrected.

### Hardening
- Corrupt `settings.json` **fails closed** (read inline so a parse error touches nothing).
- Non-object top-level JSON is left untouched.
- A **symlinked** `settings.json` (dotfiles pattern) is followed and its target rewritten in place, instead of replacing the link with a regular file.
- File permissions are preserved; a newly created file stays private `0600` (it can hold secrets). `chmod` is best-effort so unusual filesystems can't abort an otherwise-successful write.
- Settings are only rewritten when something actually changed (no per-session mtime churn).

## Tests

New `integrations/claude-code/tests/test_statusline_no_clobber.py` (20 cases) covers install / preserve / basename-lookalike / adopt / self-heal (marked + legacy) / empty / non-dict / corrupt-JSON / non-object-JSON / force-backup / reversible override / newest-wins / orphan cleanup / no-resurrect / symlink / permissions. The existing suite passes unchanged.

## Notes / deliberate scope choices
- A `settings.json` symlinked into a **read-only** location will skip the status-line install (logged) rather than risk breaking the link — fail-closed by design.
- The plugin has several divergent inline env-flag parsers; unifying them behind a shared helper is out of scope here and left as a follow-up.
