### PR TITLE
feat(integrations): add COGNEE_REMEMBER_TIMEOUT / COGNEE_REGISTER_TIMEOUT env vars

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -291,3 +291,6 @@ Config precedence:
 | idle watcher poll | `COGNEE_IDLE_POLL` | `10` | Idle watcher poll interval in seconds |
 | idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle sync fires |
 | idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `120` | Minimum seconds between idle sync runs |
+| recall timeout | `COGNEE_RECALL_TIMEOUT` | `20` | Per-request timeout (seconds) for recall/search |
+| remember timeout | `COGNEE_REMEMBER_TIMEOUT` | `30` | Per-request timeout (seconds) for remember (write), tunable independently of recall |
+| register timeout | `COGNEE_REGISTER_TIMEOUT` | `15` | Per-request timeout (seconds) for agent-session register |

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1133,15 +1133,21 @@ def remember_entry_via_http(
     session_id: str,
     entry: dict,
     *,
-    timeout: float = 30.0,
+    timeout: float | None = None,
 ) -> dict | None:
     """Store a typed QA/trace entry through the backend API.
 
     API-mode hooks use this instead of importing Cognee's Python client,
     so they don't initialize local databases while talking to a backend.
+
+    The request timeout defaults to the per-operation ``COGNEE_REMEMBER_TIMEOUT``
+    env var (seconds, default 30), tunable independently of recall/register; an
+    explicit ``timeout`` argument still overrides it.
     """
     if not dataset or not session_id:
         return None
+    if timeout is None:
+        timeout = _float_env("COGNEE_REMEMBER_TIMEOUT", 30.0)
     return _json_http_request(
         "/api/v1/remember/entry",
         {
@@ -1158,8 +1164,10 @@ def register_agent_via_http(
     agent_session_name: str,
     session_id: str = "",
     dataset_names: list[str] | None = None,
-    timeout: float = 15.0,
+    timeout: float | None = None,
 ) -> tuple[bool, dict]:
+    if timeout is None:
+        timeout = _float_env("COGNEE_REGISTER_TIMEOUT", 15.0)
     payload = {
         "agent_session_name": agent_session_name,
         "type": "api",

--- a/integrations/claude-code/scripts/_remember_http.py
+++ b/integrations/claude-code/scripts/_remember_http.py
@@ -175,9 +175,16 @@ def do_remember(
     node_set,
     *,
     opener=urllib.request.urlopen,
-    timeout=60.0,
+    timeout=None,
 ):
-    """POST content to the server. Return {"ok": true}, an error envelope, or UNREACHABLE."""
+    """POST content to the server. Return {"ok": true}, an error envelope, or UNREACHABLE.
+
+    The request timeout defaults to ``COGNEE_REMEMBER_TIMEOUT`` (seconds), falling
+    back to 60s, so slow cognify writes can be tuned independently of recall. An
+    explicit ``timeout`` argument still wins.
+    """
+    if timeout is None:
+        timeout = _float_env("COGNEE_REMEMBER_TIMEOUT", 60.0)
     url = service_url.rstrip("/") + "/api/v1/remember"
     filename = f"{node_set or 'content'}.txt"
     body, boundary = _multipart_body(

--- a/integrations/claude-code/tests/test_timeout_env.py
+++ b/integrations/claude-code/tests/test_timeout_env.py
@@ -1,9 +1,13 @@
-"""Unit tests for per-operation timeout env vars in _plugin_common.py.
+"""Unit tests for per-operation timeout env vars.
 
 remember/register each read their own timeout env var
 (`COGNEE_REMEMBER_TIMEOUT` / `COGNEE_REGISTER_TIMEOUT`) with a sane default,
 tunable independently of recall. An explicit ``timeout`` argument still wins,
 and a malformed env value falls back to the default.
+
+`COGNEE_REMEMBER_TIMEOUT` covers BOTH remember paths: the cached-entry write in
+`_plugin_common.remember_entry_via_http` (default 30s) and the server POST in
+`_remember_http.do_remember` (default 60s, preserving prior behavior).
 
 Run: `pytest integrations/claude-code/tests/test_timeout_env.py`
 (or `python integrations/claude-code/tests/test_timeout_env.py` standalone).
@@ -12,10 +16,12 @@ Run: `pytest integrations/claude-code/tests/test_timeout_env.py`
 import os
 import pathlib
 import sys
+import urllib.error
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
 
 import _plugin_common as pc  # noqa: E402
+import _remember_http as rh  # noqa: E402
 
 
 def _capture_timeout():
@@ -91,8 +97,57 @@ def test_register_explicit_arg_overrides_env():
     assert cap["timeout"] == 42.0
 
 
+# --- remember (server POST path: _remember_http.do_remember) ----------------
+# The actual /api/v1/remember write. Historically hardcoded to 60s; now honors
+# COGNEE_REMEMBER_TIMEOUT while preserving the 60s default when unset.
+def _capture_do_remember_timeout():
+    """A fake opener that records the timeout, then bails so do_remember returns."""
+    captured = {}
+
+    def fake_opener(req, timeout=None):
+        captured["timeout"] = timeout
+        raise urllib.error.URLError("stop-after-capture")
+
+    return captured, fake_opener
+
+
+def _run_do_remember(opener, **kw):
+    return rh.do_remember("http://x", "", "content", "ds", "ns", opener=opener, **kw)
+
+
+def test_do_remember_default_timeout():
+    _clear_env()
+    cap, opener = _capture_do_remember_timeout()
+    _run_do_remember(opener)
+    assert cap["timeout"] == 60.0
+
+
+def test_do_remember_env_timeout():
+    _clear_env()
+    os.environ["COGNEE_REMEMBER_TIMEOUT"] = "12.5"
+    cap, opener = _capture_do_remember_timeout()
+    _run_do_remember(opener)
+    assert cap["timeout"] == 12.5
+
+
+def test_do_remember_explicit_arg_overrides_env():
+    _clear_env()
+    os.environ["COGNEE_REMEMBER_TIMEOUT"] = "12.5"
+    cap, opener = _capture_do_remember_timeout()
+    _run_do_remember(opener, timeout=88.0)
+    assert cap["timeout"] == 88.0
+
+
+def test_do_remember_malformed_env_falls_back():
+    _clear_env()
+    os.environ["COGNEE_REMEMBER_TIMEOUT"] = "not-a-number"
+    cap, opener = _capture_do_remember_timeout()
+    _run_do_remember(opener)
+    assert cap["timeout"] == 60.0
+
+
 # Recall keeps its own independent env var (COGNEE_RECALL_TIMEOUT, in
-# _cognee_client.py) — unaffected by the two added above.
+# _cognee_client.py) — unaffected by the vars added above.
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/tests/test_timeout_env.py
+++ b/integrations/claude-code/tests/test_timeout_env.py
@@ -1,0 +1,111 @@
+"""Unit tests for per-operation timeout env vars in _plugin_common.py.
+
+remember/register each read their own timeout env var
+(`COGNEE_REMEMBER_TIMEOUT` / `COGNEE_REGISTER_TIMEOUT`) with a sane default,
+tunable independently of recall. An explicit ``timeout`` argument still wins,
+and a malformed env value falls back to the default.
+
+Run: `pytest integrations/claude-code/tests/test_timeout_env.py`
+(or `python integrations/claude-code/tests/test_timeout_env.py` standalone).
+"""
+
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+
+def _capture_timeout():
+    """Patch the HTTP layer to record the timeout it is called with."""
+    captured = {}
+
+    def fake(path, payload=None, *, method="POST", timeout=None):
+        captured["timeout"] = timeout
+        return {}
+
+    pc._json_http_request = fake
+    return captured
+
+
+def _clear_env():
+    for k in ("COGNEE_REMEMBER_TIMEOUT", "COGNEE_REGISTER_TIMEOUT"):
+        os.environ.pop(k, None)
+
+
+# --- remember ---------------------------------------------------------------
+def test_remember_default_timeout():
+    _clear_env()
+    cap = _capture_timeout()
+    pc.remember_entry_via_http("ds", "sid", {"x": 1})
+    assert cap["timeout"] == 30.0
+
+
+def test_remember_env_timeout():
+    _clear_env()
+    os.environ["COGNEE_REMEMBER_TIMEOUT"] = "7.5"
+    cap = _capture_timeout()
+    pc.remember_entry_via_http("ds", "sid", {"x": 1})
+    assert cap["timeout"] == 7.5
+
+
+def test_remember_explicit_arg_overrides_env():
+    _clear_env()
+    os.environ["COGNEE_REMEMBER_TIMEOUT"] = "7.5"
+    cap = _capture_timeout()
+    pc.remember_entry_via_http("ds", "sid", {"x": 1}, timeout=99.0)
+    assert cap["timeout"] == 99.0
+
+
+def test_remember_malformed_env_falls_back():
+    _clear_env()
+    os.environ["COGNEE_REMEMBER_TIMEOUT"] = "not-a-number"
+    cap = _capture_timeout()
+    pc.remember_entry_via_http("ds", "sid", {"x": 1})
+    assert cap["timeout"] == 30.0
+
+
+# --- register ---------------------------------------------------------------
+def test_register_default_timeout():
+    _clear_env()
+    cap = _capture_timeout()
+    pc.register_agent_via_http(agent_session_name="agent")
+    assert cap["timeout"] == 15.0
+
+
+def test_register_env_timeout():
+    _clear_env()
+    os.environ["COGNEE_REGISTER_TIMEOUT"] = "3"
+    cap = _capture_timeout()
+    pc.register_agent_via_http(agent_session_name="agent")
+    assert cap["timeout"] == 3.0
+
+
+def test_register_explicit_arg_overrides_env():
+    _clear_env()
+    os.environ["COGNEE_REGISTER_TIMEOUT"] = "3"
+    cap = _capture_timeout()
+    pc.register_agent_via_http(agent_session_name="agent", timeout=42.0)
+    assert cap["timeout"] == 42.0
+
+
+# Recall keeps its own independent env var (COGNEE_RECALL_TIMEOUT, in
+# _cognee_client.py) — unaffected by the two added above.
+
+
+if __name__ == "__main__":
+    import traceback
+
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failures = 0
+    for fn in tests:
+        try:
+            fn()
+            print(f"PASS  {fn.__name__}")
+        except Exception:  # noqa: BLE001
+            failures += 1
+            print(f"FAIL  {fn.__name__}")
+            traceback.print_exc()
+    raise SystemExit(1 if failures else 0)

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -212,6 +212,9 @@ Config precedence:
 | idle watcher poll | `COGNEE_IDLE_POLL` | `10` | Idle watcher poll interval in seconds |
 | idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle sync fires |
 | idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `120` | Minimum seconds between idle sync runs |
+| recall timeout | `COGNEE_RECALL_TIMEOUT` | `20` | Per-request timeout (seconds) for recall/search |
+| remember timeout | `COGNEE_REMEMBER_TIMEOUT` | `30` | Per-request timeout (seconds) for remember (write), tunable independently of recall |
+| register timeout | `COGNEE_REGISTER_TIMEOUT` | `15` | Per-request timeout (seconds) for agent-session register |
 
 ## Troubleshooting
 

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -1036,20 +1036,35 @@ def _json_http_request(
         return json.loads(body)
 
 
+def _float_env(name: str, default: float) -> float:
+    """Read a float from the environment, falling back to default on absence/parse error."""
+    try:
+        raw = os.environ.get(name, "").strip()
+        return float(raw) if raw else default
+    except (TypeError, ValueError):
+        return default
+
+
 def remember_entry_via_http(
     dataset: str,
     session_id: str,
     entry: dict,
     *,
-    timeout: float = 30.0,
+    timeout: float | None = None,
 ) -> dict | None:
     """Store a typed QA/trace entry through the backend API.
 
     API-mode hooks use this instead of importing Cognee's Python client,
     so they don't initialize local databases while talking to a backend.
+
+    The request timeout defaults to the per-operation ``COGNEE_REMEMBER_TIMEOUT``
+    env var (seconds, default 30), tunable independently of recall/register; an
+    explicit ``timeout`` argument still overrides it.
     """
     if not dataset or not session_id:
         return None
+    if timeout is None:
+        timeout = _float_env("COGNEE_REMEMBER_TIMEOUT", 30.0)
     return _json_http_request(
         "/api/v1/remember/entry",
         {
@@ -1066,8 +1081,10 @@ def register_agent_via_http(
     agent_session_name: str,
     session_id: str = "",
     dataset_names: list[str] | None = None,
-    timeout: float = 15.0,
+    timeout: float | None = None,
 ) -> tuple[bool, dict]:
+    if timeout is None:
+        timeout = _float_env("COGNEE_REGISTER_TIMEOUT", 15.0)
     payload = {
         "agent_session_name": agent_session_name,
         "type": "api",

--- a/integrations/codex/plugins/cognee/scripts/_remember_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_remember_http.py
@@ -92,6 +92,15 @@ def _timeout_result(timeout):
     return _error(0, "remember submitted; timed out after %ss waiting for confirmation" % timeout)
 
 
+def _float_env(name, default):
+    """Read a float from the environment, falling back to default on absence/parse error."""
+    try:
+        raw = os.environ.get(name, "").strip()
+        return float(raw) if raw else default
+    except (TypeError, ValueError):
+        return default
+
+
 def do_remember(
     service_url,
     api_key,
@@ -100,9 +109,16 @@ def do_remember(
     node_set,
     *,
     opener=urllib.request.urlopen,
-    timeout=60.0,
+    timeout=None,
 ):
-    """POST content to the server. Return {"ok": true}, an error envelope, or UNREACHABLE."""
+    """POST content to the server. Return {"ok": true}, an error envelope, or UNREACHABLE.
+
+    The request timeout defaults to ``COGNEE_REMEMBER_TIMEOUT`` (seconds), falling
+    back to 60s, so slow cognify writes can be tuned independently of recall. An
+    explicit ``timeout`` argument still wins.
+    """
+    if timeout is None:
+        timeout = _float_env("COGNEE_REMEMBER_TIMEOUT", 60.0)
     url = service_url.rstrip("/") + "/api/v1/remember"
     filename = f"{node_set or 'content'}.txt"
     body, boundary = _multipart_body(


### PR DESCRIPTION
## What

Only `COGNEE_RECALL_TIMEOUT` existed today. This adds named per-operation timeouts `COGNEE_REMEMBER_TIMEOUT` and `COGNEE_REGISTER_TIMEOUT`, so remember/register can be tuned independently of recall.

## Changes

- `remember_entry_via_http` reads `COGNEE_REMEMBER_TIMEOUT` (default `30`)
- `register_agent_via_http` reads `COGNEE_REGISTER_TIMEOUT` (default `15`)
- An explicit `timeout=` argument still overrides the env var; a malformed value falls back to the default
- Applied to both the `claude-code` and `codex` integrations (added the small `_float_env` helper to codex, which lacked it)
- Documented all three timeout vars (`RECALL` / `REMEMBER` / `REGISTER`) in both integration READMEs
- Added `integrations/claude-code/tests/test_timeout_env.py` (7 tests, all passing); existing suite still green

## Done when (from the issue)

- [x] Each op reads its **own** timeout env var with a sane default, falling back sensibly if unset
- [x] All three timeout vars are documented in the integration README

Resolves topoteretes/cognee#3543
