### PR TITLE
Per-scope recall timing + hit counts in context_lookup_hit  topoteretes/cognee#3684

### DIFF
--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -211,6 +211,15 @@ async def _run(prompt: str) -> dict | None:
 
         user = await resolve_user(_load_user_id())
 
+    # Per-scope instrumentation (WS7 observability): capture {hits, elapsed_ms}
+    # for every scope — including scopes that error or are skipped by the budget
+    # — keyed by a stable, human-readable label derived from scope_specs. Purely
+    # additive: it must not touch recall results, ordering, or control flow, and
+    # must never raise into the keystroke->answer path. Captured before the
+    # breaker-open branch below can blank scope_specs, so all 5 labels survive.
+    scope_labels = [spec[0][0] for spec in scope_specs]
+    per_scope: dict[str, dict] = {}
+
     # Hard time-box: this hook is on the keystroke->answer path, so recall must
     # never be the long pole. Each scope gets a short per-call timeout, and the
     # whole loop stops once the overall budget is spent. Partial results are fine.
@@ -230,9 +239,12 @@ async def _run(prompt: str) -> dict | None:
             hook_log("recall_breaker_open", {"retry_in": _bretry})
             scope_specs = []
     for scope_list, qtype, context_profile in scope_specs:
+        label = scope_list[0]
         if time.monotonic() >= budget_deadline:
             hook_log("recall_budget_exceeded", {"collected": len(results)})
             break
+        part = None
+        t0 = time.monotonic()
         try:
             if cloud_mode:
                 part = recall_via_http(
@@ -264,6 +276,19 @@ async def _run(prompt: str) -> dict | None:
                 results.extend(part)
         except Exception as exc:
             hook_log("recall_error", {"scope": scope_list, "error": str(exc)[:200]})
+        finally:
+            # hits = raw count from this scope's call (pre-bucketing/filtering);
+            # elapsed_ms measured around the call, recorded even when it errored.
+            per_scope[label] = {
+                "hits": len(part or []),
+                "elapsed_ms": round((time.monotonic() - t0) * 1000, 1),
+            }
+
+    # Backfill scopes that never ran — skipped by the budget break above or by
+    # the breaker-open reset (scope_specs = []) — so the event always carries all
+    # 5 scopes in their canonical order with a 0-hit/0-ms skipped marker.
+    for label in scope_labels:
+        per_scope.setdefault(label, {"hits": 0, "elapsed_ms": 0, "skipped": True})
 
     # Bucket results by _source for human-readable output.
     # Local SDK mode returns Pydantic models (ResponseQAEntry, etc.); cloud
@@ -317,6 +342,7 @@ async def _run(prompt: str) -> dict | None:
                     .datetime.now(__import__("datetime").timezone.utc)
                     .isoformat(timespec="seconds"),
                     "hits": counts,
+                    "per_scope": per_scope,
                     "saves_last_turn": saves_last_turn,
                 }
             ),
@@ -363,11 +389,17 @@ async def _run(prompt: str) -> dict | None:
             f"{header}\n\nRelevant context from this session's memory:\n\n"
             + "\n".join(section_lines).strip()
         )
-        hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
+        hook_log(
+            "context_lookup_hit",
+            {"counts": counts, "per_scope": per_scope, "saves_last_turn": saves_last_turn},
+        )
         notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
     else:
         full_context = f"{header}\n\n(no memory matches for this prompt)"
-        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
+        hook_log(
+            "context_lookup_empty",
+            {"per_scope": per_scope, "saves_last_turn": saves_last_turn},
+        )
         notify(f"no recall matches; saves last turn {saves_last_turn}")
 
     # Audit log: persist full recall details per turn. The hook output stays a
@@ -387,6 +419,7 @@ async def _run(prompt: str) -> dict | None:
                         "session_id": session_id,
                         "prompt": prompt,
                         "hits": counts,
+                        "per_scope": per_scope,
                         "context": full_context,
                     }
                 )

--- a/integrations/claude-code/tests/test_per_scope_timing.py
+++ b/integrations/claude-code/tests/test_per_scope_timing.py
@@ -1,0 +1,168 @@
+"""Unit tests for per-scope recall instrumentation (session-context-lookup.py).
+
+Recall fans out over 5 scopes (session/trace/graph_context/graph/session_context).
+This test drives the hook's ``_run`` in cloud mode with a fake ``recall_via_http``
+and asserts the emitted recall event carries a per-scope ``{hits, elapsed_ms}``
+breakdown for all 5 scopes — including scopes that return nothing — without
+changing the existing aggregate ``counts``.
+
+Run: `pytest integrations/claude-code/tests/test_per_scope_timing.py -v`
+(or `python integrations/claude-code/tests/test_per_scope_timing.py` standalone).
+"""
+
+import asyncio
+import importlib.util
+import os
+import pathlib
+import sys
+import types
+
+# Pin the loop-guard so importing the plugin never re-execs into its venv.
+os.environ.setdefault("COGNEE_PLUGIN_IN_VENV", "1")
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+# The circuit breaker is imported lazily inside _run (cloud mode). Inject a
+# fake so the test is deterministic regardless of any on-disk breaker state.
+_fake_client = types.ModuleType("_cognee_client")
+_fake_client.breaker_open = lambda: (False, 0)
+sys.modules["_cognee_client"] = _fake_client
+
+
+def _load_hook_module():
+    """Import the hyphenated hook script under a clean module name."""
+    path = SCRIPTS / "session-context-lookup.py"
+    spec = importlib.util.spec_from_file_location("session_context_lookup", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+SCOPES = ["session", "trace", "graph_context", "graph", "session_context"]
+
+
+def _run_with_recall(mod, monkeypatch, tmp_home, recall_map):
+    """Drive _run in cloud mode with a fake recall, returning captured events."""
+    events: list[tuple[str, dict]] = []
+
+    def _fake_recall(prompt, **kwargs):
+        return list(recall_map.get(kwargs["scope"][0], []))
+
+    monkeypatch.setattr(mod, "hook_log", lambda ev, detail=None: events.append((ev, detail or {})))
+    monkeypatch.setattr(mod, "notify", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "resolve_runtime_mode",
+                        lambda: {"mode": "http", "base_url": "https://cloud.example"})
+    monkeypatch.setattr(mod, "server_ready_hint", lambda _url: True)
+    monkeypatch.setattr(mod, "_load_session_id", lambda: "sess-123")
+    monkeypatch.setattr(mod, "read_and_reset_save_counter",
+                        lambda _sid: {"prompt": 0, "trace": 0, "answer": 0})
+    monkeypatch.setattr(mod, "recall_via_http", _fake_recall)
+    # Redirect last_recall.json / recall-audit.log writes into a tmp HOME.
+    monkeypatch.setenv("HOME", str(tmp_home))
+    monkeypatch.setenv("USERPROFILE", str(tmp_home))
+
+    output = asyncio.run(mod._run("please recall something relevant"))
+    return output, events
+
+
+def _event(events, name):
+    for ev, detail in events:
+        if ev == name:
+            return detail
+    return None
+
+
+def _assert_valid_per_scope(per_scope):
+    assert list(per_scope.keys()) == SCOPES, f"expected all 5 scopes in order, got {per_scope}"
+    for label, rec in per_scope.items():
+        assert isinstance(rec["hits"], int), f"{label} hits not int: {rec}"
+        assert isinstance(rec["elapsed_ms"], (int, float)), f"{label} elapsed not numeric: {rec}"
+        assert rec["elapsed_ms"] >= 0
+
+
+def test_per_scope_on_hit(monkeypatch, tmp_path):
+    """A hit emits context_lookup_hit carrying per-scope hits + timing."""
+    mod = _load_hook_module()
+    recall_map = {
+        "session": [{"question": "q1", "answer": "a1"}],
+        "trace": [],
+        "graph_context": [{"source": "graph_context", "content": "ctx"}],
+        "graph": [{"source": "graph", "content": "gg"}],
+        "session_context": [],
+    }
+    _out, events = _run_with_recall(mod, monkeypatch, tmp_path, recall_map)
+
+    detail = _event(events, "context_lookup_hit")
+    assert detail is not None, "expected a context_lookup_hit event"
+    assert "counts" in detail, "existing aggregate counts must be preserved"
+    per_scope = detail["per_scope"]
+    _assert_valid_per_scope(per_scope)
+    # Raw per-scope hit attribution (pre-bucketing): graph is NOT folded here.
+    assert per_scope["session"]["hits"] == 1
+    assert per_scope["trace"]["hits"] == 0
+    assert per_scope["graph_context"]["hits"] == 1
+    assert per_scope["graph"]["hits"] == 1
+    assert per_scope["session_context"]["hits"] == 0
+
+
+def test_per_scope_on_empty(monkeypatch, tmp_path):
+    """A total miss still emits per-scope timing for all 5 scopes."""
+    mod = _load_hook_module()
+    recall_map = {s: [] for s in SCOPES}
+    _out, events = _run_with_recall(mod, monkeypatch, tmp_path, recall_map)
+
+    detail = _event(events, "context_lookup_empty")
+    assert detail is not None, "expected a context_lookup_empty event"
+    per_scope = detail["per_scope"]
+    _assert_valid_per_scope(per_scope)
+    assert all(rec["hits"] == 0 for rec in per_scope.values())
+
+
+def _run_all():
+    """Standalone runner (no pytest) using a minimal monkeypatch shim."""
+    class _MP:
+        def __init__(self):
+            self._undo = []
+
+        def setattr(self, obj, name, val):
+            self._undo.append((obj, name, getattr(obj, name)))
+            setattr(obj, name, val)
+
+        def setenv(self, name, val):
+            self._undo.append((os.environ, name, os.environ.get(name)))
+            os.environ[name] = val
+
+        def undo(self):
+            for obj, name, old in reversed(self._undo):
+                if obj is os.environ:
+                    if old is None:
+                        os.environ.pop(name, None)
+                    else:
+                        os.environ[name] = old
+                else:
+                    setattr(obj, name, old)
+
+    import tempfile
+
+    green, red, bold, reset = "\033[32m", "\033[31m", "\033[1m", "\033[0m"
+    failures = 0
+    for test in (test_per_scope_on_hit, test_per_scope_on_empty):
+        mp = _MP()
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                test(mp, pathlib.Path(td))
+            print(f"{green}PASS{reset}  {test.__name__}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"{red}FAIL{reset}  {test.__name__}: {exc}")
+        finally:
+            mp.undo()
+    if failures:
+        print(f"{red}{bold}{failures} FAILED{reset}")
+        sys.exit(1)
+    print(f"{green}{bold}2 passed{reset}")
+
+
+if __name__ == "__main__":
+    _run_all()

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -201,6 +201,15 @@ async def _run(prompt: str) -> dict | None:
 
         user = await resolve_user(_load_user_id())
 
+    # Per-scope instrumentation (WS7 observability): capture {hits, elapsed_ms}
+    # for every scope — including scopes that error or are skipped by the budget
+    # — keyed by a stable, human-readable label derived from scope_specs. Purely
+    # additive: it must not touch recall results, ordering, or control flow, and
+    # must never raise into the keystroke->answer path. Captured before the
+    # breaker-open branch below can blank scope_specs, so all 5 labels survive.
+    scope_labels = [spec[0][0] for spec in scope_specs]
+    per_scope: dict[str, dict] = {}
+
     # Hard time-box: this hook is on the keystroke->answer path, so recall must
     # never be the long pole. Each scope gets a short per-call timeout, and the
     # whole loop stops once the overall budget is spent. Partial results are fine.
@@ -220,9 +229,12 @@ async def _run(prompt: str) -> dict | None:
             hook_log("recall_breaker_open", {"retry_in": _bretry})
             scope_specs = []
     for scope_list, qtype, context_profile in scope_specs:
+        label = scope_list[0]
         if time.monotonic() >= budget_deadline:
             hook_log("recall_budget_exceeded", {"collected": len(results)})
             break
+        part = None
+        t0 = time.monotonic()
         try:
             if cloud_mode:
                 part = recall_via_http(
@@ -254,6 +266,19 @@ async def _run(prompt: str) -> dict | None:
                 results.extend(part)
         except Exception as exc:
             hook_log("recall_error", {"scope": scope_list, "error": str(exc)[:200]})
+        finally:
+            # hits = raw count from this scope's call (pre-bucketing/filtering);
+            # elapsed_ms measured around the call, recorded even when it errored.
+            per_scope[label] = {
+                "hits": len(part or []),
+                "elapsed_ms": round((time.monotonic() - t0) * 1000, 1),
+            }
+
+    # Backfill scopes that never ran — skipped by the budget break above or by
+    # the breaker-open reset (scope_specs = []) — so the event always carries all
+    # 5 scopes in their canonical order with a 0-hit/0-ms skipped marker.
+    for label in scope_labels:
+        per_scope.setdefault(label, {"hits": 0, "elapsed_ms": 0, "skipped": True})
 
     # Bucket results by _source for human-readable output.
     # Local SDK mode returns Pydantic models (ResponseQAEntry, etc.); cloud
@@ -307,6 +332,7 @@ async def _run(prompt: str) -> dict | None:
                     .datetime.now(__import__("datetime").timezone.utc)
                     .isoformat(timespec="seconds"),
                     "hits": counts,
+                    "per_scope": per_scope,
                     "saves_last_turn": saves_last_turn,
                 }
             ),
@@ -355,11 +381,17 @@ async def _run(prompt: str) -> dict | None:
             f"{header}\n\nRelevant context from this session's memory:\n\n"
             + "\n".join(section_lines).strip()
         )
-        hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
+        hook_log(
+            "context_lookup_hit",
+            {"counts": counts, "per_scope": per_scope, "saves_last_turn": saves_last_turn},
+        )
         notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
     else:
         full_context = f"{header}\n\n(no memory matches for this prompt)"
-        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
+        hook_log(
+            "context_lookup_empty",
+            {"per_scope": per_scope, "saves_last_turn": saves_last_turn},
+        )
         notify(f"no recall matches; saves last turn {saves_last_turn}")
 
     # Audit log: persist full recall details per turn. The hook output stays a
@@ -379,6 +411,7 @@ async def _run(prompt: str) -> dict | None:
                         "session_id": session_id,
                         "prompt": prompt,
                         "hits": counts,
+                        "per_scope": per_scope,
                         "context": full_context,
                     }
                 )


### PR DESCRIPTION
Fixes topoteretes/cognee#3684
 
---
 
## Problem Statement
 
Recall fans out over 5 scopes — `session`, `trace`, `graph_context`, `graph` (HYBRID_COMPLETION), `session_context` (agent) — but logged events only record aggregate hit counts bucketed by result `_source`. Two attributions are lost before anything is logged:
 
- **No per-scope hit attribution** — results are bucketed by `_source`, not scope. Scope `graph` folds into the `graph_context` bucket, so you can't tell which scope produced hits.
- **No per-scope timing** — there's a per-call timeout and an overall budget deadline, but no `elapsed_ms` is ever captured, so you can't tell which scope is slow.
**Net:** you can't answer *"which scope is slow / which is contributing hits"* from the telemetry.
 
---
 
## Proposed Solution
 
Instrument the per-scope loop to build an ordered `per_scope: {label: {hits, elapsed_ms}}` map covering all 5 scopes, and attach it to the recall events. Purely additive — no change to results, ordering, bucketing, output payload, timeouts, or the budget short-circuit.
 
### Implementation Details
 
**1. Stable label derivation**
Derive stable labels from `scope_specs` (`session`, `trace`, `graph_context`, `graph`, `session_context`), captured before the breaker-open branch can blank `scope_specs`.
 
**2. Per-scope timing wrapping**
Wrap each scope call with monotonic timing:
 
```python
t0 = time.monotonic()
part = None          # pre-assigned so finally always has a value
try:
    part = call_scope(...)
finally:
    per_scope[label] = {
        "hits": len(part or []),
        "elapsed_ms": round((time.monotonic() - t0) * 1000, 1),
    }
```
 
`part = None` is set before the `try` so timing is recorded even when the call raises — hits record as `0`, elapsed is still measured.
 
**3. Raw hit counts**
`hits` is the raw call count (`len(part)`), pre-bucketing/filtering — true scope attribution, unlike aggregate counts where `graph` folds into `graph_context`.
 
**4. Skip backfill**
After the loop, backfill scopes that never ran (budget-break or breaker-open) as `{hits: 0, elapsed_ms: 0, skipped: true}`, so the map always carries all 5 scopes in canonical order.
 
**5. Best-effort guarantee**
Everything runs on paths that never raise into the keystroke→answer hot path.
 
**6. Attachment points**
Attach `per_scope` to:
- `context_lookup_hit`
- `context_lookup_empty`
- `last_recall.json`
- `recall-audit.log`
Existing `counts` field is preserved — `per_scope` is added alongside it, not in place of it.
 
---
 
## Files Changed
 
| File | Why |
|---|---|
| `session-context-lookup.py` (claude-code) | Primary per-scope loop named in the issue. Added `scope_labels`/`per_scope` setup, `finally`-based timing in the loop, skip-backfill, and `per_scope` on `context_lookup_hit` / `context_lookup_empty` + `last_recall.json` + `recall-audit.log`. |
| `session-context-lookup.py` (codex twin) | Parity requirement — claude-code and codex twins must stay in sync. Same changes mirrored; `per_scope` logic is byte-identical between twins. |
| `test_per_scope_timing.py` *(new)* | Regression test driving the real `_run` and asserting per-scope telemetry on both hit and empty paths. |
 
---
 
## Tests
 
All passing:
 
**Compile checks**
- `python -m py_compile` on both twins → `COMPILE OK`
- `per_scope` parity between twins → identical
**`test_per_scope_timing.py`**
 
Loads the real hook module, drives `_run` in cloud mode with a fake `recall_via_http`.
 
| Test | Assertion |
|---|---|
| `test_per_scope_on_hit` | `context_lookup_hit` carries `per_scope` with all 5 scopes in canonical order; correct raw hits (`session=1`, `trace=0`, `graph_context=1`, `graph=1`, `session_context=0`); numeric `elapsed_ms` on each; existing `counts` preserved. |
| `test_per_scope_on_empty` | Total miss still emits `context_lookup_empty` with `per_scope` for all 5 scopes (all `hits=0`). |
 
---
 
## Expected `per_scope` Payload Shape
 
```json
{
  "per_scope": {
    "session":         { "hits": 1, "elapsed_ms": 12.4 },
    "trace":           { "hits": 0, "elapsed_ms": 3.1  },
    "graph_context":   { "hits": 1, "elapsed_ms": 8.7  },
    "graph":           { "hits": 1, "elapsed_ms": 5.2  },
    "session_context": { "hits": 0, "elapsed_ms": 0,   "skipped": true }
  },
  "counts": { ... }
}
```
 
Scopes that were skipped due to budget exhaustion or breaker-open carry `"skipped": true` and both fields zeroed.
 
---
 
## Canonical Scope Order
 
| # | Label | Description |
|---|---|---|
| 1 | `session` | Current session memory |
| 2 | `trace` | Distributed trace context |
| 3 | `graph_context` | Graph context window |
| 4 | `graph` | Full graph (HYBRID_COMPLETION only) |
| 5 | `session_context` | Agent session context |

<img width="592" height="111" alt="Screenshot 2026-07-02 154743" src="https://github.com/user-attachments/assets/4883430e-7a80-4890-9cc4-4e231aa97d19" />
