### PR TITLE
feat(statusline): show installed plugin version in status line

### DIFF
--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -73,12 +73,28 @@ def _health_prefix() -> str:
     return ""
 
 
+def _plugin_version() -> str:
+    """Return `` · v<version>`` or ``""``, pure-local and fail-silent."""
+    try:
+        root = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
+        if not root:
+            return ""
+        manifest = Path(root) / ".claude-plugin" / "plugin.json"
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        version = str(data.get("version", "") or "").strip()
+        if version:
+            return f" · v{version}"
+    except Exception:
+        pass
+    return ""
+
+
 def main() -> None:
     try:
         json.load(sys.stdin)  # consume stdin as required by Claude Code
     except Exception:
         pass
-    sys.stdout.write(f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}")
+    sys.stdout.write(f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}{_plugin_version()}")
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/tests/test_statusline.py
+++ b/integrations/claude-code/tests/test_statusline.py
@@ -1,0 +1,66 @@
+"""Unit tests for the status-line version helper (_plugin_version)."""
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+# Import the module under test
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import cognee_statusline_render as m
+
+
+def _write_manifest(root: Path, version: str) -> None:
+    plugin_dir = root / ".claude-plugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.json").write_text(
+        json.dumps({"name": "cognee-memory", "version": version}), encoding="utf-8"
+    )
+
+
+def test_plugin_version_missing_env() -> None:
+    with patch.dict(os.environ, {}, clear=True):
+        assert m._plugin_version() == ""
+
+
+def test_plugin_version_empty_env() -> None:
+    with patch.dict(os.environ, {"CLAUDE_PLUGIN_ROOT": ""}):
+        assert m._plugin_version() == ""
+
+
+def test_plugin_version_no_manifest() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        manifest = Path(tmp) / ".claude-plugin" / "plugin.json"
+        manifest.parent.mkdir(parents=True)
+        # No file written — should fail silent
+        assert manifest.parent.exists()
+        with patch.dict(os.environ, {"CLAUDE_PLUGIN_ROOT": str(tmp)}):
+            assert m._plugin_version() == ""
+
+
+def test_plugin_version_valid() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        _write_manifest(Path(tmp), "0.3.0")
+        with patch.dict(os.environ, {"CLAUDE_PLUGIN_ROOT": str(tmp)}):
+            assert m._plugin_version() == " · v0.3.0"
+
+
+def test_plugin_version_invalid_json() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        plugin_dir = Path(tmp) / ".claude-plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.json").write_text("not json", encoding="utf-8")
+        with patch.dict(os.environ, {"CLAUDE_PLUGIN_ROOT": str(tmp)}):
+            assert m._plugin_version() == ""
+
+
+def test_plugin_version_missing_version_field() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        plugin_dir = Path(tmp) / ".claude-plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.json").write_text(
+            json.dumps({"name": "cognee-memory"}), encoding="utf-8"
+        )
+        with patch.dict(os.environ, {"CLAUDE_PLUGIN_ROOT": str(tmp)}):
+            assert m._plugin_version() == ""


### PR DESCRIPTION
## Summary

Add plugin version display to the status line so users can see which version of the cognee plugin is installed. Reads version from `CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json` — pure-local, fail-silent.

Before: `cognee: dataset · local`
After: `cognee: dataset · local · v0.2.0`

## Changes

- `cognee_statusline_render.py`: add `_plugin_version()` helper following the existing `_active_dataset` / `_health_prefix` pattern
- `test_statusline.py`: 6 unit tests covering missing env, empty env, no manifest, valid version, invalid JSON, and missing version field

## Test Plan

```
cd integrations/claude-code/tests && python3 test_statusline.py
```

Fixes https://github.com/topoteretes/cognee-integrations/issues/134