### PR TITLE
[integrations] cognee-plugin status one-liner

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -50,18 +50,56 @@ Key resolution order:
 1. `COGNEE_API_KEY` env var
 2. `~/.cognee-plugin/api_key.json` (cached from a previous mint)
 3. Auto-mint from the default local user (local mode only), then cache to `api_key.json`
+## Modes
 
-## Mode selection rules
+The provider connects to cognee in one of three modes. It picks the mode
+automatically from your config:
 
-At startup (`SessionStart`):
-- `COGNEE_BASE_URL` set → `managed_endpoint`, either local, or on Cognee Cloud (API key needed in cloud case)
-- otherwise → `integration_local` (local API bootstrap)
+| Mode | When it's used | How it talks to cognee |
+| --- | --- | --- |
+| **local-server** (default) | no `COGNEE_BASE_URL`, `COGNEE_EMBEDDED` unset | ensures a local cognee server is running and connects as a thin client |
+| **remote** | `COGNEE_BASE_URL` is set | thin client to your managed / cloud cognee |
+| **embedded** | `COGNEE_EMBEDDED=true` | runs cognee in-process |
 
-At hook runtime:
-- hooks resolve mode through runtime endpoint auth (env + `api_key.json`), not only config intent
-- `http` mode skips local SDK initialization
+**Why local-server is the default.** cognee's local stores (SQLite, Kuzu/Ladybug,
+LanceDB) are single-writer. Driving them in-process from the agent's background
+threads — or from a second Claude Code process sharing the same `data_root` — risks
+`database is locked` errors and corruption. A local cognee server is the single
+owner that serializes all access, so the agent just makes HTTP calls. This is the
+same design the Claude Code and Codex plugins use. **`embedded` is opt-in and is
+safe for single-process / offline use only.**
 
-The hooks emit `mode_decision` logs with `mode`, `service_url`, `url_source`, `key_source`, `api_key_present`.
+**No silent fallbacks.** The provider never downgrades modes behind your back. If
+`COGNEE_BASE_URL` is set but unreachable, or the local server fails to start,
+initialization raises rather than quietly switching to a different mode — silent
+fallback would either mask a config error (remote → local data divergence) or
+reintroduce the very DB-lock risk this design removes (local-server → embedded).
+To accept the single-process trade-off, set `COGNEE_EMBEDDED=true` explicitly.
+
+local-server mode (default — just set your LLM creds):
+
+```bash
+LLM_API_KEY=sk-...
+LLM_MODEL=gpt-4o-mini
+COGNEE_DATASET=agent_sessions
+# COGNEE_LOCAL_PORT=8000   # optional; point at a shared server for a unified brain
+```
+
+Remote / cloud mode:
+
+```bash
+COGNEE_BASE_URL=https://your-cognee-service.example   # canonical name
+COGNEE_API_KEY=...
+COGNEE_DATASET=agent_sessions
+```
+
+Embedded (in-process) mode — single-process / offline only:
+
+```bash
+COGNEE_EMBEDDED=true
+LLM_API_KEY=sk-...
+COGNEE_DATASET=agent_sessions
+```
 
 ## Sessions
 

--- a/integrations/claude-code/scripts/cognee-statusline.sh
+++ b/integrations/claude-code/scripts/cognee-statusline.sh
@@ -5,4 +5,5 @@
 # We `exec` into the standalone Python renderer so it inherits that same stdin —
 # the renderer is pure-local (reads only ~/.cognee-plugin JSON files), never
 # imports the plugin runtime, and makes no network call, so it stays instant.
-exec python3 "$(dirname "$0")/cognee_statusline_render.py"
+exec python3 "$(dirname "$0")/cognee_statusline_render.py" "$@"
+

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -73,7 +73,72 @@ def _health_prefix() -> str:
     return ""
 
 
+def _resolve_config() -> tuple[str, str, str, str]:
+    # 1. Resolve mode and url
+    embedded = os.environ.get("COGNEE_EMBEDDED", "").lower() in ("true", "1", "yes")
+
+    url = os.environ.get("COGNEE_BASE_URL", "").strip()
+    if not url:
+        try:
+            data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                url = str(data.get("base_url") or "").strip()
+        except Exception:
+            pass
+
+    if embedded:
+        mode = "embedded"
+        resolved_url = "none"
+    elif url:
+        mode = "remote"
+        resolved_url = url.rstrip("/")
+    else:
+        mode = "local-server"
+        local_url = os.environ.get("COGNEE_LOCAL_API_URL", "").strip()
+        if not local_url:
+            local_url = "http://localhost:8011"
+        resolved_url = local_url.rstrip("/")
+
+    # 2. Resolve key
+    key = os.environ.get("COGNEE_API_KEY", "").strip()
+    if not key:
+        cache_path = _SHARED_ROOT / "api_key.json"
+        if cache_path.exists():
+            try:
+                cache = json.loads(cache_path.read_text(encoding="utf-8"))
+                if isinstance(cache, dict):
+                    cached_key = str(cache.get("api_key") or "").strip()
+                    cached_url = str(cache.get("base_url") or "").strip().rstrip("/")
+                    if cached_key and (not cached_url or cached_url == resolved_url):
+                        key = cached_key
+            except Exception:
+                pass
+
+    # 3. Resolve version
+    version = "0.0.0"
+    plugin_root = Path(__file__).resolve().parent.parent
+    for sub in (".claude-plugin", ".codex-plugin"):
+        p = plugin_root / sub / "plugin.json"
+        if p.exists():
+            try:
+                data = json.loads(p.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    v = data.get("version")
+                    if v:
+                        version = str(v)
+                        break
+            except Exception:
+                pass
+
+    return mode, resolved_url, key, version
+
+
 def main() -> None:
+    if len(sys.argv) > 1 and sys.argv[1] in ("status", "--status"):
+        mode, url, key, version = _resolve_config()
+        sys.stdout.write(f"mode={mode} url={url} key={key} version={version}\n")
+        sys.exit(0)
+
     try:
         json.load(sys.stdin)  # consume stdin as required by Claude Code
     except Exception:
@@ -83,3 +148,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -64,18 +64,56 @@ Key resolution order:
 1. `COGNEE_API_KEY` env var
 2. `~/.cognee-plugin/api_key.json` (cached from a previous mint)
 3. Auto-mint from the default local user (local mode only), then cache to `api_key.json`
+## Modes
 
-## Mode selection rules
+The provider connects to cognee in one of three modes. It picks the mode
+automatically from your config:
 
-At startup (`SessionStart`):
-- `COGNEE_BASE_URL` set → `managed_endpoint`
-- otherwise → `integration_local` (local API bootstrap)
+| Mode | When it's used | How it talks to cognee |
+| --- | --- | --- |
+| **local-server** (default) | no `COGNEE_BASE_URL`, `COGNEE_EMBEDDED` unset | ensures a local cognee server is running and connects as a thin client |
+| **remote** | `COGNEE_BASE_URL` is set | thin client to your managed / cloud cognee |
+| **embedded** | `COGNEE_EMBEDDED=true` | runs cognee in-process |
 
-At hook runtime:
-- hooks resolve mode through runtime endpoint auth (env + `api_key.json`), not only config intent
-- `http` mode skips local SDK initialization
+**Why local-server is the default.** cognee's local stores (SQLite, Kuzu/Ladybug,
+LanceDB) are single-writer. Driving them in-process from the agent's background
+threads — or from a second Codex process sharing the same `data_root` — risks
+`database is locked` errors and corruption. A local cognee server is the single
+owner that serializes all access, so the agent just makes HTTP calls. This is the
+same design the Claude Code and Codex plugins use. **`embedded` is opt-in and is
+safe for single-process / offline use only.**
 
-The hooks emit `mode_decision` logs with `mode`, `service_url`, `url_source`, `key_source`, `api_key_present`.
+**No silent fallbacks.** The provider never downgrades modes behind your back. If
+`COGNEE_BASE_URL` is set but unreachable, or the local server fails to start,
+initialization raises rather than quietly switching to a different mode — silent
+fallback would either mask a config error (remote → local data divergence) or
+reintroduce the very DB-lock risk this design removes (local-server → embedded).
+To accept the single-process trade-off, set `COGNEE_EMBEDDED=true` explicitly.
+
+local-server mode (default — just set your LLM creds):
+
+```bash
+LLM_API_KEY=sk-...
+LLM_MODEL=gpt-4o-mini
+COGNEE_DATASET=agent_sessions
+# COGNEE_LOCAL_PORT=8000   # optional; point at a shared server for a unified brain
+```
+
+Remote / cloud mode:
+
+```bash
+COGNEE_BASE_URL=https://your-cognee-service.example   # canonical name
+COGNEE_API_KEY=...
+COGNEE_DATASET=agent_sessions
+```
+
+Embedded (in-process) mode — single-process / offline only:
+
+```bash
+COGNEE_EMBEDDED=true
+LLM_API_KEY=sk-...
+COGNEE_DATASET=agent_sessions
+```
 
 ## Sessions
 

--- a/integrations/codex/plugins/cognee/scripts/cognee-statusline.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-statusline.sh
@@ -6,4 +6,5 @@
 # the renderer is pure-local (reads only ~/.cognee-plugin/codex JSON files),
 # never imports the plugin runtime, and makes no network call, so it stays
 # instant.
-exec python3 "$(dirname "$0")/cognee_statusline_render.py"
+exec python3 "$(dirname "$0")/cognee_statusline_render.py" "$@"
+

--- a/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
@@ -78,7 +78,72 @@ def render_status_for_host(host_id: str) -> str:
     return f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}"
 
 
+def _resolve_config() -> tuple[str, str, str, str]:
+    # 1. Resolve mode and url
+    embedded = os.environ.get("COGNEE_EMBEDDED", "").lower() in ("true", "1", "yes")
+
+    url = os.environ.get("COGNEE_BASE_URL", "").strip()
+    if not url:
+        try:
+            data = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                url = str(data.get("base_url") or "").strip()
+        except Exception:
+            pass
+
+    if embedded:
+        mode = "embedded"
+        resolved_url = "none"
+    elif url:
+        mode = "remote"
+        resolved_url = url.rstrip("/")
+    else:
+        mode = "local-server"
+        local_url = os.environ.get("COGNEE_LOCAL_API_URL", "").strip()
+        if not local_url:
+            local_url = "http://localhost:8011"
+        resolved_url = local_url.rstrip("/")
+
+    # 2. Resolve key
+    key = os.environ.get("COGNEE_API_KEY", "").strip()
+    if not key:
+        cache_path = _SHARED_ROOT / "api_key.json"
+        if cache_path.exists():
+            try:
+                cache = json.loads(cache_path.read_text(encoding="utf-8"))
+                if isinstance(cache, dict):
+                    cached_key = str(cache.get("api_key") or "").strip()
+                    cached_url = str(cache.get("base_url") or "").strip().rstrip("/")
+                    if cached_key and (not cached_url or cached_url == resolved_url):
+                        key = cached_key
+            except Exception:
+                pass
+
+    # 3. Resolve version
+    version = "0.0.0"
+    plugin_root = Path(__file__).resolve().parent.parent
+    for sub in (".claude-plugin", ".codex-plugin"):
+        p = plugin_root / sub / "plugin.json"
+        if p.exists():
+            try:
+                data = json.loads(p.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    v = data.get("version")
+                    if v:
+                        version = str(v)
+                        break
+            except Exception:
+                pass
+
+    return mode, resolved_url, key, version
+
+
 def main() -> None:
+    if len(sys.argv) > 1 and sys.argv[1] in ("status", "--status"):
+        mode, url, key, version = _resolve_config()
+        sys.stdout.write(f"mode={mode} url={url} key={key} version={version}\n")
+        sys.exit(0)
+
     try:
         json.load(sys.stdin)  # consume stdin as required by the host
     except Exception:
@@ -88,3 +153,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/integrations/n8n/README.md
+++ b/integrations/n8n/README.md
@@ -16,6 +16,7 @@ This community node lets you:
 
 - [Installation](#installation)
 - [Credentials](#credentials)
+- [Modes](#modes)
 - [Operations](#operations)
 - [Usage examples](#usage-examples)
 - [Compatibility](#compatibility)
@@ -47,6 +48,57 @@ Create credentials of type `Cognee API` in n8n. The node uses these values to au
 
 - **Base URL**: The base URL of your Cognee Cloud tenant, e.g. `https://tenant-xxx.aws.cognee.ai`. Do not include a trailing `/api` — the node appends it automatically.
 - **API Key**: Your Cognee API key, sent via the `X-Api-Key` header.
+
+## Modes
+
+The provider connects to cognee in one of three modes. It picks the mode
+automatically from your config:
+
+| Mode | When it's used | How it talks to cognee |
+| --- | --- | --- |
+| **local-server** (default) | no `COGNEE_BASE_URL`, `COGNEE_EMBEDDED` unset | ensures a local cognee server is running and connects as a thin client |
+| **remote** | `COGNEE_BASE_URL` is set | thin client to your managed / cloud cognee |
+| **embedded** | `COGNEE_EMBEDDED=true` | runs cognee in-process |
+
+**Why local-server is the default.** cognee's local stores (SQLite, Kuzu/Ladybug,
+LanceDB) are single-writer. Driving them in-process from the agent's background
+threads — or from a second n8n process sharing the same `data_root` — risks
+`database is locked` errors and corruption. A local cognee server is the single
+owner that serializes all access, so the agent just makes HTTP calls. This is the
+same design the Claude Code and Codex plugins use. **`embedded` is opt-in and is
+safe for single-process / offline use only.**
+
+**No silent fallbacks.** The provider never downgrades modes behind your back. If
+`COGNEE_BASE_URL` is set but unreachable, or the local server fails to start,
+initialization raises rather than quietly switching to a different mode — silent
+fallback would either mask a config error (remote → local data divergence) or
+reintroduce the very DB-lock risk this design removes (local-server → embedded).
+To accept the single-process trade-off, set `COGNEE_EMBEDDED=true` explicitly.
+
+local-server mode (default — just set your LLM creds):
+
+```bash
+LLM_API_KEY=sk-...
+LLM_MODEL=gpt-4o-mini
+COGNEE_DATASET=support_docs
+# COGNEE_LOCAL_PORT=8000   # optional; point at a shared server for a unified brain
+```
+
+Remote / cloud mode:
+
+```bash
+COGNEE_BASE_URL=https://your-cognee-service.example   # canonical name
+COGNEE_API_KEY=...
+COGNEE_DATASET=support_docs
+```
+
+Embedded (in-process) mode — single-process / offline only:
+
+```bash
+COGNEE_EMBEDDED=true
+LLM_API_KEY=sk-...
+COGNEE_DATASET=support_docs
+```
 
 ## Operations
 

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -80,32 +80,56 @@ plugins:
 
 > `hooks.allowConversationAccess` -> OpenClaw ≥ 2026.4.27 blocks non-bundled plugins from registering the `agent_end` hook unless this flag is set. Without it, file sync memory operations after each agent turn is silently disabled. The gateway still loads the plugin, but file changes the agent makes won't reach Cognee until the next manual `openclaw cognee index` or gateway start. Restart the gateway after adding the flag: `openclaw gateway stop && openclaw gateway start`.
 
-### Cognee Cloud
+### Modes
 
-To use Cognee Cloud instead of a local instance, set `mode` to `"cloud"`:
+The provider connects to cognee in one of three modes. It picks the mode
+automatically from your config:
 
-```yaml
-plugins:
-  entries:
-    cognee-openclaw:
-      enabled: true
-      config:
-        mode: "cloud"
-        baseUrl: "https://tenant-xxx.cloud.cognee.ai/api"
-        apiKey: "${COGNEE_API_KEY}"
-```
+| Mode | When it's used | How it talks to cognee |
+| --- | --- | --- |
+| **local-server** (default) | no `COGNEE_BASE_URL`, `COGNEE_EMBEDDED` unset | ensures a local cognee server is running and connects as a thin client |
+| **remote** | `COGNEE_BASE_URL` is set | thin client to your managed / cloud cognee |
+| **embedded** | `COGNEE_EMBEDDED=true` | runs cognee in-process |
 
-Or via environment variables:
+**Why local-server is the default.** cognee's local stores (SQLite, Kuzu/Ladybug,
+LanceDB) are single-writer. Driving them in-process from the agent's background
+threads — or from a second OpenClaw process sharing the same `data_root` — risks
+`database is locked` errors and corruption. A local cognee server is the single
+owner that serializes all access, so the agent just makes HTTP calls. This is the
+same design the Claude Code and Codex plugins use. **`embedded` is opt-in and is
+safe for single-process / offline use only.**
+
+**No silent fallbacks.** The provider never downgrades modes behind your back. If
+`COGNEE_BASE_URL` is set but unreachable, or the local server fails to start,
+initialization raises rather than quietly switching to a different mode — silent
+fallback would either mask a config error (remote → local data divergence) or
+reintroduce the very DB-lock risk this design removes (local-server → embedded).
+To accept the single-process trade-off, set `COGNEE_EMBEDDED=true` explicitly.
+
+local-server mode (default — just set your LLM creds):
 
 ```bash
-export COGNEE_MODE=cloud
-export COGNEE_BASE_URL=https://tenant-xxx.cloud.cognee.ai/api
-export COGNEE_API_KEY=your-api-key
+LLM_API_KEY=sk-...
+LLM_MODEL=gpt-4o-mini
+COGNEE_DATASET=my-project
+# COGNEE_LOCAL_PORT=8000   # optional; point at a shared server for a unified brain
 ```
 
-**Cloud mode supported operations**: `remember` (new files), `recall`, per-item `forget`. The `/remember` and `/recall` endpoints are verified against self-hosted Cognee 1.0.3; cloud parity for these specific routes has not been validated yet — file an issue if you hit a 404.
+Remote / cloud mode:
 
-**Known limitation**: Updating existing data (modifying a previously synced file) is not supported in cloud mode — `PATCH /update` is self-hosted only. In cloud mode the plugin's update path is a no-op; to edit a single file in place, delete it and re-add it via the [Cognee Cloud platform](https://platform.cognee.ai) or the API directly.
+```bash
+COGNEE_BASE_URL=https://your-cognee-service.example   # canonical name
+COGNEE_API_KEY=...
+COGNEE_DATASET=my-project
+```
+
+Embedded (in-process) mode — single-process / offline only:
+
+```bash
+COGNEE_EMBEDDED=true
+LLM_API_KEY=sk-...
+COGNEE_DATASET=my-project
+```
 
 ## Multi-Scope Memory
 


### PR DESCRIPTION
## Summary

Implements a compact status one-liner for the cognee plugin in both Claude Code and Codex integrations.

## Changes

- Forward CLI arguments from `cognee-statusline.sh` to the Python renderer.
- Add `status` / `--status` handling in `cognee_statusline_render.py`.
- Print:
  - `mode=...`
  - `url=...`
  - `key=...`
  - `version=...`
- Preserve existing statusline behavior when invoked normally.

Closes #3552