### PR TITLE
feat(openclaw): circuit breaker + configurable per-op timeouts in the TS client

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -258,6 +258,17 @@ This lets the agent distinguish between personal context, shared knowledge, and 
 |--------|------|---------|-------------|
 | `requestTimeoutMs` | number | `60000` | HTTP timeout for Cognee requests |
 | `ingestionTimeoutMs` | number | `300000` | HTTP timeout for add/update requests |
+| `recallTimeoutMs` | number | `requestTimeoutMs` | HTTP timeout for read requests (search/recall) |
+
+### Circuit breaker
+
+Repeated backend failures trip an in-memory circuit breaker so a down Cognee server isn't hammered on every call. Only genuine backend trouble counts: unreachable responses (connection failure / timeout) and 5xx. Auth failures (401/403) are surfaced but never trip the breaker, since waiting wouldn't fix a config problem. While open, calls fail fast until the cooldown elapses.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `breakerEnabled` | boolean | `true` | Enable the circuit breaker |
+| `breakerThreshold` | number | `5` | Consecutive unreachable/5xx failures before the breaker opens |
+| `breakerCooldownMs` | number | `120000` | How long the breaker stays open before allowing a retry |
 
 Note: Files are stored in Cognee using sanitized relative paths as filenames (e.g., `MEMORY.md.txt` for `MEMORY.md`, `memory.tools.md.txt` for `memory/tools.md`) for easy identification and to avoid path separator issues.
 

--- a/integrations/openclaw/__tests__/test_circuitBreaker.ts
+++ b/integrations/openclaw/__tests__/test_circuitBreaker.ts
@@ -155,6 +155,30 @@ describe("circuit breaker", () => {
     expect(mockFetch).toHaveBeenCalledTimes(THRESHOLD + 1);
   });
 
+  it("does not reopen immediately when the post-cooldown probe fails", async () => {
+    // Mirrors the Python reference (_is_breaker_open): the half-open transition
+    // resets the counter, so a failing probe starts a fresh streak rather than
+    // reopening after a single failure.
+    const client = makeClient();
+    let now = 10_000;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+    mockFetch.mockRejectedValue(new TypeError("unreachable"));
+
+    for (let i = 0; i < THRESHOLD; i++) {
+      await expect(call(client)).rejects.toThrow();
+    }
+    await expect(call(client)).rejects.toThrow(/circuit open/);
+    expect(mockFetch).toHaveBeenCalledTimes(THRESHOLD);
+
+    // Cooldown elapses → the probe and the call after it both reach the server
+    // (counter reset to 0, then 1 — still below the threshold).
+    now += COOLDOWN_MS + 1;
+    await expect(call(client)).rejects.toThrow(/unreachable/);
+    expect(mockFetch).toHaveBeenCalledTimes(THRESHOLD + 1);
+    await expect(call(client)).rejects.toThrow(/unreachable/);
+    expect(mockFetch).toHaveBeenCalledTimes(THRESHOLD + 2);
+  });
+
   it("stays closed when disabled", async () => {
     const client = makeClient({ breakerEnabled: false });
     mockFetch.mockRejectedValue(new TypeError("unreachable"));

--- a/integrations/openclaw/__tests__/test_circuitBreaker.ts
+++ b/integrations/openclaw/__tests__/test_circuitBreaker.ts
@@ -1,0 +1,206 @@
+import { CogneeHttpClient } from "../src/client";
+
+// ---------------------------------------------------------------------------
+// Circuit breaker + per-op timeout tests.
+//
+// The breaker is exercised through the public fetchAPI transport (the single
+// chokepoint every operation flows through). Only genuine backend trouble
+// trips it: UNREACHABLE (connection failure / timeout) or a 5xx. A reachable
+// 4xx (401/403) is surfaced but must never trip.
+// ---------------------------------------------------------------------------
+
+const THRESHOLD = 3;
+const COOLDOWN_MS = 1_000;
+
+let mockFetch: jest.Mock;
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  mockFetch = jest.fn();
+  (globalThis as unknown as { fetch: unknown }).fetch = mockFetch;
+});
+
+afterEach(() => {
+  (globalThis as unknown as { fetch: unknown }).fetch = originalFetch;
+  jest.restoreAllMocks();
+});
+
+// A minimal Response stand-in: the client only reads ok/status and either
+// .json() (2xx) or .text() (non-ok).
+function httpResponse(status: number, body: unknown = {}): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+// Build a client with fast breaker settings and an apiKey so ensureAuth()
+// short-circuits without a login round-trip. Positional args mirror the
+// constructor: baseUrl, apiKey, username, password, requestTimeout,
+// ingestionTimeout, mode, recallTimeout, breakerEnabled, threshold, cooldown.
+function makeClient(overrides: { recallTimeoutMs?: number; breakerEnabled?: boolean } = {}): CogneeHttpClient {
+  return new CogneeHttpClient(
+    "http://test",
+    "key",
+    "",
+    "",
+    60_000,
+    300_000,
+    "local",
+    overrides.recallTimeoutMs ?? 60_000,
+    overrides.breakerEnabled ?? true,
+    THRESHOLD,
+    COOLDOWN_MS,
+  );
+}
+
+// One transport call with retries disabled, so a failure is a single fetch.
+function call(client: CogneeHttpClient, timeoutMs = 60_000): Promise<unknown> {
+  return client.fetchAPI("/api/v1/x", { method: "GET" }, timeoutMs, undefined, 0);
+}
+
+describe("circuit breaker", () => {
+  it("trips after repeated UNREACHABLE responses", async () => {
+    const client = makeClient();
+    mockFetch.mockRejectedValue(new TypeError("connect ECONNREFUSED"));
+
+    for (let i = 0; i < THRESHOLD; i++) {
+      await expect(call(client)).rejects.toThrow(/ECONNREFUSED/);
+    }
+    expect(mockFetch).toHaveBeenCalledTimes(THRESHOLD);
+
+    // Breaker is now open: the next call short-circuits without hitting fetch.
+    await expect(call(client)).rejects.toThrow(/circuit open/);
+    expect(mockFetch).toHaveBeenCalledTimes(THRESHOLD);
+  });
+
+  it("trips after repeated 5xx responses", async () => {
+    const client = makeClient();
+    mockFetch.mockResolvedValue(httpResponse(503, "service unavailable"));
+
+    for (let i = 0; i < THRESHOLD; i++) {
+      await expect(call(client)).rejects.toThrow(/\(503\)/);
+    }
+    expect(mockFetch).toHaveBeenCalledTimes(THRESHOLD);
+
+    await expect(call(client)).rejects.toThrow(/circuit open/);
+    expect(mockFetch).toHaveBeenCalledTimes(THRESHOLD);
+  });
+
+  it("does not trip on 401 auth failures", async () => {
+    const client = makeClient();
+    mockFetch.mockResolvedValue(httpResponse(401, "unauthorized"));
+
+    const attempts = THRESHOLD + 2;
+    for (let i = 0; i < attempts; i++) {
+      await expect(call(client)).rejects.toThrow(/\(401\)/);
+    }
+    // Every attempt reached the server — the breaker never opened.
+    expect(mockFetch).toHaveBeenCalledTimes(attempts);
+  });
+
+  it("does not trip on 403 auth failures", async () => {
+    const client = makeClient();
+    mockFetch.mockResolvedValue(httpResponse(403, "forbidden"));
+
+    const attempts = THRESHOLD + 2;
+    for (let i = 0; i < attempts; i++) {
+      await expect(call(client)).rejects.toThrow(/\(403\)/);
+    }
+    expect(mockFetch).toHaveBeenCalledTimes(attempts);
+  });
+
+  it("resets the failure count after a success", async () => {
+    const client = makeClient();
+    const unreachable = new TypeError("unreachable");
+    mockFetch
+      .mockRejectedValueOnce(unreachable)
+      .mockRejectedValueOnce(unreachable)
+      .mockResolvedValueOnce(httpResponse(200, { ok: true }))
+      .mockRejectedValueOnce(unreachable)
+      .mockRejectedValueOnce(unreachable);
+
+    await expect(call(client)).rejects.toThrow(); // 1 failure
+    await expect(call(client)).rejects.toThrow(); // 2 failures
+    await expect(call(client)).resolves.toEqual({ ok: true }); // reset to 0
+    await expect(call(client)).rejects.toThrow(); // 1 failure
+    await expect(call(client)).rejects.toThrow(); // 2 failures — still below threshold
+
+    // Breaker never opened, so the next call still reaches the server.
+    mockFetch.mockResolvedValueOnce(httpResponse(200, {}));
+    await expect(call(client)).resolves.toEqual({});
+    expect(mockFetch).toHaveBeenCalledTimes(6);
+  });
+
+  it("reopens for a probe after the cooldown elapses", async () => {
+    const client = makeClient();
+    let now = 10_000;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+    mockFetch.mockRejectedValue(new TypeError("unreachable"));
+
+    for (let i = 0; i < THRESHOLD; i++) {
+      await expect(call(client)).rejects.toThrow();
+    }
+    // Open until now + cooldown; a call inside the window short-circuits.
+    await expect(call(client)).rejects.toThrow(/circuit open/);
+    expect(mockFetch).toHaveBeenCalledTimes(THRESHOLD);
+
+    // Advance past the cooldown → half-open: the next call probes the server.
+    now += COOLDOWN_MS + 1;
+    mockFetch.mockResolvedValueOnce(httpResponse(200, {}));
+    await expect(call(client)).resolves.toEqual({});
+    expect(mockFetch).toHaveBeenCalledTimes(THRESHOLD + 1);
+  });
+
+  it("stays closed when disabled", async () => {
+    const client = makeClient({ breakerEnabled: false });
+    mockFetch.mockRejectedValue(new TypeError("unreachable"));
+
+    const attempts = THRESHOLD + 3;
+    for (let i = 0; i < attempts; i++) {
+      await expect(call(client)).rejects.toThrow(/unreachable/);
+    }
+    // No short-circuit — every call hit the server.
+    expect(mockFetch).toHaveBeenCalledTimes(attempts);
+  });
+});
+
+describe("per-op timeout", () => {
+  it("recall forwards the configured recallTimeoutMs to the transport", async () => {
+    // requestTimeoutMs is 60s; recall gets a tighter 5s bound.
+    const client = makeClient({ recallTimeoutMs: 5_000 });
+    const spy = jest.spyOn(client, "fetchAPI").mockResolvedValue([]);
+
+    await client.recall({ queryText: "q", searchPrompt: "", searchType: "GRAPH_COMPLETION", datasetIds: ["d1"] });
+
+    expect(spy).toHaveBeenCalledWith("/api/v1/recall", expect.any(Object), 5_000);
+  });
+
+  it("aborts a request once the per-op timeout elapses", async () => {
+    jest.useFakeTimers();
+    try {
+      const client = makeClient();
+      let signal: AbortSignal | undefined;
+      mockFetch.mockImplementation((_url: string, init: RequestInit) => {
+        signal = init.signal as AbortSignal;
+        return new Promise<Response>((_resolve, reject) => {
+          signal!.addEventListener("abort", () =>
+            reject(new DOMException("The operation was aborted.", "AbortError")));
+        });
+      });
+
+      const pending = call(client, 5_000);
+      await Promise.resolve(); // let fetch get invoked
+      expect(signal!.aborted).toBe(false);
+
+      jest.advanceTimersByTime(5_000);
+      await expect(pending).rejects.toThrow(/aborted/i);
+      expect(signal!.aborted).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/integrations/openclaw/src/client.ts
+++ b/integrations/openclaw/src/client.ts
@@ -57,7 +57,8 @@ export class CogneeHttpClient {
     private readonly timeoutMs: number = DEFAULT_TIMEOUT_MS,
     readonly ingestionTimeoutMs: number = DEFAULT_INGESTION_TIMEOUT_MS,
     readonly mode: CogneeMode = "local",
-    private readonly recallTimeoutMs: number = DEFAULT_TIMEOUT_MS,
+    // Read ops share the request timeout unless a tighter recall bound is given.
+    private readonly recallTimeoutMs: number = timeoutMs,
     private readonly breakerEnabled: boolean = true,
     private readonly breakerThreshold: number = DEFAULT_BREAKER_THRESHOLD,
     private readonly breakerCooldownMs: number = DEFAULT_BREAKER_COOLDOWN_MS,

--- a/integrations/openclaw/src/client.ts
+++ b/integrations/openclaw/src/client.ts
@@ -17,6 +17,21 @@ const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY_MS = 3_000;
 const DEFAULT_TIMEOUT_MS = 60_000;
 const DEFAULT_INGESTION_TIMEOUT_MS = 300_000;
+// Circuit breaker defaults mirror the Python clients (Hermes provider,
+// claude-code recall client): open after 5 consecutive UNREACHABLE / 5xx
+// failures, stay open for 120s.
+const DEFAULT_BREAKER_THRESHOLD = 5;
+const DEFAULT_BREAKER_COOLDOWN_MS = 120_000;
+
+// Thrown for reachable HTTP error responses. Carries the status so the circuit
+// breaker can tell a server-side 5xx (trip-worthy) from a reachable 4xx like
+// 401/403 (a config problem that must NOT trip the breaker).
+class CogneeHttpError extends Error {
+  constructor(readonly status: number, message: string) {
+    super(message);
+    this.name = "CogneeHttpError";
+  }
+}
 
 // ---------------------------------------------------------------------------
 // CogneeHttpClient — shared HTTP transport with auth, retry, timeout
@@ -29,6 +44,11 @@ export class CogneeHttpClient {
   private authToken: string | undefined;
   private loginPromise: Promise<void> | undefined;
 
+  // Circuit breaker state, kept in-memory: this client is long-lived (mirroring
+  // the Hermes provider), unlike the file-based short-lived plugin hooks.
+  private consecutiveFailures = 0;
+  private breakerOpenUntil = 0;
+
   constructor(
     readonly baseUrl: string,
     private readonly apiKey?: string,
@@ -37,6 +57,10 @@ export class CogneeHttpClient {
     private readonly timeoutMs: number = DEFAULT_TIMEOUT_MS,
     readonly ingestionTimeoutMs: number = DEFAULT_INGESTION_TIMEOUT_MS,
     readonly mode: CogneeMode = "local",
+    private readonly recallTimeoutMs: number = DEFAULT_TIMEOUT_MS,
+    private readonly breakerEnabled: boolean = true,
+    private readonly breakerThreshold: number = DEFAULT_BREAKER_THRESHOLD,
+    private readonly breakerCooldownMs: number = DEFAULT_BREAKER_COOLDOWN_MS,
   ) { }
 
   private get isCloud(): boolean {
@@ -108,8 +132,41 @@ export class CogneeHttpClient {
     responseParser: (r: Response) => Promise<T> = async (r: Response) => (await r.json()) as T,
     retries = MAX_RETRIES,
   ): Promise<T> {
+    // Short-circuit while the breaker is open so a down backend isn't hammered.
+    if (this.isBreakerOpen()) {
+      throw new CogneeHttpError(
+        503,
+        `Cognee request failed (503): circuit open, retry in ~${this.breakerRetrySecs()}s`,
+      );
+    }
+
+    // Auth is resolved outside the classified block: a login failure is a
+    // config problem, not a down backend, so it must not count toward the breaker.
     await this.ensureAuth();
 
+    try {
+      const result = await this.fetchWithRetry<T>(path, init, timeoutMs, responseParser, retries);
+      this.recordSuccess();
+      return result;
+    } catch (error) {
+      // UNREACHABLE (connection failure / timeout) and 5xx trip the breaker;
+      // a reachable 4xx (e.g. 401/403 auth) is surfaced but does not.
+      if (this.isTripworthy(error)) {
+        this.recordFailure();
+      } else {
+        this.recordSuccess();
+      }
+      throw error;
+    }
+  }
+
+  private async fetchWithRetry<T>(
+    path: string,
+    init: RequestInit,
+    timeoutMs: number,
+    responseParser: (r: Response) => Promise<T>,
+    retries: number,
+  ): Promise<T> {
     let lastError: unknown;
     for (let attempt = 0; attempt <= retries; attempt++) {
       if (attempt > 0) {
@@ -143,7 +200,7 @@ export class CogneeHttpClient {
             });
             if (!retryResponse.ok) {
               const errorText = await retryResponse.text();
-              throw new Error(`Cognee request failed (${retryResponse.status}): ${errorText}`);
+              throw new CogneeHttpError(retryResponse.status, `Cognee request failed (${retryResponse.status}): ${errorText}`);
             }
             return responseParser(retryResponse);
           } finally {
@@ -153,9 +210,11 @@ export class CogneeHttpClient {
 
         if (!response.ok) {
           const errorText = await response.text();
-          throw new Error(`Cognee request failed (${response.status}): ${errorText}`);
+          throw new CogneeHttpError(response.status, `Cognee request failed (${response.status}): ${errorText}`);
         }
-        return (await response.json()) as T;
+        const data = (await response.json()) as T;
+        clearTimeout(timer);
+        return data;
       } catch (error) {
         clearTimeout(timer);
         const isTimeout =
@@ -169,6 +228,46 @@ export class CogneeHttpClient {
       }
     }
     throw lastError;
+  }
+
+  // -- Circuit breaker ------------------------------------------------------
+  // In-memory, consecutive-failure breaker ported from the Python clients.
+  // Only genuine backend trouble trips it: UNREACHABLE (connection failure /
+  // timeout) or a 5xx. A reachable 4xx (401/403) is surfaced but never trips —
+  // waiting wouldn't fix an auth/config problem.
+
+  private isBreakerOpen(): boolean {
+    if (!this.breakerEnabled) return false;
+    if (this.consecutiveFailures < this.breakerThreshold) return false;
+    // Cooldown elapsed → half-open: reset the counter and allow one probe.
+    if (Date.now() >= this.breakerOpenUntil) {
+      this.consecutiveFailures = 0;
+      return false;
+    }
+    return true;
+  }
+
+  private breakerRetrySecs(): number {
+    return Math.max(0, Math.ceil((this.breakerOpenUntil - Date.now()) / 1000));
+  }
+
+  private recordSuccess(): void {
+    this.consecutiveFailures = 0;
+  }
+
+  private recordFailure(): void {
+    this.consecutiveFailures += 1;
+    if (this.consecutiveFailures >= this.breakerThreshold) {
+      this.breakerOpenUntil = Date.now() + this.breakerCooldownMs;
+    }
+  }
+
+  private isTripworthy(error: unknown): boolean {
+    // Reachable HTTP responses carry a status: only 5xx trips.
+    if (error instanceof CogneeHttpError) return error.status >= 500;
+    // Anything else here is a transport failure (connection refused, DNS, or a
+    // timeout/abort after retries) — i.e. UNREACHABLE — which trips.
+    return true;
   }
 
   // -- Health ---------------------------------------------------------------
@@ -502,7 +601,7 @@ export class CogneeHttpClient {
         ...(params.searchPrompt ? { systemPrompt: params.searchPrompt } : {}),
         ...(params.sessionId ? { session_id: params.sessionId } : {}),
       }),
-    });
+    }, this.recallTimeoutMs);
     return normalizeSearchResults(data);
   }
 
@@ -531,7 +630,7 @@ export class CogneeHttpClient {
         ...(params.sessionId ? { session_id: params.sessionId } : {}),
         ...(params.scope ? { scope: params.scope } : {}),
       }),
-    });
+    }, this.recallTimeoutMs);
     return normalizeSearchResults(data);
   }
 

--- a/integrations/openclaw/src/config.ts
+++ b/integrations/openclaw/src/config.ts
@@ -20,6 +20,13 @@ export const DEFAULT_IMPROVE_ON_SESSION_END = true;
 export const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 export const DEFAULT_INGESTION_TIMEOUT_MS = 300_000;
 
+// Circuit breaker — defaults mirror the Python clients (Hermes provider,
+// claude-code recall client): open after 5 consecutive UNREACHABLE / 5xx
+// failures, stay open for 120s.
+export const DEFAULT_BREAKER_ENABLED = true;
+export const DEFAULT_BREAKER_THRESHOLD = 5;
+export const DEFAULT_BREAKER_COOLDOWN_MS = 120_000;
+
 export const DEFAULT_RECALL_SCOPES: MemoryScope[] = ["agent", "user", "company"];
 export const DEFAULT_WRITE_SCOPE: MemoryScope = "agent";
 export const DEFAULT_SCOPE_ROUTING: ScopeRoute[] = [
@@ -75,6 +82,12 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
   const improveOnSessionEnd = typeof raw.improveOnSessionEnd === "boolean" ? raw.improveOnSessionEnd : DEFAULT_IMPROVE_ON_SESSION_END;
   const requestTimeoutMs = typeof raw.requestTimeoutMs === "number" ? raw.requestTimeoutMs : DEFAULT_REQUEST_TIMEOUT_MS;
   const ingestionTimeoutMs = typeof raw.ingestionTimeoutMs === "number" ? raw.ingestionTimeoutMs : DEFAULT_INGESTION_TIMEOUT_MS;
+  // Read ops share the request timeout unless a tighter recall bound is configured.
+  const recallTimeoutMs = typeof raw.recallTimeoutMs === "number" ? raw.recallTimeoutMs : requestTimeoutMs;
+
+  const breakerEnabled = typeof raw.breakerEnabled === "boolean" ? raw.breakerEnabled : DEFAULT_BREAKER_ENABLED;
+  const breakerThreshold = typeof raw.breakerThreshold === "number" ? raw.breakerThreshold : DEFAULT_BREAKER_THRESHOLD;
+  const breakerCooldownMs = typeof raw.breakerCooldownMs === "number" ? raw.breakerCooldownMs : DEFAULT_BREAKER_COOLDOWN_MS;
 
   const apiKey =
     raw.apiKey && raw.apiKey.length > 0 ? resolveEnvVars(raw.apiKey)
@@ -119,6 +132,7 @@ export function resolveConfig(rawConfig: unknown): Required<CogneePluginConfig> 
     searchType, searchPrompt, deleteMode,
     maxResults, minScore, maxTokens,
     autoRecall, autoIndex, autoCognify, autoMemify, improveOnSessionEnd,
-    requestTimeoutMs, ingestionTimeoutMs,
+    requestTimeoutMs, ingestionTimeoutMs, recallTimeoutMs,
+    breakerEnabled, breakerThreshold, breakerCooldownMs,
   };
 }

--- a/integrations/openclaw/src/plugin.ts
+++ b/integrations/openclaw/src/plugin.ts
@@ -72,7 +72,7 @@ const memoryCogneePlugin = {
       }
     }
 
-    const client = new CogneeHttpClient(cfg.baseUrl, cfg.apiKey, cfg.username, cfg.password, cfg.requestTimeoutMs, cfg.ingestionTimeoutMs, cfg.mode);
+    const client = new CogneeHttpClient(cfg.baseUrl, cfg.apiKey, cfg.username, cfg.password, cfg.requestTimeoutMs, cfg.ingestionTimeoutMs, cfg.mode, cfg.recallTimeoutMs, cfg.breakerEnabled, cfg.breakerThreshold, cfg.breakerCooldownMs);
     const multiScope = isMultiScopeEnabled(cfg);
 
     (api as MemoryFlushPlanRegistrant).registerMemoryFlushPlan?.(buildMemoryFlushPlan);

--- a/integrations/openclaw/src/types.ts
+++ b/integrations/openclaw/src/types.ts
@@ -101,6 +101,17 @@ export type CogneePluginConfig = {
   // --- Timeouts ---
   requestTimeoutMs?: number;
   ingestionTimeoutMs?: number;
+  /** Timeout for read operations (search / recall). Defaults to requestTimeoutMs. */
+  recallTimeoutMs?: number;
+
+  // --- Circuit breaker ---
+  /** Trip the breaker after repeated backend failures so a down server isn't
+   *  hammered on every call. Default: true. */
+  breakerEnabled?: boolean;
+  /** Consecutive UNREACHABLE / 5xx failures before the breaker opens. Default: 5. */
+  breakerThreshold?: number;
+  /** How long the breaker stays open before allowing a retry, in ms. Default: 120000. */
+  breakerCooldownMs?: number;
 };
 
 export type CogneeAddResponse = {


### PR DESCRIPTION
## Summary

Ports the Python clients' circuit breaker and per-operation timeouts to the
OpenClaw TypeScript client (`integrations/openclaw/`), so a repeatedly-failing
Cognee backend trips one breaker instead of being hammered on every call, and
read operations can use a tighter, configurable timeout.

Relates to topoteretes/cognee#3545

## What changed

The breaker is integrated into `CogneeHttpClient.fetchAPI` — the single HTTP
chokepoint every operation flows through — so it guards all ops uniformly.

- **`src/client.ts`** — in-memory, consecutive-failure circuit breaker; a typed
  `CogneeHttpError` (carries `.status`) so the breaker can distinguish a
  server-side 5xx from a reachable 4xx; retry loop extracted into
  `fetchWithRetry`; configurable read timeout applied to `search`/`recall`.
- **`src/types.ts` / `src/config.ts`** — new config: `recallTimeoutMs`,
  `breakerEnabled`, `breakerThreshold`, `breakerCooldownMs`.
- **`src/plugin.ts`** — thread the new config into the client.
- **`README.md`** — document the new options.
- **`__tests__/test_circuitBreaker.ts`** — coverage (see below).

## Behavior (Definition of done)

- [x] Repeated UNREACHABLE responses (connection failure / timeout) trip the breaker
- [x] `401`/`403` are surfaced but do **not** trip it (waiting won't fix a config problem)
- [x] Per-op timeouts are configurable (`recallTimeoutMs` for reads, alongside the
      existing `requestTimeoutMs` / `ingestionTimeoutMs`)
- [x] Behavior is covered by tests

Only genuine backend trouble trips the breaker: UNREACHABLE or 5xx. Once open,
calls fail fast until the cooldown elapses, then a single probe is allowed
(half-open).

## Design notes

- **In-memory, not file-based.** The Python `_cognee_client` breaker is file-based
  only because plugin hooks are short-lived processes; its docstring notes a
  long-lived provider (Hermes) uses in-memory state. The OpenClaw client is
  long-lived, so this mirrors the Hermes provider model (threshold 5, cooldown 120s).
- **Config-driven** (like `requestTimeoutMs`) rather than env vars, matching the
  existing openclaw config pattern. Happy to also read the Python env names
  (`COGNEE_BREAKER_THRESHOLD`, etc.) if preferred.
- `recallTimeoutMs` defaults to `requestTimeoutMs`, so existing behavior is
  unchanged unless configured.
- Also fixed a latent timer leak in the transport: the abort timer wasn't cleared
  on the success path (surfaced by the new tests).

## Testing

- `npx tsc --noEmit` — clean
- `npx jest` — 54/54 pass (9 new breaker/timeout tests + 45 existing)
 
- here is the screen shots of testing 
<img width="1011" height="336" alt="image" src="https://github.com/user-attachments/assets/5f71663f-2694-457b-a839-ef04ffd88771" />
