### PR TITLE
fix(openclaw): restore fetchJson helper for skills plugin

### DIFF
--- a/integrations/openclaw/__tests__/test_clientFetchJson.ts
+++ b/integrations/openclaw/__tests__/test_clientFetchJson.ts
@@ -1,0 +1,37 @@
+import { CogneeHttpClient } from "../src/client";
+
+describe("CogneeHttpClient.fetchJson", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("delegates JSON requests through the shared authenticated transport", async () => {
+    const fetchMock = jest.fn(async () => {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const client = new CogneeHttpClient("http://localhost:8000", "test-api-key");
+
+    await expect(client.fetchJson<{ ok: boolean }>("/api/v1/skills", { method: "GET" }))
+      .resolves.toEqual({ ok: true });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8000/api/v1/skills",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-api-key",
+          "X-Api-Key": "test-api-key",
+        }),
+      }),
+    );
+  });
+});

--- a/integrations/openclaw/src/client.ts
+++ b/integrations/openclaw/src/client.ts
@@ -171,6 +171,16 @@ export class CogneeHttpClient {
     throw lastError;
   }
 
+  async fetchJson<T>(
+    path: string,
+    init: RequestInit,
+    timeoutMs = this.timeoutMs,
+    responseParser: (r: Response) => Promise<T> = async (r: Response) => (await r.json()) as T,
+    retries = MAX_RETRIES,
+  ): Promise<T> {
+    return this.fetchAPI<T>(path, init, timeoutMs, responseParser, retries);
+  }
+
   // -- Health ---------------------------------------------------------------
 
   async health(): Promise<{ status: string }> {

--- a/integrations/opencode/src/client.ts
+++ b/integrations/opencode/src/client.ts
@@ -158,6 +158,16 @@ export class CogneeHttpClient {
     throw lastError;
   }
 
+  async fetchJson<T>(
+    path: string,
+    init: RequestInit,
+    timeoutMs = this.timeoutMs,
+    responseParser: (r: Response) => Promise<T> = async (r: Response) => (await r.json()) as T,
+    retries = MAX_RETRIES,
+  ): Promise<T> {
+    return this.fetchAPI<T>(path, init, timeoutMs, responseParser, retries);
+  }
+
   async health(): Promise<{ status: string }> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);


### PR DESCRIPTION
## Summary
- restores `CogneeHttpClient.fetchJson<T>()` in the OpenClaw shared client by delegating to `fetchAPI<T>()`
- adds the same helper to the OpenCode client for parity
- adds a regression test proving `fetchJson` uses the shared authenticated transport

Fixes #194.

## Verification
- `git diff --check` passed
- attempted lightweight TypeScript check for the changed files

Full package verification could not be completed in this local workspace because dependencies were not installed and `npm ci --ignore-scripts` failed with `ENOSPC: no space left on device` before installing `tsc`/`jest`. The partial generated `node_modules` directory was removed after the failed install.