### PR TITLE
feat(discord): add Cognee-backed Discord memory bot (HTTP adapter)

### DIFF
--- a/integrations/discord/README.md
+++ b/integrations/discord/README.md
@@ -1,0 +1,80 @@
+# cognee-integration-discord
+
+A Discord bot that gives community/support servers **persistent memory** backed
+by [cognee](https://github.com/topoteretes/cognee). It ingests channel messages
+into a per-server knowledge graph and answers questions with **citations** back
+to the source messages.
+
+> **Design note.** All memory logic lives behind a thin `ChatMemoryAdapter`
+> (see cognee issue #3608) so Discord/Slack/Telegram bots can share one memory
+> model. This branch ships the **HTTP-client** adapter (`CogneeHttpAdapter`,
+> talks to a running cognee server over `/api/v1/remember|recall|forget`). A
+> sibling branch provides an in-process SDK adapter instead.
+
+## Memory model
+
+| Discord | cognee | Why |
+|---|---|---|
+| Server (guild) | dataset (`discord-guild-<id>`) | hard isolation — one server's memory can't leak into another |
+| Channel / thread | session (`discord-<guild>-<channel>`) | fast conversational recall scoped to the channel |
+| Message | remembered document + provenance header | citations link answers back to the exact message |
+
+## Slash commands
+
+| Command | Who | Effect |
+|---|---|---|
+| `/cognee-enable` | server admin (`Manage Server`) | opt this channel in to memory capture (nothing is captured until enabled) |
+| `/cognee-disable` | server admin | stop capturing this channel |
+| `/cognee-ask <question>` | anyone | answer from the server's memory, with a **Sources** footer of message links |
+| `/cognee-forget` | server admin | forget everything cognee holds for this server |
+
+Privacy-first: capture is **opt-in per channel**, and `/cognee-forget` removes
+the server's memory on request.
+
+## Setup
+
+```bash
+cd integrations/discord
+pip install -e .
+
+export DISCORD_BOT_TOKEN="your-bot-token"
+export COGNEE_BASE_URL="http://localhost:8000"   # a running cognee server
+export COGNEE_API_KEY="your-cognee-api-key"       # omit for a local server with auth disabled
+
+python -m cognee_integration_discord
+```
+
+This variant talks to a **running cognee server** over HTTP, so cognee itself
+(and its `LLM_API_KEY`) is configured on the server, not the bot.
+
+Invite the bot with the `applications.commands` scope and the **Message Content**
+privileged intent enabled (needed to read messages for capture).
+
+## Running the bot from code
+
+```python
+from cognee_integration_discord import bot
+
+bot.run()  # reads DISCORD_BOT_TOKEN + COGNEE_BASE_URL; talks to a cognee server
+```
+
+## Architecture
+
+- `mapping.py` — dependency-free naming + citation helpers
+- `adapter.py` — `ChatMemoryAdapter` seam + `CogneeHttpAdapter` (cognee HTTP API)
+- `service.py` — platform-agnostic bot behavior (opt-in, ingest, answer, forget)
+- `bot.py` — the only discord.py-facing module (slash commands + message listener)
+
+The behavior in `service.py` is fully unit-tested against a fake adapter, so no
+live bot or cognee instance is needed to run the tests:
+
+```bash
+pip install pytest
+pytest
+```
+
+## Scope
+
+v1 covers channel opt-in, live message capture, ask-with-citations, and forget.
+Channel-history / pinned-message backfill and a dedicated FAQ knowledge-base mode
+are planned follow-ups.

--- a/integrations/discord/cognee_integration_discord/__init__.py
+++ b/integrations/discord/cognee_integration_discord/__init__.py
@@ -1,0 +1,18 @@
+"""Cognee-backed memory for Discord servers (per-guild/per-channel isolation).
+
+Public surface:
+    - ChatMemoryAdapter / CogneeHttpAdapter — the memory seam (see #3608)
+    - MemoryService — platform-agnostic bot behavior
+    - build_cog / run — discord.py wiring
+"""
+
+from .adapter import ChatMemoryAdapter, CogneeHttpAdapter, RecallResult
+from .service import AnswerResult, MemoryService
+
+__all__ = [
+    "ChatMemoryAdapter",
+    "CogneeHttpAdapter",
+    "RecallResult",
+    "MemoryService",
+    "AnswerResult",
+]

--- a/integrations/discord/cognee_integration_discord/__main__.py
+++ b/integrations/discord/cognee_integration_discord/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point: ``python -m cognee_integration_discord`` starts the bot."""
+
+from .bot import run
+
+if __name__ == "__main__":
+    run()

--- a/integrations/discord/cognee_integration_discord/adapter.py
+++ b/integrations/discord/cognee_integration_discord/adapter.py
@@ -1,0 +1,146 @@
+"""Chat-memory adapter seam.
+
+``ChatMemoryAdapter`` is the thin interface every platform bot (Discord, Slack,
+Telegram) talks to, so the bot layer never calls cognee directly. This mirrors
+the shared adapter proposed in #3608 — when that lands, its implementation drops
+in here and the bot/service layers are untouched.
+
+This branch ships ``CogneeHttpAdapter``, which talks to a running cognee server
+over HTTP (``/api/v1/remember`` | ``/recall`` | ``/forget``). A sibling branch
+provides an in-process SDK implementation instead.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class RecallResult:
+    """Normalized recall payload the bot layer can render without knowing cognee."""
+
+    answer: str
+    sources: list[str] = field(default_factory=list)
+
+
+class ChatMemoryAdapter(ABC):
+    """Minimal memory surface a chat bot needs: remember, recall, forget."""
+
+    @abstractmethod
+    async def remember(
+        self, text: str, *, dataset: str, session: str, provenance: Optional[dict] = None
+    ) -> None:
+        """Persist a message into memory under the given dataset/session."""
+
+    @abstractmethod
+    async def recall(
+        self, query: str, *, dataset: str, session: str, top_k: int = 5
+    ) -> RecallResult:
+        """Answer a question from the dataset/session memory."""
+
+    @abstractmethod
+    async def forget(self, *, dataset: str, everything: bool = False) -> None:
+        """Remove a dataset's memory (or everything the bot owns)."""
+
+
+class CogneeHttpAdapter(ChatMemoryAdapter):
+    """Adapter that talks to a running cognee server over HTTP.
+
+    Auth is via ``X-Api-Key`` when an api key is configured; a local cognee with
+    access control disabled works without one. An ``httpx.AsyncClient`` can be
+    injected (tests); otherwise one is created per request.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: Optional[str] = None,
+        *,
+        client: Any = None,
+        timeout: float = 60.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._timeout = timeout
+        self._client = client
+
+    async def remember(
+        self, text: str, *, dataset: str, session: str, provenance: Optional[dict] = None
+    ) -> None:
+        response = await self._request(
+            "POST",
+            "/api/v1/remember",
+            data={"datasetName": dataset, "session_id": session},
+            files={"data": ("message.txt", text.encode("utf-8"), "text/plain")},
+        )
+        response.raise_for_status()
+
+    async def recall(
+        self, query: str, *, dataset: str, session: str, top_k: int = 5
+    ) -> RecallResult:
+        response = await self._request(
+            "POST",
+            "/api/v1/recall",
+            json={
+                "query": query,
+                "top_k": top_k,
+                "session_id": session,
+                "datasets": [dataset],
+                "include_references": True,
+            },
+        )
+        response.raise_for_status()
+        return _parse_recall(response.json())
+
+    async def forget(self, *, dataset: str, everything: bool = False) -> None:
+        response = await self._request(
+            "POST",
+            "/api/v1/forget",
+            json={"dataset": dataset, "everything": everything},
+        )
+        response.raise_for_status()
+
+    # -- transport ------------------------------------------------------------
+
+    def _headers(self) -> dict:
+        return {"X-Api-Key": self._api_key} if self._api_key else {}
+
+    async def _request(self, method: str, path: str, **kwargs):
+        import httpx
+
+        url = self._base_url + path
+        headers = {**self._headers(), **kwargs.pop("headers", {})}
+        if self._client is not None:
+            return await self._client.request(method, url, headers=headers, **kwargs)
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            return await client.request(method, url, headers=headers, **kwargs)
+
+
+def _parse_recall(data: Any) -> RecallResult:
+    """Normalize cognee's recall response (list of results / error) to RecallResult."""
+    items = data.get("results", data) if isinstance(data, dict) else data
+    texts: list[str] = []
+    if isinstance(items, list):
+        for item in items:
+            text = _item_text(item)
+            if text:
+                texts.append(text)
+    return RecallResult(answer=texts[0] if texts else "", sources=texts)
+
+
+def _item_text(item: Any) -> str:
+    if isinstance(item, str):
+        return item.strip()
+    if isinstance(item, dict):
+        text = item.get("text")
+        if not text:
+            search_result = item.get("search_result")
+            if isinstance(search_result, list):
+                text = "\n".join(str(part) for part in search_result)
+            elif isinstance(search_result, str):
+                text = search_result
+        if isinstance(text, str):
+            return text.strip()
+    return ""

--- a/integrations/discord/cognee_integration_discord/bot.py
+++ b/integrations/discord/cognee_integration_discord/bot.py
@@ -1,0 +1,102 @@
+"""discord.py wiring: slash commands + message ingestion over MemoryService.
+
+This is the only module that imports discord.py; it stays a thin cog so the
+behavior (in ``service.py``) is tested without a live bot. Slash commands defer
+first because cognify/recall exceed Discord's ~3s ack window.
+"""
+
+from __future__ import annotations
+
+from .adapter import ChatMemoryAdapter, CogneeHttpAdapter
+from .config import BotConfig
+from .service import MemoryService
+
+
+def build_cog(service: MemoryService):
+    """Build the Discord cog bound to a MemoryService.
+
+    discord.py is imported lazily so the package (and its tests) import without
+    the optional dependency installed.
+    """
+    import discord
+    from discord import app_commands
+    from discord.ext import commands
+
+    class CogneeMemory(commands.Cog):
+        def __init__(self, memory: MemoryService) -> None:
+            self.memory = memory
+
+        @app_commands.command(
+            name="cognee-enable", description="Enable cognee memory capture in this channel"
+        )
+        @app_commands.checks.has_permissions(manage_guild=True)
+        async def enable(self, interaction: discord.Interaction) -> None:
+            self.memory.enable_channel(interaction.guild_id, interaction.channel_id)
+            await interaction.response.send_message(
+                "Cognee memory is now enabled in this channel.", ephemeral=True
+            )
+
+        @app_commands.command(
+            name="cognee-disable", description="Stop cognee memory capture in this channel"
+        )
+        @app_commands.checks.has_permissions(manage_guild=True)
+        async def disable(self, interaction: discord.Interaction) -> None:
+            self.memory.disable_channel(interaction.guild_id, interaction.channel_id)
+            await interaction.response.send_message(
+                "Cognee memory capture disabled in this channel.", ephemeral=True
+            )
+
+        @app_commands.command(
+            name="cognee-ask", description="Ask a question against this server's memory"
+        )
+        async def ask(self, interaction: discord.Interaction, question: str) -> None:
+            await interaction.response.defer(thinking=True)
+            result = await self.memory.answer(
+                interaction.guild_id, interaction.channel_id, question
+            )
+            await interaction.followup.send(result.text)
+
+        @app_commands.command(
+            name="cognee-forget", description="Forget everything cognee holds for this server"
+        )
+        @app_commands.checks.has_permissions(manage_guild=True)
+        async def forget(self, interaction: discord.Interaction) -> None:
+            await interaction.response.defer(thinking=True, ephemeral=True)
+            await self.memory.forget_guild(interaction.guild_id)
+            await interaction.followup.send("Forgot this server's cognee memory.", ephemeral=True)
+
+        @commands.Cog.listener()
+        async def on_message(self, message: discord.Message) -> None:
+            if message.author.bot or message.guild is None:
+                return
+            await self.memory.ingest_message(
+                message.guild.id,
+                message.channel.id,
+                message.id,
+                str(message.author),
+                message.content,
+            )
+
+    return CogneeMemory(service)
+
+
+def run(config: BotConfig | None = None, adapter: ChatMemoryAdapter | None = None) -> None:
+    """Start the Discord bot (blocking). Requires discord.py + DISCORD_BOT_TOKEN."""
+    import discord
+    from discord.ext import commands
+
+    config = config or BotConfig.from_env()
+    if adapter is None:
+        adapter = CogneeHttpAdapter(config.cognee_base_url, config.cognee_api_key or None)
+    service = MemoryService(adapter)
+
+    intents = discord.Intents.default()
+    intents.message_content = True
+    bot = commands.Bot(command_prefix="!", intents=intents)
+
+    @bot.event
+    async def on_ready() -> None:
+        await bot.add_cog(build_cog(service))
+        await bot.tree.sync()
+
+    bot.run(config.discord_token)

--- a/integrations/discord/cognee_integration_discord/config.py
+++ b/integrations/discord/cognee_integration_discord/config.py
@@ -1,0 +1,33 @@
+"""Environment-based configuration for the Discord memory bot (HTTP variant)."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class BotConfig:
+    discord_token: str
+    cognee_base_url: str = "http://localhost:8000"
+    cognee_api_key: str = ""
+    top_k: int = 5
+
+    @classmethod
+    def from_env(cls) -> "BotConfig":
+        token = os.environ.get("DISCORD_BOT_TOKEN", "")
+        if not token:
+            raise ValueError("DISCORD_BOT_TOKEN is required to run the Discord memory bot.")
+        return cls(
+            discord_token=token,
+            cognee_base_url=os.environ.get("COGNEE_BASE_URL", "http://localhost:8000"),
+            cognee_api_key=os.environ.get("COGNEE_API_KEY", ""),
+            top_k=_int_env("COGNEE_DISCORD_TOP_K", 5),
+        )
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ[name])
+    except (KeyError, ValueError):
+        return default

--- a/integrations/discord/cognee_integration_discord/mapping.py
+++ b/integrations/discord/cognee_integration_discord/mapping.py
@@ -1,0 +1,57 @@
+"""Pure mapping + formatting helpers shared by every backend.
+
+These are deliberately dependency-free (no discord.py, no cognee) so the
+guild→dataset / channel→session convention, the message-provenance header, and
+citation formatting can be unit-tested in isolation and reused unchanged when
+the shared chat-memory adapter (#3608) lands.
+"""
+
+import re
+
+# A Discord message deep-link, e.g.
+# https://discord.com/channels/<guild>/<channel>/<message>
+_DISCORD_MSG_URL = re.compile(r"https://discord\.com/channels/\d+/\d+/\d+")
+
+
+def dataset_for_guild(guild_id) -> str:
+    """One cognee dataset per Discord server (hard memory-isolation boundary)."""
+    return f"discord-guild-{guild_id}"
+
+
+def session_for_channel(guild_id, channel_id) -> str:
+    """One cognee session per channel, for fast conversational recall."""
+    return f"discord-{guild_id}-{channel_id}"
+
+
+def message_url(guild_id, channel_id, message_id) -> str:
+    """Build the canonical Discord deep-link for a message (used as a citation)."""
+    return f"https://discord.com/channels/{guild_id}/{channel_id}/{message_id}"
+
+
+def format_ingest_text(content: str, url: str, author: str) -> str:
+    """Prefix a message with a provenance header so recall can cite its source.
+
+    The header carries the message link and author into the stored text; recall
+    surfaces it back and ``extract_citations`` turns it into a Sources list.
+    """
+    return f"[source] {url} — {author}\n{content}"
+
+
+def extract_citations(snippets, limit: int = 5) -> list[str]:
+    """Collect unique Discord message links found in recalled snippets."""
+    seen: list[str] = []
+    for snippet in snippets:
+        for match in _DISCORD_MSG_URL.findall(snippet or ""):
+            if match not in seen:
+                seen.append(match)
+            if len(seen) >= limit:
+                return seen
+    return seen
+
+
+def format_answer(answer: str, citations) -> str:
+    """Append a Sources footer of message links to an answer, if any."""
+    if not citations:
+        return answer
+    sources = "\n".join(f"- <{url}>" for url in citations)
+    return f"{answer}\n\n**Sources:**\n{sources}"

--- a/integrations/discord/cognee_integration_discord/service.py
+++ b/integrations/discord/cognee_integration_discord/service.py
@@ -1,0 +1,84 @@
+"""Platform-agnostic memory service.
+
+Holds all the bot's memory behavior — channel opt-in, message ingestion,
+question answering with citations, and forget — driven purely through a
+``ChatMemoryAdapter``. It knows nothing about discord.py, so it is fully
+unit-testable with a fake adapter, and could back a Slack/Telegram bot too.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from . import mapping
+from .adapter import ChatMemoryAdapter
+
+_NO_MEMORY = "I don't have anything in memory about that yet."
+
+
+@dataclass
+class AnswerResult:
+    text: str
+    found: bool
+
+
+class MemoryService:
+    """Bot memory behavior over a ChatMemoryAdapter.
+
+    Channel opt-in is privacy-first: nothing is ingested until a channel is
+    explicitly enabled (an admin action in the bot layer).
+    """
+
+    def __init__(self, adapter: ChatMemoryAdapter, enabled_channels=None) -> None:
+        self._adapter = adapter
+        self._enabled: set[tuple[str, str]] = set(enabled_channels or [])
+
+    # -- Channel opt-in -------------------------------------------------------
+
+    def enable_channel(self, guild_id, channel_id) -> None:
+        self._enabled.add((str(guild_id), str(channel_id)))
+
+    def disable_channel(self, guild_id, channel_id) -> None:
+        self._enabled.discard((str(guild_id), str(channel_id)))
+
+    def is_enabled(self, guild_id, channel_id) -> bool:
+        return (str(guild_id), str(channel_id)) in self._enabled
+
+    # -- Memory operations ----------------------------------------------------
+
+    async def ingest_message(
+        self, guild_id, channel_id, message_id, author: str, content: str
+    ) -> bool:
+        """Remember a message if its channel is opted in. Returns whether stored."""
+        if not content or not content.strip():
+            return False
+        if not self.is_enabled(guild_id, channel_id):
+            return False
+
+        url = mapping.message_url(guild_id, channel_id, message_id)
+        await self._adapter.remember(
+            mapping.format_ingest_text(content, url, author),
+            dataset=mapping.dataset_for_guild(guild_id),
+            session=mapping.session_for_channel(guild_id, channel_id),
+            provenance={"url": url, "author": author},
+        )
+        return True
+
+    async def answer(self, guild_id, channel_id, question: str, top_k: int = 5) -> AnswerResult:
+        """Recall an answer for a question, with a Sources footer of message links."""
+        result = await self._adapter.recall(
+            question,
+            dataset=mapping.dataset_for_guild(guild_id),
+            session=mapping.session_for_channel(guild_id, channel_id),
+            top_k=top_k,
+        )
+        answer = (result.answer or "").strip()
+        if not answer:
+            return AnswerResult(text=_NO_MEMORY, found=False)
+
+        citations = mapping.extract_citations(result.sources)
+        return AnswerResult(text=mapping.format_answer(answer, citations), found=True)
+
+    async def forget_guild(self, guild_id) -> None:
+        """Forget everything cognee holds for this server."""
+        await self._adapter.forget(dataset=mapping.dataset_for_guild(guild_id))

--- a/integrations/discord/pyproject.toml
+++ b/integrations/discord/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cognee-integration-discord"
+version = "0.1.0"
+description = "Cognee-backed memory for Discord servers (per-guild/per-channel isolation)."
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [
+    {name = "Cognee team"}
+]
+dependencies = [
+    "discord.py>=2.3,<3",
+    "httpx>=0.27,<1",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["cognee_integration_discord*"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.14.6",
+]

--- a/integrations/discord/tests/conftest.py
+++ b/integrations/discord/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Make the package importable when running pytest from anywhere.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/integrations/discord/tests/test_http_adapter.py
+++ b/integrations/discord/tests/test_http_adapter.py
@@ -1,0 +1,114 @@
+import asyncio
+import json
+
+import httpx
+from cognee_integration_discord.adapter import CogneeHttpAdapter
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def _adapter(handler):
+    """CogneeHttpAdapter wired to an httpx MockTransport (no real server)."""
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    adapter = CogneeHttpAdapter("http://cognee:8000", api_key="test-key", client=client)
+    return adapter, client
+
+
+def test_recall_posts_json_to_recall_endpoint_and_scopes_dataset():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json=[{"text": "Deploy is at 5pm. https://discord.com/channels/1/2/3"}],
+        )
+
+    adapter, client = _adapter(handler)
+    try:
+        result = run(
+            adapter.recall("when is deploy", dataset="discord-guild-1", session="s", top_k=3)
+        )
+    finally:
+        run(client.aclose())
+
+    assert captured["url"].endswith("/api/v1/recall")
+    assert captured["headers"]["x-api-key"] == "test-key"
+    assert captured["body"]["datasets"] == ["discord-guild-1"]
+    assert captured["body"]["session_id"] == "s"
+    assert captured["body"]["top_k"] == 3
+    assert result.answer.startswith("Deploy is at 5pm.")
+    assert "https://discord.com/channels/1/2/3" in result.sources[0]
+
+
+def test_recall_normalizes_search_result_field():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[{"search_result": ["line one", "line two"]}])
+
+    adapter, client = _adapter(handler)
+    try:
+        result = run(adapter.recall("q", dataset="d", session="s"))
+    finally:
+        run(client.aclose())
+
+    assert result.answer == "line one\nline two"
+
+
+def test_remember_posts_multipart_to_remember_endpoint():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["content_type"] = request.headers.get("content-type", "")
+        captured["body"] = request.content
+        return httpx.Response(200, json={"status": "ok"})
+
+    adapter, client = _adapter(handler)
+    try:
+        run(adapter.remember("hello world", dataset="discord-guild-1", session="s"))
+    finally:
+        run(client.aclose())
+
+    assert captured["url"].endswith("/api/v1/remember")
+    assert captured["content_type"].startswith("multipart/form-data")
+    assert b"discord-guild-1" in captured["body"]
+    assert b"hello world" in captured["body"]
+
+
+def test_forget_posts_dataset_to_forget_endpoint():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"status": "ok"})
+
+    adapter, client = _adapter(handler)
+    try:
+        run(adapter.forget(dataset="discord-guild-1"))
+    finally:
+        run(client.aclose())
+
+    assert captured["url"].endswith("/api/v1/forget")
+    assert captured["body"] == {"dataset": "discord-guild-1", "everything": False}
+
+
+def test_http_error_raises():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    adapter, client = _adapter(handler)
+    try:
+        raised = False
+        try:
+            run(adapter.forget(dataset="d"))
+        except httpx.HTTPStatusError:
+            raised = True
+    finally:
+        run(client.aclose())
+
+    assert raised

--- a/integrations/discord/tests/test_mapping.py
+++ b/integrations/discord/tests/test_mapping.py
@@ -1,0 +1,42 @@
+from cognee_integration_discord import mapping
+
+
+def test_dataset_and_session_naming():
+    assert mapping.dataset_for_guild(42) == "discord-guild-42"
+    assert mapping.session_for_channel(42, 7) == "discord-42-7"
+
+
+def test_message_url():
+    assert mapping.message_url(1, 2, 3) == "https://discord.com/channels/1/2/3"
+
+
+def test_format_ingest_text_has_provenance_header():
+    text = mapping.format_ingest_text("hello", "https://discord.com/channels/1/2/3", "alice")
+    assert text.startswith("[source] https://discord.com/channels/1/2/3 — alice")
+    assert "hello" in text
+
+
+def test_extract_citations_dedupes_and_limits():
+    snippets = [
+        "see https://discord.com/channels/1/2/3 and https://discord.com/channels/1/2/3",
+        "also https://discord.com/channels/1/2/9",
+        "no links here",
+    ]
+    assert mapping.extract_citations(snippets) == [
+        "https://discord.com/channels/1/2/3",
+        "https://discord.com/channels/1/2/9",
+    ]
+    # limit is honored
+    many = [f"https://discord.com/channels/1/2/{i}" for i in range(10)]
+    assert len(mapping.extract_citations(many, limit=3)) == 3
+
+
+def test_format_answer_without_citations_returns_answer_unchanged():
+    assert mapping.format_answer("just the answer", []) == "just the answer"
+
+
+def test_format_answer_with_citations_appends_sources():
+    out = mapping.format_answer("the answer", ["https://discord.com/channels/1/2/3"])
+    assert "the answer" in out
+    assert "**Sources:**" in out
+    assert "<https://discord.com/channels/1/2/3>" in out

--- a/integrations/discord/tests/test_service.py
+++ b/integrations/discord/tests/test_service.py
@@ -1,0 +1,105 @@
+import asyncio
+
+from cognee_integration_discord.adapter import ChatMemoryAdapter, RecallResult
+from cognee_integration_discord.service import MemoryService
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class FakeAdapter(ChatMemoryAdapter):
+    """Records calls and returns a canned recall result (no cognee needed)."""
+
+    def __init__(self, recall_result: RecallResult | None = None) -> None:
+        self.remembered: list[dict] = []
+        self.forgotten: list[dict] = []
+        self._recall_result = recall_result or RecallResult(answer="", sources=[])
+
+    async def remember(self, text, *, dataset, session, provenance=None):
+        self.remembered.append(
+            {"text": text, "dataset": dataset, "session": session, "provenance": provenance}
+        )
+
+    async def recall(self, query, *, dataset, session, top_k=5):
+        return self._recall_result
+
+    async def forget(self, *, dataset, everything=False):
+        self.forgotten.append({"dataset": dataset, "everything": everything})
+
+
+def test_disabled_channel_is_not_ingested():
+    adapter = FakeAdapter()
+    service = MemoryService(adapter)
+
+    stored = run(service.ingest_message("g", "c", "m", "alice", "hello"))
+
+    assert stored is False
+    assert adapter.remembered == []
+
+
+def test_enabled_channel_ingests_with_provenance_and_scoping():
+    adapter = FakeAdapter()
+    service = MemoryService(adapter)
+    service.enable_channel("g", "c")
+
+    stored = run(service.ingest_message("g", "c", "m", "alice", "hello world"))
+
+    assert stored is True
+    assert len(adapter.remembered) == 1
+    record = adapter.remembered[0]
+    assert record["dataset"] == "discord-guild-g"
+    assert record["session"] == "discord-g-c"
+    assert "https://discord.com/channels/g/c/m" in record["text"]
+    assert "alice" in record["text"]
+    assert "hello world" in record["text"]
+
+
+def test_blank_message_is_skipped_even_when_enabled():
+    adapter = FakeAdapter()
+    service = MemoryService(adapter)
+    service.enable_channel("g", "c")
+
+    assert run(service.ingest_message("g", "c", "m", "alice", "   ")) is False
+    assert adapter.remembered == []
+
+
+def test_disable_channel_stops_ingestion():
+    adapter = FakeAdapter()
+    service = MemoryService(adapter)
+    service.enable_channel("g", "c")
+    service.disable_channel("g", "c")
+
+    assert run(service.ingest_message("g", "c", "m", "alice", "hi")) is False
+
+
+def test_answer_includes_citations_from_recall():
+    snippet = "[source] https://discord.com/channels/1/2/3 — bob\nThe deploy runs at 5pm."
+    adapter = FakeAdapter(RecallResult(answer="The deploy runs at 5pm.", sources=[snippet]))
+    service = MemoryService(adapter)
+
+    result = run(service.answer("g", "c", "when is the deploy"))
+
+    assert result.found is True
+    assert "The deploy runs at 5pm." in result.text
+    assert "https://discord.com/channels/1/2/3" in result.text
+    assert "**Sources:**" in result.text
+
+
+def test_answer_with_empty_memory_reports_not_found():
+    adapter = FakeAdapter(RecallResult(answer="", sources=[]))
+    service = MemoryService(adapter)
+
+    result = run(service.answer("g", "c", "anything"))
+
+    assert result.found is False
+    assert "don't have anything" in result.text
+
+
+def test_forget_guild_targets_the_guild_dataset():
+    adapter = FakeAdapter()
+    service = MemoryService(adapter)
+
+    run(service.forget_guild("g"))
+
+    assert adapter.forgotten == [{"dataset": "discord-guild-g", "everything": False}]


### PR DESCRIPTION
## Summary

A Discord bot that gives community/support servers persistent memory backed by
cognee, with per-guild/per-channel isolation and citations back to source messages.

Refs #3611

## Memory model
- Server (guild) -> cognee dataset `discord-guild-<id>` (hard isolation)
- Channel/thread -> cognee session `discord-<guild>-<channel>`
- Message -> remembered document with a provenance header; recall cites the message link

## Commands
/cognee-enable, /cognee-disable (admin), /cognee-ask <q> (recall + Sources footer),
/cognee-forget (admin). Capture is opt-in per channel (privacy-first).

## Design
All memory logic sits behind a thin `ChatMemoryAdapter` (per #3608) so the bot
layer never calls cognee directly, and Discord/Slack/Telegram can share one model.
**Connection model: <in-process cognee SDK | HTTP to a running cognee server>.**

## Tests
mapping + service (fake adapter) [+ HTTP adapter via httpx.MockTransport].
No live bot or cognee instance needed.

<img width="690" height="212" alt="image" src="https://github.com/user-attachments/assets/2cdf3102-862e-44f3-bad0-dfb7194c8d6c" />
