### PR TITLE
feat(claude-code): add elapsed_ms timing to recall / bridge / improve hook events

### DIFF
--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -524,6 +524,15 @@ async def resolve_user(user_id: str):
     return await get_default_user()
 
 
+def _elapsed_ms(start: float) -> int:
+    """Whole milliseconds elapsed since a ``time.monotonic()`` reference.
+
+    Floored at 0 so a non-monotonic clock reading can never yield a negative
+    duration in a ``hook_log`` ``elapsed_ms`` field.
+    """
+    return max(0, int((time.monotonic() - start) * 1000))
+
+
 def hook_log(event: str, detail: Optional[dict] = None) -> None:
     """Append one structured line to ~/.cognee-plugin/hook.log.
 
@@ -1422,6 +1431,7 @@ def persist_session_cache_to_graph_via_http(
             if time.monotonic() - overall_start >= poll_deadline:
                 hook_log("http_bridge_deadline_exceeded", {"dataset": dataset, "kind": kind})
                 break
+            doc_started = time.monotonic()
             submitted = _post_remember_document(
                 base_url, api_key, dataset, document, node_set, submit_timeout
             )
@@ -1465,7 +1475,13 @@ def persist_session_cache_to_graph_via_http(
                 wrote = True
             hook_log(
                 "http_bridge_poll",
-                {"dataset": dataset, "kind": kind, "outcome": outcome, "dataset_id": dataset_id},
+                {
+                    "dataset": dataset,
+                    "kind": kind,
+                    "outcome": outcome,
+                    "dataset_id": dataset_id,
+                    "elapsed_ms": _elapsed_ms(doc_started),
+                },
             )
         if isinstance(bridge_cache, dict):
             bridge_cache["_state"] = state

--- a/integrations/claude-code/scripts/idle-watcher.py
+++ b/integrations/claude-code/scripts/idle-watcher.py
@@ -87,6 +87,7 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
     sys.path.insert(0, os.path.dirname(__file__))
     try:
         from _plugin_common import (  # type: ignore
+            _elapsed_ms,
             http_api_ready,
             load_resolved,
             persist_session_cache_to_graph_via_http,
@@ -120,6 +121,7 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
             )
 
             if api_mode:
+                started = time.monotonic()
                 wrote = persist_session_cache_to_graph_via_http(dataset, session_id)
                 _log(
                     "session_bridge_done",
@@ -127,6 +129,7 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
                     dataset=dataset,
                     via="http_remember",
                     wrote=wrote,
+                    elapsed_ms=_elapsed_ms(started),
                 )
                 return True
 

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -20,6 +20,7 @@ import time
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
+    _elapsed_ms,
     get_session_key,
     hook_log,
     load_resolved,
@@ -215,7 +216,8 @@ async def _run(prompt: str) -> dict | None:
     # never be the long pole. Each scope gets a short per-call timeout, and the
     # whole loop stops once the overall budget is spent. Partial results are fine.
     recall_timeout = _float_env("COGNEE_RECALL_TIMEOUT", 2.5)
-    budget_deadline = time.monotonic() + _float_env("COGNEE_RECALL_BUDGET", 4.0)
+    recall_started = time.monotonic()
+    budget_deadline = recall_started + _float_env("COGNEE_RECALL_BUDGET", 4.0)
     # Respect the shared circuit breaker: when the server has been failing (tripped
     # by the explicit recall path), skip this per-prompt recall rather than hammering
     # a down backend on every keystroke. HTTP/cloud mode only.
@@ -363,11 +365,21 @@ async def _run(prompt: str) -> dict | None:
             f"{header}\n\nRelevant context from this session's memory:\n\n"
             + "\n".join(section_lines).strip()
         )
-        hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
+        hook_log(
+            "context_lookup_hit",
+            {
+                "counts": counts,
+                "saves_last_turn": saves_last_turn,
+                "elapsed_ms": _elapsed_ms(recall_started),
+            },
+        )
         notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
     else:
         full_context = f"{header}\n\n(no memory matches for this prompt)"
-        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
+        hook_log(
+            "context_lookup_empty",
+            {"saves_last_turn": saves_last_turn, "elapsed_ms": _elapsed_ms(recall_started)},
+        )
         notify(f"no recall matches; saves last turn {saves_last_turn}")
 
     # Audit log: persist full recall details per turn. The hook output stays a

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -16,10 +16,12 @@ import asyncio
 import json
 import os
 import sys
+import time
 
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
+    _elapsed_ms,
     append_http_bridge_entry,
     bump_save_counter,
     bump_turn_counter,
@@ -57,12 +59,19 @@ _MAX_ASSISTANT_BYTES = 8000
 
 async def _fire_improve_background(dataset: str, session_id: str, user, reason: str) -> None:
     """Fire-and-forget session bridge; failures are logged but never raised."""
+    started = time.monotonic()
     try:
         if http_api_ready():
             wrote = persist_session_cache_to_graph_via_http(dataset, session_id)
             hook_log(
                 "auto_bridge_fired",
-                {"reason": reason, "session": session_id, "via": "http_remember", "wrote": wrote},
+                {
+                    "reason": reason,
+                    "session": session_id,
+                    "via": "http_remember",
+                    "wrote": wrote,
+                    "elapsed_ms": _elapsed_ms(started),
+                },
             )
             if wrote:
                 notify(f"session bridge persisted ({reason})")
@@ -78,6 +87,7 @@ async def _fire_improve_background(dataset: str, session_id: str, user, reason: 
                 "session": session_id,
                 "wrote": wrote,
                 "graph_synced": graph_result.get("synced", 0),
+                "elapsed_ms": _elapsed_ms(started),
             },
         )
         notify(f"session bridge persisted ({reason})")

--- a/integrations/claude-code/tests/test_elapsed_ms.py
+++ b/integrations/claude-code/tests/test_elapsed_ms.py
@@ -1,0 +1,103 @@
+"""Unit tests for elapsed_ms timing on hook events (_plugin_common._elapsed_ms).
+
+Covers the helper itself (deterministic via a patched monotonic clock) and the
+bridge poll path, asserting `http_bridge_poll` carries an integer `elapsed_ms`
+with no behavior change to the dedup/poll contract.
+
+Run: python integrations/claude-code/tests/test_elapsed_ms.py (or via pytest).
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+
+def _patch_monotonic(values):
+    """Replace pc.time.monotonic with a generator over `values`; returns a restore()."""
+    seq = iter(values)
+    orig = pc.time.monotonic
+    pc.time.monotonic = lambda: next(seq)
+    return lambda: setattr(pc.time, "monotonic", orig)
+
+
+# --- _elapsed_ms helper -----------------------------------------------------
+def test_elapsed_ms_basic():
+    restore = _patch_monotonic([100.0, 100.25])  # start, then measured end (+250ms)
+    try:
+        start = pc.time.monotonic()
+        assert pc._elapsed_ms(start) == 250
+    finally:
+        restore()
+
+
+def test_elapsed_ms_floors_at_zero():
+    # A non-monotonic reading (clock goes backwards) must never produce a negative.
+    restore = _patch_monotonic([100.0, 99.0])
+    try:
+        start = pc.time.monotonic()
+        assert pc._elapsed_ms(start) == 0
+    finally:
+        restore()
+
+
+def test_elapsed_ms_returns_int():
+    start = pc.time.monotonic()
+    out = pc._elapsed_ms(start)
+    assert isinstance(out, int)
+    assert out >= 0
+
+
+# --- bridge poll carries elapsed_ms -----------------------------------------
+def test_http_bridge_poll_logs_elapsed_ms():
+    logs = []
+    seams = (
+        "_local_api_url",
+        "_backend_reachable",
+        "_api_key",
+        "_format_cached_bridge_document",
+        "_bridge_file",
+        "_load_json_file",
+        "_write_json_file",
+        "_post_remember_document",
+        "wait_for_cognify",
+        "hook_log",
+    )
+    saved = {k: getattr(pc, k) for k in seams}
+
+    pc._local_api_url = lambda: "http://x"
+    pc._backend_reachable = lambda url: True
+    pc._api_key = lambda: "k"
+    pc._format_cached_bridge_document = lambda dataset, sid: ("qa text", "")
+    pc._bridge_file = lambda sid: pathlib.Path("/tmp/_elapsed_bridge_test.json")
+    pc._load_json_file = lambda p: {}
+    pc._write_json_file = lambda p, data: None
+    pc._post_remember_document = lambda *a, **k: {"ok": True, "dataset_id": "d1"}
+    pc.wait_for_cognify = lambda *a, **k: "completed"
+    pc.hook_log = lambda event, detail=None: logs.append((event, detail))
+    try:
+        pc.persist_session_cache_to_graph_via_http("ds", "sid")
+    finally:
+        for k, v in saved.items():
+            setattr(pc, k, v)
+
+    polls = [detail for event, detail in logs if event == "http_bridge_poll"]
+    assert polls, "expected an http_bridge_poll event"
+    assert "elapsed_ms" in polls[0]
+    assert isinstance(polls[0]["elapsed_ms"], int)
+    assert polls[0]["elapsed_ms"] >= 0
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
WhatHook events logged outcomes but no timing, so we couldn't see recall / bridge / improve latency from `hook.log`. This adds an `elapsed_ms` field to those events.## Changes- New `_elapsed_ms(start)` helper in `_plugin_common.py` — whole milliseconds since a `time.monotonic()` reference, floored at 0 so a non-monotonic reading can't emit a negative duration.- Stamp `elapsed_ms` onto:  - `context_lookup_hit` / `context_lookup_empty` — recall (`session-context-lookup.py`)  - `http_bridge_poll` — bridge POST + `wait_for_cognify` poll, timed per document (`_plugin_common.py`)  - `auto_bridge_fired` / `session_bridge_done` — improve (`store-to-session.py`, `idle-watcher.py`)## Acceptance- `hook.log` `context_lookup_hit` and `http_bridge_poll` now carry `elapsed_ms`.- Pure observability: no control-flow or output change.## Tests- `tests/test_elapsed_ms.py`: deterministic unit tests for `_elapsed_ms` (basic, zero-floor, int type) via a patched monotonic clock, plus an assertion that `http_bridge_poll` emits an integer `elapsed_ms`.- Existing `tests/test_bridge_poll.py` and the full `tests/` suite pass unchanged.Resolves #135