### PR TITLE
feat(openclaw): port circuit breaker and per-op timeouts from Python client

### DIFF
--- a/integrations/openclaw/__tests__/test_circuitBreaker.ts
+++ b/integrations/openclaw/__tests__/test_circuitBreaker.ts
@@ -1,0 +1,135 @@
+import { CogneeHttpClient, CircuitBreaker } from "../src/client";
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+function mockFetch(status: number, body: unknown = {}) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  } as Response);
+}
+
+function mockFetchFail(errorName = "AbortError") {
+  const err = new DOMException("timeout", errorName);
+  global.fetch = jest.fn().mockRejectedValue(err);
+}
+
+// ---------------------------------------------------------------------------
+// CircuitBreaker unit tests
+// ---------------------------------------------------------------------------
+
+describe("CircuitBreaker", () => {
+  it("starts closed", () => {
+    const b = new CircuitBreaker(3, 5000);
+    expect(b.isOpen).toBe(false);
+  });
+
+  it("opens after threshold failures", () => {
+    const b = new CircuitBreaker(3, 5000);
+    b.recordFailure();
+    b.recordFailure();
+    expect(b.isOpen).toBe(false);
+    b.recordFailure();
+    expect(b.isOpen).toBe(true);
+  });
+
+  it("resets on success", () => {
+    const b = new CircuitBreaker(2, 5000);
+    b.recordFailure();
+    b.recordFailure();
+    expect(b.isOpen).toBe(true);
+    b.recordSuccess();
+    expect(b.isOpen).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CogneeHttpClient breaker integration tests
+// ---------------------------------------------------------------------------
+
+describe("CogneeHttpClient breaker integration", () => {
+  it("trips on repeated network errors, not on 401", async () => {
+    const breaker = new CircuitBreaker(2, 60_000);
+    const client = new CogneeHttpClient(
+      "http://localhost:9999", "key", "", "", 1000, 1000, "cloud",
+      1000, 1000, breaker,
+    );
+
+    // Two network failures (TypeError = network error, not retried as timeout)
+    const networkErr = Object.assign(new Error("network failure"), { name: "TypeError" });
+    global.fetch = jest.fn().mockRejectedValue(networkErr);
+    await expect(client.recall({
+      queryText: "q", searchPrompt: "", searchType: "GRAPH_COMPLETION",
+      datasetIds: [], topK: 5,
+    })).rejects.toThrow();
+    await expect(client.recall({
+      queryText: "q", searchPrompt: "", searchType: "GRAPH_COMPLETION",
+      datasetIds: [], topK: 5,
+    })).rejects.toThrow();
+
+    expect(breaker.isOpen).toBe(true);
+
+    // A 401 should NOT trip the breaker (auth config problem, not a transient outage)
+    const b2 = new CircuitBreaker(3, 60_000);
+    const c2 = new CogneeHttpClient(
+      "http://localhost:9999", "key", "", "", 1000, 1000, "cloud",
+      1000, 1000, b2,
+    );
+    mockFetch(401);
+    await expect(c2.recall({
+      queryText: "q", searchPrompt: "", searchType: "GRAPH_COMPLETION",
+      datasetIds: [], topK: 5,
+    })).rejects.toThrow();
+    expect(b2.isOpen).toBe(false); // 401 must NOT trip the breaker
+  });
+
+  it("trips on 5xx", async () => {
+    const breaker = new CircuitBreaker(1, 60_000);
+    const client = new CogneeHttpClient(
+      "http://localhost:9999", "key", "", "", 1000, 1000, "cloud",
+      1000, 1000, breaker,
+    );
+    mockFetch(500, { error: "boom" });
+    await expect(client.search({
+      queryText: "q", searchPrompt: "", searchType: "GRAPH_COMPLETION",
+      datasetIds: [], maxTokens: 512,
+    })).rejects.toThrow();
+    expect(breaker.isOpen).toBe(true);
+  });
+
+  it("rejects immediately when open, without calling fetch", async () => {
+    const breaker = new CircuitBreaker(1, 60_000);
+    breaker.recordFailure(); // trip it manually
+    const client = new CogneeHttpClient(
+      "http://localhost:9999", "key", "", "", 1000, 1000, "cloud",
+      1000, 1000, breaker,
+    );
+    const spy = jest.fn();
+    global.fetch = spy;
+    await expect(client.search({
+      queryText: "q", searchPrompt: "", searchType: "GRAPH_COMPLETION",
+      datasetIds: [], maxTokens: 512,
+    })).rejects.toThrow(/circuit open/);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("clears breaker on success", async () => {
+    const breaker = new CircuitBreaker(3, 60_000);
+    breaker.recordFailure();
+    breaker.recordFailure();
+    const client = new CogneeHttpClient(
+      "http://localhost:9999", "key", "", "", 1000, 1000, "cloud",
+      1000, 1000, breaker,
+    );
+    mockFetch(200, []);
+    await client.search({
+      queryText: "q", searchPrompt: "", searchType: "GRAPH_COMPLETION",
+      datasetIds: [], maxTokens: 512,
+    });
+    expect(breaker.isOpen).toBe(false);
+  });
+});

--- a/integrations/openclaw/src/client.ts
+++ b/integrations/openclaw/src/client.ts
@@ -17,6 +17,9 @@ const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY_MS = 3_000;
 const DEFAULT_TIMEOUT_MS = 60_000;
 const DEFAULT_INGESTION_TIMEOUT_MS = 300_000;
+export const DEFAULT_RECALL_TIMEOUT_MS  = 20_000;
+export const DEFAULT_SEARCH_TIMEOUT_MS  = 20_000;
+export const DEFAULT_HEALTH_TIMEOUT_MS  = 10_000;
 
 // ---------------------------------------------------------------------------
 // CogneeHttpClient — shared HTTP transport with auth, retry, timeout
@@ -24,6 +27,44 @@ const DEFAULT_INGESTION_TIMEOUT_MS = 300_000;
 // Extracted so both the memory plugin and skills plugin can share one
 // implementation instead of duplicating ~200 lines of fetch/auth logic.
 // ---------------------------------------------------------------------------
+
+// --- Circuit breaker -------------------------------------------------------
+// Trips on UNREACHABLE (AbortError / network error) and 5xx.
+// 401/403 are auth config problems — they do NOT trip the breaker.
+
+export const DEFAULT_BREAKER_THRESHOLD = 5;
+export const DEFAULT_BREAKER_COOLDOWN_MS = 120_000;
+
+export class CircuitBreaker {
+  private failures = 0;
+  private cooldownUntil = 0;
+
+  constructor(
+    private readonly threshold: number = DEFAULT_BREAKER_THRESHOLD,
+    private readonly cooldownMs: number = DEFAULT_BREAKER_COOLDOWN_MS,
+  ) {}
+
+  get isOpen(): boolean {
+    return Date.now() < this.cooldownUntil;
+  }
+
+  get retryInMs(): number {
+    return Math.max(0, this.cooldownUntil - Date.now());
+  }
+
+  recordFailure(): void {
+    this.failures += 1;
+    if (this.failures >= this.threshold) {
+      this.cooldownUntil = Date.now() + this.cooldownMs;
+    }
+  }
+
+  recordSuccess(): void {
+    this.failures = 0;
+    this.cooldownUntil = 0;
+  }
+}
+// --------------------------------------------------------------------------
 
 export class CogneeHttpClient {
   private authToken: string | undefined;
@@ -37,6 +78,10 @@ export class CogneeHttpClient {
     private readonly timeoutMs: number = DEFAULT_TIMEOUT_MS,
     readonly ingestionTimeoutMs: number = DEFAULT_INGESTION_TIMEOUT_MS,
     readonly mode: CogneeMode = "local",
+    // --- new (optional, append-only) ---
+    private readonly recallTimeoutMs: number = DEFAULT_RECALL_TIMEOUT_MS,
+    private readonly searchTimeoutMs: number = DEFAULT_SEARCH_TIMEOUT_MS,
+    readonly breaker: CircuitBreaker = new CircuitBreaker(),
   ) { }
 
   private get isCloud(): boolean {
@@ -110,6 +155,13 @@ export class CogneeHttpClient {
   ): Promise<T> {
     await this.ensureAuth();
 
+    // Circuit breaker: reject immediately when open (no network call).
+    if (this.breaker.isOpen) {
+      throw new Error(
+        `Cognee temporarily unavailable (circuit open, retry in ~${Math.ceil(this.breaker.retryInMs / 1000)}s)`
+      );
+    }
+
     let lastError: unknown;
     for (let attempt = 0; attempt <= retries; attempt++) {
       if (attempt > 0) {
@@ -145,6 +197,7 @@ export class CogneeHttpClient {
               const errorText = await retryResponse.text();
               throw new Error(`Cognee request failed (${retryResponse.status}): ${errorText}`);
             }
+            this.breaker.recordSuccess();
             return responseParser(retryResponse);
           } finally {
             clearTimeout(retryTimeout);
@@ -153,11 +206,25 @@ export class CogneeHttpClient {
 
         if (!response.ok) {
           const errorText = await response.text();
+          // 5xx — transient server failure, trip the breaker.
+          // 401/403 — auth config problem, do NOT trip the breaker.
+          if (response.status >= 500) {
+            this.breaker.recordFailure();
+          }
           throw new Error(`Cognee request failed (${response.status}): ${errorText}`);
         }
+        this.breaker.recordSuccess();
         return (await response.json()) as T;
       } catch (error) {
         clearTimeout(timer);
+        // Trip the breaker on network/timeout errors (not on HTTP errors, which
+        // are already handled by the status check above).
+        const isNetworkError =
+          error instanceof DOMException ||
+          (error instanceof Error && (error.name === "AbortError" || error.name === "TypeError"));
+        if (isNetworkError) {
+          this.breaker.recordFailure();
+        }
         const isTimeout =
           error instanceof DOMException ||
           (error instanceof Error && error.name === "AbortError");
@@ -175,7 +242,7 @@ export class CogneeHttpClient {
 
   async health(): Promise<{ status: string }> {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    const timer = setTimeout(() => controller.abort(), DEFAULT_HEALTH_TIMEOUT_MS);
     try {
       const headers = this.isCloud ? { "X-Api-Key": this.apiKey! } : {};
       const response = await fetch(`${this.baseUrl}/health`, {
@@ -502,7 +569,7 @@ export class CogneeHttpClient {
         ...(params.searchPrompt ? { systemPrompt: params.searchPrompt } : {}),
         ...(params.sessionId ? { session_id: params.sessionId } : {}),
       }),
-    });
+    }, this.searchTimeoutMs);
     return normalizeSearchResults(data);
   }
 
@@ -531,7 +598,7 @@ export class CogneeHttpClient {
         ...(params.sessionId ? { session_id: params.sessionId } : {}),
         ...(params.scope ? { scope: params.scope } : {}),
       }),
-    });
+    }, this.recallTimeoutMs);
     return normalizeSearchResults(data);
   }
 

--- a/integrations/openclaw/src/config.ts
+++ b/integrations/openclaw/src/config.ts
@@ -1,4 +1,5 @@
 import type { CogneeMode, CogneePluginConfig, CogneeSearchType, MemoryScope, ScopeRoute } from "./types.js";
+import { DEFAULT_RECALL_TIMEOUT_MS, DEFAULT_SEARCH_TIMEOUT_MS, DEFAULT_BREAKER_THRESHOLD, DEFAULT_BREAKER_COOLDOWN_MS } from "./client.js";
 
 // ---------------------------------------------------------------------------
 // Defaults
@@ -75,6 +76,10 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
   const improveOnSessionEnd = typeof raw.improveOnSessionEnd === "boolean" ? raw.improveOnSessionEnd : DEFAULT_IMPROVE_ON_SESSION_END;
   const requestTimeoutMs = typeof raw.requestTimeoutMs === "number" ? raw.requestTimeoutMs : DEFAULT_REQUEST_TIMEOUT_MS;
   const ingestionTimeoutMs = typeof raw.ingestionTimeoutMs === "number" ? raw.ingestionTimeoutMs : DEFAULT_INGESTION_TIMEOUT_MS;
+  const recallTimeoutMs = typeof raw.recallTimeoutMs === "number" ? raw.recallTimeoutMs : DEFAULT_RECALL_TIMEOUT_MS;
+  const searchTimeoutMs = typeof raw.searchTimeoutMs === "number" ? raw.searchTimeoutMs : DEFAULT_SEARCH_TIMEOUT_MS;
+  const breakerThreshold = typeof raw.breakerThreshold === "number" ? raw.breakerThreshold : DEFAULT_BREAKER_THRESHOLD;
+  const breakerCooldownMs = typeof raw.breakerCooldownMs === "number" ? raw.breakerCooldownMs : DEFAULT_BREAKER_COOLDOWN_MS;
 
   const apiKey =
     raw.apiKey && raw.apiKey.length > 0 ? resolveEnvVars(raw.apiKey)
@@ -120,5 +125,6 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
     maxResults, minScore, maxTokens,
     autoRecall, autoIndex, autoCognify, autoMemify, improveOnSessionEnd,
     requestTimeoutMs, ingestionTimeoutMs,
+    recallTimeoutMs, searchTimeoutMs, breakerThreshold, breakerCooldownMs,
   };
 }

--- a/integrations/openclaw/src/types.ts
+++ b/integrations/openclaw/src/types.ts
@@ -101,6 +101,10 @@ export type CogneePluginConfig = {
   // --- Timeouts ---
   requestTimeoutMs?: number;
   ingestionTimeoutMs?: number;
+  recallTimeoutMs?: number;
+  searchTimeoutMs?: number;
+  breakerThreshold?: number;
+  breakerCooldownMs?: number;
 };
 
 export type CogneeAddResponse = {


### PR DESCRIPTION
### Description
Ports the circuit breaker and per-op timeouts from the Python `_cognee_client.py`
to the TypeScript `CogneeHttpClient` in the OpenClaw integration.
The breaker trips on network errors and 5xx responses, rejects calls immediately
while open, and resets on success. 401/403 (auth config errors) do not trip it.

Closes topoteretes/cognee#3545

## Code changes
- **`src/client.ts`** — adds `CircuitBreaker` class and constants
  (`DEFAULT_BREAKER_THRESHOLD`, `DEFAULT_BREAKER_COOLDOWN_MS`); extends
  `CogneeHttpClient` constructor with three append-only optional params
  (`recallTimeoutMs`, `searchTimeoutMs`, `breaker`); wires breaker into
  `fetchAPI` (open-check at top, trip on 5xx and network errors, reset on
  success); adds `DEFAULT_RECALL_TIMEOUT_MS` (20s), `DEFAULT_SEARCH_TIMEOUT_MS`
  (20s), `DEFAULT_HEALTH_TIMEOUT_MS` (10s) and passes them to `recall()`,
  `search()`, and `health()` respectively.
- **`src/types.ts`** — adds `recallTimeoutMs?`, `searchTimeoutMs?`,
  `breakerThreshold?`, `breakerCooldownMs?` to `CogneePluginConfig`.
- **`src/config.ts`** — imports the four new constants from `client.ts` and
  resolves all four fields in `resolveConfig()`.
- **`__tests__/test_circuitBreaker.ts`** *(new)* — 7 tests: breaker starts
  closed, opens at threshold, resets on success, trips on network errors, does
  not trip on 401, trips on 5xx, rejects without fetching when already open.

All new constructor params have defaults — `plugin.ts` is untouched.