### PR TITLE
feat: add improve as main way to sync sessions to graphs

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -140,13 +140,20 @@ in the launching shell, if your Claude Code version supports it).
 
 ## Session sync and watchers
 
-An idle watcher runs in the background for the lifetime of each launch. It polls activity every `COGNEE_IDLE_POLL` seconds and persists the session cache when the session has been quiet for `COGNEE_IDLE_THRESHOLD` seconds, then waits at least `COGNEE_IMPROVE_COOLDOWN` seconds before the next run.
+Session→graph sync runs through Cognee's session-aware `improve` endpoint: the server bridges the session from its own session cache (feedback weights, Q&A persist, compact trace-feedback persist, distillation, enrichment) instead of the plugin re-posting the full accumulated session text — which used to trigger a complete re-cognify of the whole transcript on every sync. Servers without session-aware improve automatically fall back to the legacy document bridge.
+
+An idle watcher runs in the background for the lifetime of each launch. It polls activity every `COGNEE_IDLE_POLL` seconds and fires an improve when the session has been quiet for `COGNEE_IDLE_THRESHOLD` seconds, then waits at least `COGNEE_IMPROVE_COOLDOWN` seconds before the next run. An automatic improve also fires every `COGNEE_AUTO_IMPROVE_EVERY` stored tool calls/stops.
 
 | Env var | Default | Effect |
 |---|---|---|
 | `COGNEE_IDLE_POLL` | `10` | Poll interval in seconds |
-| `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle sync fires |
-| `COGNEE_IMPROVE_COOLDOWN` | `120` | Minimum seconds between idle sync runs |
+| `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle improve fires |
+| `COGNEE_IMPROVE_COOLDOWN` | `600` | Minimum seconds between idle improve runs |
+| `COGNEE_AUTO_IMPROVE_EVERY` | `150` | Stored tool calls/stops between automatic improves (0 disables) |
+| `COGNEE_IMPROVE_SUBMIT_TIMEOUT` | `180` | Read timeout for the improve POST (distillation runs inside the request) |
+| `COGNEE_IMPROVE_POLL_DEADLINE` | `600` | Best-effort wait for cognify/memify completion after submit |
+| `COGNEE_IMPROVE_BUSY_DEADLINE` | `600` | How long to wait for a concurrent improve's session lock before giving up |
+| `COGNEE_IMPROVE_BUSY_RETRY_INTERVAL` | `15` | Seconds between re-submits while the session lock is held |
 
 Final sync on session end is triggered by the `SessionEnd` detached worker, with an exit watcher as fallback if the process exits without firing `SessionEnd`.
 
@@ -289,5 +296,8 @@ Config precedence:
 | local LLM | `LLM_API_KEY`, `LLM_MODEL` | unset | Required for local mode runtime |
 | demo auto-clear | `COGNEE_CLAUDE_CLEAR_AFTER_MESSAGE` | disabled | Clear transcript on Stop after capture |
 | idle watcher poll | `COGNEE_IDLE_POLL` | `10` | Idle watcher poll interval in seconds |
-| idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle sync fires |
-| idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `120` | Minimum seconds between idle sync runs |
+| idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle improve fires |
+| idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `600` | Minimum seconds between idle improve runs |
+| auto-improve threshold | `COGNEE_AUTO_IMPROVE_EVERY` | `150` | Stored tool calls/stops between automatic improves (0 disables) |
+| improve submit timeout | `COGNEE_IMPROVE_SUBMIT_TIMEOUT` | `180` | Read timeout for the improve POST |
+| improve poll deadline | `COGNEE_IMPROVE_POLL_DEADLINE` | `600` | Best-effort wait for pipeline completion after submit |

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1535,38 +1535,101 @@ def append_warmup_entry(dataset: str, session_id: str, entry: dict) -> None:
     _write_json_file(_bridge_file(session_id), cache)
 
 
-def drain_warmup_entries(dataset: str, session_id: str) -> int:
+_DRAIN_LOCK = _PLUGIN_DIR / "drain.lock"
+_DRAIN_LOCK_STALE_SECONDS = 60.0
+# Pause before the one in-place drain retry in run_session_improve: long enough
+# for a momentary server blip to pass, short enough not to hold up a sync.
+_DRAIN_RETRY_PAUSE_SECONDS = 2.0
+
+
+def _try_acquire_drain_lock() -> bool:
+    """Single-drainer guard: concurrent drains would double-replay entries into
+    the server cache and clobber each other's buffer write-backs."""
+    try:
+        _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        if _DRAIN_LOCK.exists():
+            try:
+                if time.time() - _DRAIN_LOCK.stat().st_mtime > _DRAIN_LOCK_STALE_SECONDS:
+                    _DRAIN_LOCK.unlink()
+            except FileNotFoundError:
+                pass
+        fd = os.open(str(_DRAIN_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.close(fd)
+        return True
+    except FileExistsError:
+        return False
+    except Exception as exc:
+        # Fail open: a rare double replay (deduped server-side per entry write)
+        # is better than a buffer that can never drain.
+        hook_log("drain_lock_error", {"error": str(exc)[:200]})
+        return True
+
+
+def _release_drain_lock() -> None:
+    try:
+        _DRAIN_LOCK.unlink()
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        hook_log("drain_lock_release_failed", {"error": str(exc)[:200]})
+
+
+def drain_warmup_entries(dataset: str, session_id: str) -> tuple:
     """Replay warmup-buffered entries into the server session cache, in order.
 
-    Returns the number of entries replayed. Stops at the first failure so the
-    unreplayed tail stays buffered for the next attempt (order preserved).
+    Returns ``(drained, remaining)``. Stops at the first replay failure so the
+    unreplayed tail stays buffered (order preserved). Guarded by a single-drainer
+    lock, and the buffer trim is computed against a FRESH re-read of the file so
+    entries appended while the replay was in flight are never lost — the replay
+    is N sequential HTTP calls, a wide window for concurrent async hooks.
     """
     if not dataset or not session_id:
-        return 0
+        return 0, 0
     path = _bridge_file(session_id)
-    cache = _load_json_file(path)
     key = _bridge_cache_key(dataset, session_id)
-    session_cache = cache.get(key) or {}
-    pending = list(session_cache.get("pending_entries") or [])
-    if not pending:
-        return 0
-    drained = 0
-    for entry in pending:
-        try:
-            remember_entry_via_http(dataset, session_id, entry)
-            drained += 1
-        except Exception as exc:
-            hook_log("warmup_drain_error", {"error": str(exc)[:200], "drained": drained})
-            break
-    if drained:
-        session_cache["pending_entries"] = pending[drained:]
-        cache[key] = session_cache
-        _write_json_file(path, cache)
-        hook_log(
-            "warmup_drained",
-            {"session": session_id, "count": drained, "left": len(pending) - drained},
-        )
-    return drained
+    snapshot = list((_load_json_file(path).get(key) or {}).get("pending_entries") or [])
+    if not snapshot:
+        return 0, 0
+    if not _try_acquire_drain_lock():
+        hook_log("warmup_drain_skipped_locked", {"session": session_id, "pending": len(snapshot)})
+        return 0, len(snapshot)
+    try:
+        drained = 0
+        for entry in snapshot:
+            try:
+                remember_entry_via_http(dataset, session_id, entry)
+                drained += 1
+            except Exception as exc:
+                hook_log("warmup_drain_error", {"error": str(exc)[:200], "drained": drained})
+                break
+        remaining = len(snapshot) - drained
+        if drained:
+            # Re-read before trimming: hooks may have appended new pending
+            # entries (or qa/trace mirror text) during the replay; writing back
+            # the stale snapshot would silently delete them.
+            cache = _load_json_file(path)
+            session_cache = cache.get(key) or {}
+            fresh = list(session_cache.get("pending_entries") or [])
+            if fresh[:drained] == snapshot[:drained]:
+                fresh = fresh[drained:]
+            else:
+                # Unexpected interleaving — remove the replayed entries by value.
+                for entry in snapshot[:drained]:
+                    try:
+                        fresh.remove(entry)
+                    except ValueError:
+                        pass
+            session_cache["pending_entries"] = fresh
+            cache[key] = session_cache
+            _write_json_file(path, cache)
+            remaining = len(fresh)
+            hook_log(
+                "warmup_drained",
+                {"session": session_id, "count": drained, "left": remaining},
+            )
+        return drained, remaining
+    finally:
+        _release_drain_lock()
 
 
 def improve_session_via_http(dataset: str, session_id: str, *, timeout: float = None) -> dict:
@@ -1639,7 +1702,12 @@ def run_session_improve(dataset: str, session_id: str) -> bool:
     base_url = _local_api_url()
     if not _backend_reachable(base_url):
         return False
-    drain_warmup_entries(dataset, session_id)
+    _, remaining = drain_warmup_entries(dataset, session_id)
+    if remaining:
+        # One bounded retry after a short pause: the tail usually failed on a
+        # momentary blip, and improve reads only what reached the server cache.
+        time.sleep(_DRAIN_RETRY_PAUSE_SECONDS)
+        _, remaining = drain_warmup_entries(dataset, session_id)
     if improve_unsupported(base_url):
         return persist_session_cache_to_graph_via_http(dataset, session_id)
     outcome = improve_session_via_http(dataset, session_id)
@@ -1668,4 +1736,19 @@ def run_session_improve(dataset: str, session_id: str) -> bool:
             "error": str(outcome.get("error") or "")[:120],
         },
     )
+    if remaining:
+        # Buffered entries never reached the server cache, so the improve above
+        # persisted an incomplete session. Partial persist beats none (hence the
+        # improve still ran), but report not-synced so the caller's retry loop
+        # re-drives the whole drain+improve — dedup makes the re-run cheap.
+        hook_log(
+            "improve_incomplete_drain",
+            {
+                "dataset": dataset,
+                "session": session_id,
+                "remaining": remaining,
+                "improve_ok": bool(outcome.get("ok")),
+            },
+        )
+        return False
     return bool(outcome.get("ok"))

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -52,7 +52,7 @@ SAVE_KINDS = ("prompt", "trace", "answer")
 _LOG_LINE_CAP = 600
 
 # Default auto-improve threshold (tool calls + stops). Env override.
-AUTO_IMPROVE_EVERY_DEFAULT = 30
+AUTO_IMPROVE_EVERY_DEFAULT = 150
 SYNC_LOCK_STALE_SECONDS = 15 * 60
 _DEFAULT_LOCAL_SERVICE_URL = "http://localhost:8011"
 
@@ -1481,3 +1481,191 @@ def persist_session_cache_to_graph_via_http(
             {"error": str(exc)[:200], "dataset": dataset, "session": session_id},
         )
         return False
+
+
+# --- Session improve (server-side session->graph bridge) ----------------------
+# The hooks write every turn into the SERVER session cache via /remember/entry,
+# so the server can bridge a session itself: POST /api/v1/improve runs feedback
+# weights, QA persist, trace-feedback persist, distillation, and enrichment over
+# that cache. This replaces the legacy full-document bridge above, which re-sent
+# the whole accumulated session text (raw tool outputs included) for a full
+# re-cognify on every sync. The legacy path is kept only as a fallback for
+# servers without session-aware improve.
+_IMPROVE_UNSUPPORTED_MARKER = _SHARED_PLUGIN_ROOT / "improve-unsupported.json"
+_IMPROVE_UNSUPPORTED_TTL_SECONDS = 24 * 3600
+
+
+def mark_improve_unsupported(base_url: str) -> None:
+    """Record that this server lacks the session-aware improve endpoint."""
+    _write_json_file(
+        _IMPROVE_UNSUPPORTED_MARKER,
+        {
+            "base_url": _normalize_service_url(base_url),
+            "marked_at": datetime.now(timezone.utc).timestamp(),
+        },
+    )
+
+
+def improve_unsupported(base_url: str) -> bool:
+    """True if this server recently rejected the improve endpoint (TTL-bounded)."""
+    data = _load_json_file(_IMPROVE_UNSUPPORTED_MARKER)
+    if not data:
+        return False
+    marked_url = _normalize_service_url(str(data.get("base_url") or ""))
+    if marked_url and marked_url != _normalize_service_url(base_url):
+        return False
+    marked_at = float(data.get("marked_at", 0) or 0)
+    return datetime.now(timezone.utc).timestamp() - marked_at < _IMPROVE_UNSUPPORTED_TTL_SECONDS
+
+
+def append_warmup_entry(dataset: str, session_id: str, entry: dict) -> None:
+    """Buffer a typed QA/trace entry while the server is still warming.
+
+    Per-turn stores go to the server session cache via /remember/entry; before
+    the server serves, those writes would be lost — and improve() bridges only
+    what the server cache holds. Buffered entries are replayed in order by
+    ``drain_warmup_entries`` once the server is ready.
+    """
+    if not dataset or not session_id or not isinstance(entry, dict):
+        return
+    cache = _load_json_file(_bridge_file(session_id))
+    key = _bridge_cache_key(dataset, session_id)
+    session_cache = cache.setdefault(key, {"qa": [], "trace": []})
+    session_cache.setdefault("pending_entries", []).append(entry)
+    _write_json_file(_bridge_file(session_id), cache)
+
+
+def drain_warmup_entries(dataset: str, session_id: str) -> int:
+    """Replay warmup-buffered entries into the server session cache, in order.
+
+    Returns the number of entries replayed. Stops at the first failure so the
+    unreplayed tail stays buffered for the next attempt (order preserved).
+    """
+    if not dataset or not session_id:
+        return 0
+    path = _bridge_file(session_id)
+    cache = _load_json_file(path)
+    key = _bridge_cache_key(dataset, session_id)
+    session_cache = cache.get(key) or {}
+    pending = list(session_cache.get("pending_entries") or [])
+    if not pending:
+        return 0
+    drained = 0
+    for entry in pending:
+        try:
+            remember_entry_via_http(dataset, session_id, entry)
+            drained += 1
+        except Exception as exc:
+            hook_log("warmup_drain_error", {"error": str(exc)[:200], "drained": drained})
+            break
+    if drained:
+        session_cache["pending_entries"] = pending[drained:]
+        cache[key] = session_cache
+        _write_json_file(path, cache)
+        hook_log(
+            "warmup_drained",
+            {"session": session_id, "count": drained, "left": len(pending) - drained},
+        )
+    return drained
+
+
+def improve_session_via_http(dataset: str, session_id: str, *, timeout: float = None) -> dict:
+    """Bridge one session into the graph via POST /api/v1/improve.
+
+    The server reads its own session cache (feedback weights, QA persist,
+    trace-feedback persist, distillation, enrichment), so no session text is
+    sent. ``run_in_background=true`` backgrounds the cognify-heavy pipelines,
+    but the agent-context and distillation stages still run inside the request,
+    so the submit timeout must stay generous — this must only ever be called
+    from detached workers/async hooks, never a synchronous hook window.
+
+    A 2xx submit counts as success: improve is idempotent (unchanged session
+    content dedups server-side by content hash, and a per-session improve lock
+    makes a concurrent run a no-op). The status poll afterwards is best-effort
+    observability and never turns a successful submit into a failure.
+    """
+    if not dataset or not session_id:
+        return {"ok": False, "error": "missing dataset/session"}
+    submit_timeout = (
+        timeout if timeout is not None else _float_env("COGNEE_IMPROVE_SUBMIT_TIMEOUT", 180.0)
+    )
+    try:
+        result = _json_http_request(
+            "/api/v1/improve",
+            {
+                "dataset_name": dataset,
+                "session_ids": [session_id],
+                "run_in_background": True,
+            },
+            timeout=submit_timeout,
+        )
+    except urllib.error.HTTPError as exc:
+        if exc.code in (404, 405, 422):
+            # Older server without session-aware improve: remember it (TTL'd)
+            # so callers fall back to the legacy document bridge.
+            mark_improve_unsupported(_local_api_url())
+            return {"ok": False, "unsupported": True, "status": exc.code}
+        return {"ok": False, "status": exc.code, "error": f"HTTP {exc.code}: {exc.reason}"}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {"ok": False, "status": 0, "error": str(exc)[:200]}
+
+    if isinstance(result, dict) and not result:
+        # The server's per-session improve lock skipped this run ({} response):
+        # another improve is in flight. That run may have extracted the session
+        # cache BEFORE the latest turns landed, so a skip is NOT success — the
+        # caller must retry once the lock frees.
+        return {"ok": False, "busy": True}
+
+    outcome = {"ok": True, "result": result if isinstance(result, dict) else {}}
+    poll_deadline = _float_env("COGNEE_IMPROVE_POLL_DEADLINE", 600.0)
+    dataset_id = ""
+    if isinstance(result, dict):
+        dataset_id = str(result.get("dataset_id") or "")
+    if dataset_id and poll_deadline > 0:
+        half = poll_deadline / 2
+        outcome["cognify_status"] = wait_for_cognify(dataset_id, deadline_seconds=half)
+        outcome["memify_status"] = wait_for_cognify(
+            dataset_id, deadline_seconds=half, pipeline="memify_pipeline"
+        )
+    return outcome
+
+
+def run_session_improve(dataset: str, session_id: str) -> bool:
+    """API-mode session->graph sync: drain warmup entries, then improve.
+
+    Falls back to the legacy full-document bridge when the server does not
+    support session-aware improve. Returns True when a sync ran successfully.
+    """
+    base_url = _local_api_url()
+    if not _backend_reachable(base_url):
+        return False
+    drain_warmup_entries(dataset, session_id)
+    if improve_unsupported(base_url):
+        return persist_session_cache_to_graph_via_http(dataset, session_id)
+    outcome = improve_session_via_http(dataset, session_id)
+    if outcome.get("unsupported"):
+        hook_log("improve_unsupported_fallback", {"dataset": dataset, "session": session_id})
+        return persist_session_cache_to_graph_via_http(dataset, session_id)
+    # Busy = another improve holds the session lock (e.g. an idle-watcher run
+    # racing the SessionEnd sync). That run's snapshot may predate the latest
+    # turns, so wait for the lock to free and re-submit; the retried improve
+    # dedups unchanged content server-side, so this never double-processes.
+    busy_deadline = time.monotonic() + _float_env("COGNEE_IMPROVE_BUSY_DEADLINE", 600.0)
+    busy_interval = max(0.1, _float_env("COGNEE_IMPROVE_BUSY_RETRY_INTERVAL", 15.0))
+    while outcome.get("busy") and time.monotonic() < busy_deadline:
+        hook_log("improve_busy_retry", {"dataset": dataset, "session": session_id})
+        time.sleep(busy_interval)
+        outcome = improve_session_via_http(dataset, session_id)
+    hook_log(
+        "improve_fired",
+        {
+            "dataset": dataset,
+            "session": session_id,
+            "ok": bool(outcome.get("ok")),
+            "busy": bool(outcome.get("busy")),
+            "cognify": str(outcome.get("cognify_status") or ""),
+            "memify": str(outcome.get("memify_status") or ""),
+            "error": str(outcome.get("error") or "")[:120],
+        },
+    )
+    return bool(outcome.get("ok"))

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -477,6 +477,59 @@ def _bridge_file(session_id: str = "") -> Path:
     return _BRIDGE_DIR / f"{_agent_session_scope(session_id)}.json"
 
 
+# Short mutex for read-modify-write of the per-session buffer file. Appends
+# from concurrent async hooks (and the drain's trim write-back) would otherwise
+# clobber each other: os.replace keeps the file valid but last-writer-wins,
+# silently dropping the other writer's entry. Critical sections are
+# milliseconds, so waiting is cheap.
+_BUFFER_LOCK = _PLUGIN_DIR / "buffer.lock"
+_BUFFER_LOCK_STALE_SECONDS = 15.0
+_BUFFER_LOCK_TIMEOUT_SECONDS = 1.0
+_BUFFER_LOCK_POLL_SECONDS = 0.02
+
+
+@contextmanager
+def _buffer_lock():
+    """Acquire the buffer-file mutex, waiting briefly; fail open on timeout.
+
+    Yields True when the lock was acquired. On timeout/error the caller
+    proceeds WITHOUT the lock — a rare lost update beats a hook that hangs.
+    """
+    deadline = time.monotonic() + _BUFFER_LOCK_TIMEOUT_SECONDS
+    acquired = False
+    while True:
+        try:
+            _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+            if _BUFFER_LOCK.exists():
+                try:
+                    if time.time() - _BUFFER_LOCK.stat().st_mtime > _BUFFER_LOCK_STALE_SECONDS:
+                        _BUFFER_LOCK.unlink()
+                except FileNotFoundError:
+                    pass
+            fd = os.open(str(_BUFFER_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.close(fd)
+            acquired = True
+            break
+        except FileExistsError:
+            if time.monotonic() >= deadline:
+                hook_log("buffer_lock_timeout", {})
+                break
+            time.sleep(_BUFFER_LOCK_POLL_SECONDS)
+        except Exception as exc:
+            hook_log("buffer_lock_error", {"error": str(exc)[:200]})
+            break
+    try:
+        yield acquired
+    finally:
+        if acquired:
+            try:
+                _BUFFER_LOCK.unlink()
+            except FileNotFoundError:
+                pass
+            except Exception as exc:
+                hook_log("buffer_lock_release_failed", {"error": str(exc)[:200]})
+
+
 def append_http_bridge_entry(
     dataset: str,
     session_id: str,
@@ -496,14 +549,15 @@ def append_http_bridge_entry(
     if not (question or answer or trace):
         return
 
-    cache = _load_json_file(_bridge_file(session_id))
-    key = _bridge_cache_key(dataset, session_id)
-    session_cache = cache.setdefault(key, {"qa": [], "trace": []})
-    if question or answer:
-        session_cache.setdefault("qa", []).append({"question": question, "answer": answer})
-    if trace:
-        session_cache.setdefault("trace", []).append(trace)
-    _write_json_file(_bridge_file(session_id), cache)
+    with _buffer_lock():
+        cache = _load_json_file(_bridge_file(session_id))
+        key = _bridge_cache_key(dataset, session_id)
+        session_cache = cache.setdefault(key, {"qa": [], "trace": []})
+        if question or answer:
+            session_cache.setdefault("qa", []).append({"question": question, "answer": answer})
+        if trace:
+            session_cache.setdefault("trace", []).append(trace)
+        _write_json_file(_bridge_file(session_id), cache)
 
 
 async def resolve_user(user_id: str):
@@ -1528,11 +1582,12 @@ def append_warmup_entry(dataset: str, session_id: str, entry: dict) -> None:
     """
     if not dataset or not session_id or not isinstance(entry, dict):
         return
-    cache = _load_json_file(_bridge_file(session_id))
-    key = _bridge_cache_key(dataset, session_id)
-    session_cache = cache.setdefault(key, {"qa": [], "trace": []})
-    session_cache.setdefault("pending_entries", []).append(entry)
-    _write_json_file(_bridge_file(session_id), cache)
+    with _buffer_lock():
+        cache = _load_json_file(_bridge_file(session_id))
+        key = _bridge_cache_key(dataset, session_id)
+        session_cache = cache.setdefault(key, {"qa": [], "trace": []})
+        session_cache.setdefault("pending_entries", []).append(entry)
+        _write_json_file(_bridge_file(session_id), cache)
 
 
 _DRAIN_LOCK = _PLUGIN_DIR / "drain.lock"
@@ -1604,24 +1659,25 @@ def drain_warmup_entries(dataset: str, session_id: str) -> tuple:
                 break
         remaining = len(snapshot) - drained
         if drained:
-            # Re-read before trimming: hooks may have appended new pending
-            # entries (or qa/trace mirror text) during the replay; writing back
-            # the stale snapshot would silently delete them.
-            cache = _load_json_file(path)
-            session_cache = cache.get(key) or {}
-            fresh = list(session_cache.get("pending_entries") or [])
-            if fresh[:drained] == snapshot[:drained]:
-                fresh = fresh[drained:]
-            else:
-                # Unexpected interleaving — remove the replayed entries by value.
-                for entry in snapshot[:drained]:
-                    try:
-                        fresh.remove(entry)
-                    except ValueError:
-                        pass
-            session_cache["pending_entries"] = fresh
-            cache[key] = session_cache
-            _write_json_file(path, cache)
+            # Re-read before trimming, under the buffer mutex: hooks may append
+            # new pending entries (or qa/trace mirror text) during the replay,
+            # and writing back a stale snapshot would silently delete them.
+            with _buffer_lock():
+                cache = _load_json_file(path)
+                session_cache = cache.get(key) or {}
+                fresh = list(session_cache.get("pending_entries") or [])
+                if fresh[:drained] == snapshot[:drained]:
+                    fresh = fresh[drained:]
+                else:
+                    # Unexpected interleaving — remove the replayed entries by value.
+                    for entry in snapshot[:drained]:
+                        try:
+                            fresh.remove(entry)
+                        except ValueError:
+                            pass
+                session_cache["pending_entries"] = fresh
+                cache[key] = session_cache
+                _write_json_file(path, cache)
             remaining = len(fresh)
             hook_log(
                 "warmup_drained",

--- a/integrations/claude-code/scripts/_recall_http.py
+++ b/integrations/claude-code/scripts/_recall_http.py
@@ -69,12 +69,6 @@ def _build_https_opener():
 _HTTPS_OPENER = _build_https_opener()
 
 
-def _is_local(url):
-    """True for a localhost/loopback target (where a cloud API key is meaningless)."""
-    host = (urllib.parse.urlparse(url).hostname or "").lower()
-    return host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
-
-
 def coerce_top_k(value, default=5):
     """Best-effort positive int; never raises (a bad value must not look like a server failure)."""
     try:
@@ -138,10 +132,10 @@ def do_recall(
     if context_profile:
         body["context_profile"] = context_profile
     headers = {"Content-Type": "application/json"}
-    # COGNEE_API_KEY is a *cloud* credential; the local single-user server needs no
-    # auth and ignores it. Only attach it for a remote/cloud target, so we don't send
-    # a meaningless (and confusing) cloud key to localhost.
-    if api_key and not _is_local(service_url):
+    # Always attach the key when present: cognee >=1.2.2 enforces auth on its
+    # API routes even on localhost (the local key is auto-minted at bootstrap),
+    # and a server running with auth disabled simply ignores the header.
+    if api_key:
         headers["X-Api-Key"] = api_key
 
     req = urllib.request.Request(

--- a/integrations/claude-code/scripts/_remember_http.py
+++ b/integrations/claude-code/scripts/_remember_http.py
@@ -31,12 +31,6 @@ import uuid
 UNREACHABLE = "UNREACHABLE"
 
 
-def _is_local(url):
-    """True for a localhost/loopback target (where a cloud API key is meaningless)."""
-    host = (urllib.parse.urlparse(url).hostname or "").lower()
-    return host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
-
-
 def _multipart_body(fields, files):
     boundary = f"----cogneeRemember{uuid.uuid4().hex}"
     chunks = []
@@ -135,7 +129,9 @@ def _poll_status(
         + "&pipeline=cognify_pipeline"
     )
     headers = {}
-    if api_key and not _is_local(service_url):
+    # Always attach the key when present: cognee >=1.2.2 enforces auth even on
+    # localhost; a server with auth disabled ignores the header.
+    if api_key:
         headers["X-Api-Key"] = api_key
     deadline = time.monotonic() + max(0.0, deadline_seconds)
     while True:
@@ -189,9 +185,10 @@ def do_remember(
         [("data", filename, content.encode("utf-8") if isinstance(content, str) else content)],
     )
     headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
-    # COGNEE_API_KEY is a cloud credential; local single-user servers need no
-    # auth and ignore it. Only attach it for a remote/cloud target.
-    if api_key and not _is_local(service_url):
+    # Always attach the key when present: cognee >=1.2.2 enforces auth on its
+    # API routes even on localhost (the local key is auto-minted at bootstrap),
+    # and a server running with auth disabled simply ignores the header.
+    if api_key:
         headers["X-Api-Key"] = api_key
 
     req = urllib.request.Request(url, data=body, headers=headers, method="POST")

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -388,6 +388,37 @@ async def sync_graph_context_to_session(dataset: str, session_id: str, user) -> 
     )
 
 
+async def improve_session_local(dataset: str, session_id: str, user) -> dict:
+    """Bridge one session into the graph via the SDK's session-aware improve.
+
+    ``cognee.improve(session_ids=[...])`` reads the session cache itself and
+    runs feedback weights, QA persist, trace-feedback persist (the compact
+    per-step feedback lines — not raw tool output), distillation, enrichment,
+    and (in foreground mode) the graph→session sync — so the explicit
+    persist+sync pair below is only kept as a fallback for older cognee
+    versions without session-aware improve.
+    """
+    if not session_id or not user:
+        return {"ok": False, "error": "missing session/user"}
+
+    import cognee
+
+    try:
+        result = await cognee.improve(
+            dataset,
+            session_ids=[session_id],
+            user=user,
+            run_in_background=False,
+        )
+        return {"ok": True, "result": result}
+    except TypeError as exc:
+        # Older cognee without session-aware improve: legacy persist + sync.
+        _config_log("improve_local_unsupported", {"error": str(exc)[:200]})
+        wrote = await persist_session_cache_to_graph(dataset, session_id, user)
+        graph_result = await sync_graph_context_to_session(dataset, session_id, user)
+        return {"ok": wrote, "legacy": True, "graph_synced": graph_result.get("synced", 0)}
+
+
 def _read_field(entry, field: str) -> str:
     if isinstance(entry, dict):
         return str(entry.get(field) or "")

--- a/integrations/claude-code/scripts/idle-watcher.py
+++ b/integrations/claude-code/scripts/idle-watcher.py
@@ -25,11 +25,11 @@ from pathlib import Path
 from typing import Optional
 
 # Tunable via env. Defaults chosen to avoid thrashing the LLM: 60s idle
-# threshold means you have to actively pause a full minute, and the 20s
-# bridge cooldown prevents back-to-back runs when activity is sporadic.
+# threshold means you have to actively pause a full minute, and the 10-minute
+# improve cooldown prevents back-to-back improve runs when activity is sporadic.
 POLL_SECONDS = float(os.environ.get("COGNEE_IDLE_POLL", "10"))
 IDLE_SECONDS = float(os.environ.get("COGNEE_IDLE_THRESHOLD", "60"))
-IMPROVE_COOLDOWN = float(os.environ.get("COGNEE_IMPROVE_COOLDOWN", "120"))
+IMPROVE_COOLDOWN = float(os.environ.get("COGNEE_IMPROVE_COOLDOWN", "600"))
 
 _PLUGIN_DIR = Path.home() / ".cognee-plugin" / "claude-code"
 _ACTIVITY = _PLUGIN_DIR / "activity.ts"
@@ -83,14 +83,14 @@ def _install_signal_handlers() -> None:
 
 
 async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
-    """Fire one session bridge cycle. Returns True on success."""
+    """Fire one session improve cycle. Returns True on success."""
     sys.path.insert(0, os.path.dirname(__file__))
     try:
         from _plugin_common import (  # type: ignore
             http_api_ready,
             load_resolved,
-            persist_session_cache_to_graph_via_http,
             resolve_user,
+            run_session_improve,
             set_session_key,
             sync_lock,
         )
@@ -99,6 +99,8 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
         if session_key:
             set_session_key(session_key)
         api_mode = http_api_ready()
+        # Server-side improve has its own per-session lock; only local SDK
+        # mode needs the cross-hook file lock.
         lock = nullcontext(True) if api_mode else sync_lock("idle-watcher")
     except Exception as exc:
         _log("sync_lock_import_error", error=str(exc)[:200])
@@ -115,17 +117,16 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
                 ensure_cognee_ready,
                 ensure_dataset_ready,
                 ensure_identity,
-                persist_session_cache_to_graph,
-                sync_graph_context_to_session,
+                improve_session_local,
             )
 
             if api_mode:
-                wrote = persist_session_cache_to_graph_via_http(dataset, session_id)
+                wrote = run_session_improve(dataset, session_id)
                 _log(
                     "session_bridge_done",
                     session=session_id,
                     dataset=dataset,
-                    via="http_remember",
+                    via="http_improve",
                     wrote=wrote,
                 )
                 return True
@@ -138,15 +139,14 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
             user = await resolve_user(user_id) if user_id else None
             if user:
                 await ensure_dataset_ready(dataset, user)
-                wrote = await persist_session_cache_to_graph(dataset, session_id, user)
-                graph_result = await sync_graph_context_to_session(dataset, session_id, user)
+                result = await improve_session_local(dataset, session_id, user)
                 _log(
                     "session_bridge_done",
                     session=session_id,
                     dataset=dataset,
                     user_id=str(user.id),
-                    wrote=wrote,
-                    graph_synced=graph_result.get("synced", 0),
+                    via="local_improve",
+                    ok=bool(result.get("ok")),
                 )
             return True
         except Exception as exc:

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -20,6 +20,7 @@ import time
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
+    drain_warmup_entries,
     get_session_key,
     hook_log,
     load_resolved,
@@ -35,7 +36,7 @@ from _plugin_common import (
     server_ready_hint,
     set_session_key,
 )
-from config import ensure_cognee_ready, get_session_id, load_config
+from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
 
 
 def _float_env(name: str, default: float) -> float:
@@ -176,9 +177,11 @@ async def _run(prompt: str) -> dict | None:
     # short /health probe and record the result. If still not ready, skip recall
     # entirely so the prompt is answered at full speed (memory turns on later).
     service_url = runtime.get("base_url", "")
+    just_became_ready = False
     if not server_ready_hint(service_url):
         if server_health_ok(service_url, timeout=_float_env("COGNEE_READY_PROBE_TIMEOUT", 1.0)):
             mark_server_ready(service_url)
+            just_became_ready = True
         else:
             hook_log("recall_skipped_warming", {"base_url": service_url})
             return None
@@ -190,6 +193,15 @@ async def _run(prompt: str) -> dict | None:
     if not session_id:
         hook_log("no_session_id", {"event": "context_lookup"})
         return None
+
+    if just_became_ready:
+        # First prompt after the server came up: replay any entries buffered
+        # while it was warming so the server session cache (which improve
+        # bridges from) holds the full session.
+        try:
+            drain_warmup_entries(get_dataset(config), session_id)
+        except Exception as exc:
+            hook_log("warmup_drain_failed", {"error": str(exc)[:200]})
 
     saves_last_turn = read_and_reset_save_counter(session_id)
 

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -94,7 +94,7 @@ _UV_BIN = _UV_DIR / ("uv.exe" if os.name == "nt" else "uv")
 _UV_PYTHON_DIR = _GLOBAL_STATE_DIR / "python"
 _UV_INSTALL_URL = "https://astral.sh/uv/install.sh"
 _PINNED_PYTHON = os.environ.get("COGNEE_PLUGIN_PYTHON", "") or "3.12"
-_PINNED_COGNEE_VERSION = "1.2.2.dev0"
+_PINNED_COGNEE_VERSION = "1.2.2"
 _INSTALL_TIMEOUT_SECONDS = float(os.environ.get("COGNEE_INSTALL_TIMEOUT", "") or 600.0)
 
 # Install single-flight. Distinct from the server boot lock (which is short, on

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -21,6 +21,7 @@ import sys
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
     append_http_bridge_entry,
+    append_warmup_entry,
     bump_save_counter,
     bump_turn_counter,
     get_session_key,
@@ -28,13 +29,13 @@ from _plugin_common import (
     http_api_ready,
     load_resolved,
     notify,
-    persist_session_cache_to_graph_via_http,
     pop_pending_prompt,
     quiet_hook_output,
     remember_entry_via_http,
     resolve_runtime_mode,
     resolve_session_key_from_payload,
     resolve_user,
+    run_session_improve,
     server_ready_hint,
     set_session_key,
     touch_activity,
@@ -44,9 +45,8 @@ from config import (
     ensure_dataset_ready,
     get_dataset,
     get_session_id,
+    improve_session_local,
     load_config,
-    persist_session_cache_to_graph,
-    sync_graph_context_to_session,
 )
 
 # Hard cap per field to avoid ballooning the cache with massive tool outputs.
@@ -56,33 +56,36 @@ _MAX_ASSISTANT_BYTES = 8000
 
 
 async def _fire_improve_background(dataset: str, session_id: str, user, reason: str) -> None:
-    """Fire-and-forget session bridge; failures are logged but never raised."""
+    """Fire-and-forget session improve; failures are logged but never raised.
+
+    The server bridges the session itself from its session cache (improve),
+    instead of the old client-side full-document re-post — see run_session_improve.
+    """
     try:
         if http_api_ready():
-            wrote = persist_session_cache_to_graph_via_http(dataset, session_id)
+            wrote = run_session_improve(dataset, session_id)
             hook_log(
-                "auto_bridge_fired",
-                {"reason": reason, "session": session_id, "via": "http_remember", "wrote": wrote},
+                "auto_improve_fired",
+                {"reason": reason, "session": session_id, "via": "http_improve", "wrote": wrote},
             )
             if wrote:
-                notify(f"session bridge persisted ({reason})")
+                notify(f"session improve submitted ({reason})")
             return
 
         await ensure_dataset_ready(dataset, user)
-        wrote = await persist_session_cache_to_graph(dataset, session_id, user)
-        graph_result = await sync_graph_context_to_session(dataset, session_id, user)
+        result = await improve_session_local(dataset, session_id, user)
         hook_log(
-            "auto_bridge_fired",
+            "auto_improve_fired",
             {
                 "reason": reason,
                 "session": session_id,
-                "wrote": wrote,
-                "graph_synced": graph_result.get("synced", 0),
+                "via": "local_improve",
+                "ok": bool(result.get("ok")),
             },
         )
-        notify(f"session bridge persisted ({reason})")
+        notify(f"session improve completed ({reason})")
     except Exception as exc:
-        hook_log("auto_bridge_error", {"reason": reason, "error": str(exc)[:200]})
+        hook_log("auto_improve_error", {"reason": reason, "error": str(exc)[:200]})
 
 
 def _truncate_str(value, cap: int) -> str:
@@ -171,22 +174,6 @@ async def _store_tool_call(payload: dict) -> None:
             "api_key_present": runtime.get("api_key_present", False),
         },
     )
-    if not server_ready_hint(runtime.get("base_url", "")):
-        # Server still warming: don't block the tool call and don't lose the
-        # trace. Mirror it into the local bridge shadow; the session->graph
-        # sync drains it once the server is ready.
-        trace_text = (
-            f"{tool_name} [{status}]\n"
-            f"Params: {json.dumps(params, ensure_ascii=False)}\n"
-            f"Return: {return_value}"
-        )
-        append_http_bridge_entry(dataset, session_id, trace=trace_text)
-        bump_save_counter(session_id, "trace")
-        hook_log("store_buffered_warming", {"hook": "tool", "tool": tool_name})
-        return
-    if not use_http:
-        await ensure_cognee_ready(config)
-
     entry = {
         "type": "trace",
         "origin_function": tool_name,
@@ -199,6 +186,24 @@ async def _store_tool_call(payload: dict) -> None:
         # LLM summary can flip this in a future config.
         "generate_feedback_with_llm": False,
     }
+
+    if not server_ready_hint(runtime.get("base_url", "")):
+        # Server still warming: don't block the tool call and don't lose the
+        # trace. Buffer the structured entry for a later /remember/entry replay
+        # (improve bridges only what the server session cache holds), and keep
+        # the legacy text mirror for the document-bridge fallback path.
+        append_warmup_entry(dataset, session_id, entry)
+        trace_text = (
+            f"{tool_name} [{status}]\n"
+            f"Params: {json.dumps(params, ensure_ascii=False)}\n"
+            f"Return: {return_value}"
+        )
+        append_http_bridge_entry(dataset, session_id, trace=trace_text)
+        bump_save_counter(session_id, "trace")
+        hook_log("store_buffered_warming", {"hook": "tool", "tool": tool_name})
+        return
+    if not use_http:
+        await ensure_cognee_ready(config)
 
     try:
         if use_http:
@@ -284,23 +289,6 @@ async def _store_assistant_stop(payload: dict) -> None:
             "api_key_present": runtime.get("api_key_present", False),
         },
     )
-    if not server_ready_hint(runtime.get("base_url", "")):
-        # Server still warming: buffer the prompt+answer into the local bridge
-        # shadow instead of dropping it; the session->graph sync drains it once
-        # the server is ready.
-        pending = pop_pending_prompt(session_id, turn_id=str(payload.get("turn_id") or ""))
-        append_http_bridge_entry(
-            dataset,
-            session_id,
-            question=pending.get("prompt", ""),
-            answer=msg,
-        )
-        bump_save_counter(session_id, "answer")
-        hook_log("store_buffered_warming", {"hook": "stop"})
-        return
-    if not use_http:
-        await ensure_cognee_ready(config)
-
     pending = pop_pending_prompt(session_id, turn_id=str(payload.get("turn_id") or ""))
 
     # Codex intentionally differs from Claude here: store one paired
@@ -312,6 +300,24 @@ async def _store_assistant_stop(payload: dict) -> None:
         "answer": msg,
         "context": pending.get("context", ""),
     }
+
+    if not server_ready_hint(runtime.get("base_url", "")):
+        # Server still warming: buffer the structured entry for a later
+        # /remember/entry replay (improve bridges only what the server session
+        # cache holds), and keep the legacy text mirror for the document-bridge
+        # fallback path.
+        append_warmup_entry(dataset, session_id, entry)
+        append_http_bridge_entry(
+            dataset,
+            session_id,
+            question=pending.get("prompt", ""),
+            answer=msg,
+        )
+        bump_save_counter(session_id, "answer")
+        hook_log("store_buffered_warming", {"hook": "stop"})
+        return
+    if not use_http:
+        await ensure_cognee_ready(config)
 
     try:
         if use_http:

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -242,7 +242,7 @@ def _load_resolved() -> tuple:
     )
 
 
-async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
+async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: bool = False):
     session_id, dataset, user_id, agent_session_name, was_registered, has_api_key, session_key = (
         _load_resolved()
     )
@@ -276,9 +276,12 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
                 hook_log("sync_no_target_sessions", {"dataset": dataset})
                 return
 
+            incomplete: list[str] = []
             if api_mode:
                 for sid in target_sessions:
                     wrote = run_session_improve(dataset, sid)
+                    if not wrote:
+                        incomplete.append(sid)
                     hook_log(
                         "sync_bridge_done",
                         {
@@ -293,6 +296,14 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
                         f"via=http_improve wrote={wrote}",
                         file=sys.stderr,
                     )
+                if strict and incomplete:
+                    # The detached final worker retries on exceptions only. This
+                    # is the session's LAST sync — an incomplete one (failed
+                    # improve or undelivered warmup entries) must re-drive the
+                    # whole drain+improve, not silently report success.
+                    raise RuntimeError(
+                        f"final session sync incomplete for: {', '.join(incomplete)}"
+                    )
                 return
 
             await ensure_cognee_ready(config)
@@ -300,6 +311,8 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
             await ensure_dataset_ready(dataset, user)
             for sid in target_sessions:
                 result = await improve_session_local(dataset, sid, user)
+                if not result.get("ok"):
+                    incomplete.append(sid)
                 hook_log(
                     "sync_bridge_done",
                     {
@@ -315,6 +328,8 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
                     f"via=local_improve ok={result.get('ok')}",
                     file=sys.stderr,
                 )
+            if strict and incomplete:
+                raise RuntimeError(f"final session sync incomplete for: {', '.join(incomplete)}")
     finally:
         if unregister_on_finish:
             if not (was_registered or has_api_key):
@@ -408,6 +423,9 @@ def main():
                 _sync(
                     stop_watcher=False,
                     unregister_on_finish=unregister_on_finish,
+                    # The detached-final run is the session's last sync: an
+                    # incomplete result raises so this loop retries it.
+                    strict=detached_final,
                 )
             )
             return

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -27,10 +27,10 @@ from _plugin_common import (
     hook_log,
     http_api_ready,
     load_resolved,
-    persist_session_cache_to_graph_via_http,
     resolve_session_key_from_payload,
     resolve_user,
     resolved_http_endpoint_auth,
+    run_session_improve,
     set_session_key,
     sync_lock,
     unregister_agent_via_http,
@@ -40,9 +40,8 @@ from config import (
     ensure_dataset_ready,
     get_dataset,
     get_session_id,
+    improve_session_local,
     load_config,
-    persist_session_cache_to_graph,
-    sync_graph_context_to_session,
 )
 
 _STATE_DIR = Path.home() / ".cognee-plugin" / "claude-code"
@@ -216,7 +215,10 @@ def _load_resolved() -> tuple:
             os.environ["COGNEE_USER_ID"] = str(data.get("user_id"))
         return (
             env_session_id or data.get("session_id", ""),
-            env_dataset or data.get("dataset", ""),
+            # load_resolved() carries no dataset key, so without the env
+            # override (only the exit watcher sets it) this must fall back to
+            # config, or the SessionEnd worker syncs with an empty dataset.
+            env_dataset or data.get("dataset", "") or get_dataset(load_config()),
             data.get("user_id", ""),
             env_agent_session_name or data.get("agent_session_name", ""),
             bool(data.get("registered", False)),
@@ -276,19 +278,19 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
 
             if api_mode:
                 for sid in target_sessions:
-                    wrote = persist_session_cache_to_graph_via_http(dataset, sid)
+                    wrote = run_session_improve(dataset, sid)
                     hook_log(
                         "sync_bridge_done",
                         {
                             "session": sid,
                             "dataset": dataset,
-                            "via": "http_remember",
+                            "via": "http_improve",
                             "wrote": wrote,
                         },
                     )
                     print(
                         f"cognee-sync: dataset={dataset} session={sid} "
-                        f"via=http_remember wrote={wrote}",
+                        f"via=http_improve wrote={wrote}",
                         file=sys.stderr,
                     )
                 return
@@ -297,21 +299,20 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
             user = await resolve_user(user_id)
             await ensure_dataset_ready(dataset, user)
             for sid in target_sessions:
-                wrote = await persist_session_cache_to_graph(dataset, sid, user)
-                graph_result = await sync_graph_context_to_session(dataset, sid, user)
+                result = await improve_session_local(dataset, sid, user)
                 hook_log(
                     "sync_bridge_done",
                     {
                         "session": sid,
                         "dataset": dataset,
                         "user_id": str(getattr(user, "id", "")),
-                        "wrote": wrote,
-                        "graph_synced": graph_result.get("synced", 0),
+                        "via": "local_improve",
+                        "ok": bool(result.get("ok")),
                     },
                 )
                 print(
-                    f"cognee-sync: dataset={dataset} session={sid} wrote={wrote} "
-                    f"graph_synced={graph_result.get('synced', 0)}",
+                    f"cognee-sync: dataset={dataset} session={sid} "
+                    f"via=local_improve ok={result.get('ok')}",
                     file=sys.stderr,
                 )
     finally:

--- a/integrations/claude-code/skills/cognee-sync/SKILL.md
+++ b/integrations/claude-code/skills/cognee-sync/SKILL.md
@@ -17,10 +17,13 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/sync-session-to-graph.py
 
 ## What this does
 
+Runs Cognee's session-aware `improve` for the current session (the server bridges the session from its own session cache — no session text is re-uploaded):
+
 1. **Apply feedback weights** -- session entries with feedback scores update graph node/edge weights
-2. **Persist session Q&A** -- cognifies session text into the permanent graph
-3. **Enrich triplets** -- extracts and indexes triplet embeddings for vector search
-4. **Sync graph to session** -- copies new graph relationships back into the session cache as a knowledge snapshot, so subsequent completions have instant access to the enriched graph context
+2. **Persist session Q&A** -- cognifies the session's question/answer turns into the permanent graph
+3. **Persist trace feedback** -- cognifies the compact per-step tool feedback lines (not raw tool output)
+4. **Distill lessons** -- curates gated session guidance into entity-anchored lessons in the graph
+5. **Enrich + sync back** -- runs graph enrichment and copies new graph relationships back into the session cache as a knowledge snapshot, so subsequent completions have instant access to the enriched graph context
 
 After this, session entries become searchable via `/cognee-memory:cognee-search`, and the graph knowledge is automatically included in session completion prompts.
 

--- a/integrations/claude-code/tests/test_improve_sync.py
+++ b/integrations/claude-code/tests/test_improve_sync.py
@@ -149,13 +149,24 @@ def test_improve_polls_when_dataset_id_present():
     assert res["memify_status"] == "completed"
 
 
-def _run_session_improve(improve_result, *, unsupported_marker=False):
-    """Drive run_session_improve with all seams mocked; return (result, calls)."""
+def _run_session_improve(improve_result, *, unsupported_marker=False, drain_results=None):
+    """Drive run_session_improve with all seams mocked; return (result, calls).
+
+    ``drain_results`` is an optional list of (drained, remaining) tuples returned
+    per drain call, defaulting to a clean (0, 0).
+    """
     calls = {"drain": 0, "improve": 0, "legacy": 0}
+
+    def _drain(d, s):
+        calls["drain"] += 1
+        if drain_results:
+            return drain_results[min(calls["drain"] - 1, len(drain_results) - 1)]
+        return (0, 0)
+
     saved = _with_seams(
         _local_api_url=lambda: "http://x",
         _backend_reachable=lambda url: True,
-        drain_warmup_entries=lambda d, s: calls.__setitem__("drain", calls["drain"] + 1) or 0,
+        drain_warmup_entries=_drain,
         improve_unsupported=lambda url: unsupported_marker,
         improve_session_via_http=lambda d, s, **k: (
             calls.__setitem__("improve", calls["improve"] + 1) or improve_result
@@ -164,6 +175,7 @@ def _run_session_improve(improve_result, *, unsupported_marker=False):
             calls.__setitem__("legacy", calls["legacy"] + 1) or True
         ),
         hook_log=lambda *a, **k: None,
+        _DRAIN_RETRY_PAUSE_SECONDS=0.0,
     )
     try:
         wrote = pc.run_session_improve("ds", "sid")
@@ -234,7 +246,7 @@ def test_run_session_improve_retries_busy_until_lock_frees():
     saved = _with_seams(
         _local_api_url=lambda: "http://x",
         _backend_reachable=lambda url: True,
-        drain_warmup_entries=lambda d, s: 0,
+        drain_warmup_entries=lambda d, s: (0, 0),
         improve_unsupported=lambda url: False,
         improve_session_via_http=_improve,
         hook_log=lambda *a, **k: None,
@@ -247,6 +259,32 @@ def test_run_session_improve_retries_busy_until_lock_frees():
 
     assert wrote is True
     assert calls["improve"] == 3
+
+
+def test_incomplete_drain_returns_false_but_improve_still_runs():
+    # Undelivered warmup entries mean the improve persisted an incomplete
+    # session: the improve must still run (partial persist beats none), but the
+    # sync must report failure so the caller's retry loop re-drives it.
+    wrote, calls = _run_session_improve({"ok": True}, drain_results=[(0, 3), (0, 3)])
+    assert wrote is False
+    assert calls["improve"] == 1  # improve ran despite the incomplete drain
+    assert calls["drain"] == 2  # one in-place retry happened
+    assert calls["legacy"] == 0
+
+
+def test_drain_retry_recovers_and_sync_succeeds():
+    # First drain fails on a blip, the in-place retry delivers the tail →
+    # the sync is complete and reports success.
+    wrote, calls = _run_session_improve({"ok": True}, drain_results=[(0, 3), (3, 0)])
+    assert wrote is True
+    assert calls["drain"] == 2
+    assert calls["improve"] == 1
+
+
+def test_clean_drain_skips_retry():
+    wrote, calls = _run_session_improve({"ok": True}, drain_results=[(2, 0)])
+    assert wrote is True
+    assert calls["drain"] == 1  # nothing remaining → no retry
 
 
 def test_run_session_improve_busy_deadline_gives_up():
@@ -263,7 +301,7 @@ def test_run_session_improve_busy_deadline_gives_up():
     saved = _with_seams(
         _local_api_url=lambda: "http://x",
         _backend_reachable=lambda url: True,
-        drain_warmup_entries=lambda d, s: 0,
+        drain_warmup_entries=lambda d, s: (0, 0),
         improve_unsupported=lambda url: False,
         improve_session_via_http=_always_busy,
         hook_log=lambda *a, **k: None,

--- a/integrations/claude-code/tests/test_improve_sync.py
+++ b/integrations/claude-code/tests/test_improve_sync.py
@@ -1,0 +1,292 @@
+"""Unit tests for the session->graph improve bridge
+(_plugin_common.improve_session_via_http and run_session_improve).
+
+Confirms the improve contract:
+  * the sync POSTs /api/v1/improve with {dataset_name, session_ids, run_in_background};
+  * a 2xx submit counts as success (improve is idempotent server-side);
+  * 404/405/422 marks the server improve-unsupported and falls back to the
+    legacy full-document bridge;
+  * warmup-buffered entries are drained before improve runs;
+  * a dataset_id in the response triggers best-effort cognify+memify polling.
+
+Run: python integrations/claude-code/tests/test_improve_sync.py (or via pytest).
+"""
+
+import json
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+
+class _Resp:
+    def __init__(self, body=b"{}", status=200):
+        self._body = body
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def _with_seams(**overrides):
+    """Return (saved, apply) helpers for attribute-patching pc seams."""
+    saved = {k: getattr(pc, k) for k in overrides}
+    for k, v in overrides.items():
+        setattr(pc, k, v)
+    return saved
+
+
+def _restore(saved):
+    for k, v in saved.items():
+        setattr(pc, k, v)
+
+
+def test_improve_posts_expected_json_payload():
+    captured = {}
+    orig = urllib.request.urlopen
+
+    def _fake(req, timeout=None):
+        captured["req"] = req
+        captured["timeout"] = timeout
+        return _Resp(b'{"status":"running"}')
+
+    urllib.request.urlopen = _fake
+    saved = _with_seams(_local_api_url=lambda: "http://x", _api_key=lambda: "k")
+    try:
+        res = pc.improve_session_via_http("ds", "sid")
+    finally:
+        _restore(saved)
+        urllib.request.urlopen = orig
+
+    assert res["ok"] is True
+    assert captured["req"].full_url.endswith("/api/v1/improve")
+    body = json.loads(captured["req"].data.decode("utf-8"))
+    assert body == {"dataset_name": "ds", "session_ids": ["sid"], "run_in_background": True}
+    # Distillation/agent-context run inside the request even in background
+    # mode, so the submit timeout must be generous (default 180s).
+    assert captured["timeout"] >= 60
+
+
+def test_improve_404_marks_unsupported():
+    marker_writes = {}
+    orig = urllib.request.urlopen
+
+    def _raise(req, timeout=None):
+        raise urllib.error.HTTPError("http://x", 404, "Not Found", {}, None)
+
+    urllib.request.urlopen = _raise
+    saved = _with_seams(
+        _local_api_url=lambda: "http://x",
+        _api_key=lambda: "k",
+        _write_json_file=lambda p, data: marker_writes.update({str(p): data}),
+    )
+    try:
+        res = pc.improve_session_via_http("ds", "sid")
+    finally:
+        _restore(saved)
+        urllib.request.urlopen = orig
+
+    assert res["ok"] is False
+    assert res["unsupported"] is True
+    assert any("improve-unsupported" in p for p in marker_writes)
+
+
+def test_improve_network_error_is_graceful():
+    orig = urllib.request.urlopen
+
+    def _raise(req, timeout=None):
+        raise urllib.error.URLError("connection refused")
+
+    urllib.request.urlopen = _raise
+    saved = _with_seams(_local_api_url=lambda: "http://x", _api_key=lambda: "k")
+    try:
+        res = pc.improve_session_via_http("ds", "sid")
+    finally:
+        _restore(saved)
+        urllib.request.urlopen = orig
+
+    assert res["ok"] is False
+    assert res["status"] == 0
+    assert "error" in res
+
+
+def test_improve_polls_when_dataset_id_present():
+    polled = []
+    orig = urllib.request.urlopen
+
+    def _fake(req, timeout=None):
+        return _Resp(b'{"status":"running","dataset_id":"d1"}')
+
+    def _wait(dataset_id, *, deadline_seconds, **kw):
+        polled.append(kw.get("pipeline", "cognify_pipeline"))
+        return "completed"
+
+    urllib.request.urlopen = _fake
+    saved = _with_seams(
+        _local_api_url=lambda: "http://x",
+        _api_key=lambda: "k",
+        wait_for_cognify=_wait,
+    )
+    try:
+        res = pc.improve_session_via_http("ds", "sid")
+    finally:
+        _restore(saved)
+        urllib.request.urlopen = orig
+
+    assert res["ok"] is True
+    assert polled == ["cognify_pipeline", "memify_pipeline"]
+    assert res["cognify_status"] == "completed"
+    assert res["memify_status"] == "completed"
+
+
+def _run_session_improve(improve_result, *, unsupported_marker=False):
+    """Drive run_session_improve with all seams mocked; return (result, calls)."""
+    calls = {"drain": 0, "improve": 0, "legacy": 0}
+    saved = _with_seams(
+        _local_api_url=lambda: "http://x",
+        _backend_reachable=lambda url: True,
+        drain_warmup_entries=lambda d, s: calls.__setitem__("drain", calls["drain"] + 1) or 0,
+        improve_unsupported=lambda url: unsupported_marker,
+        improve_session_via_http=lambda d, s, **k: (
+            calls.__setitem__("improve", calls["improve"] + 1) or improve_result
+        ),
+        persist_session_cache_to_graph_via_http=lambda d, s: (
+            calls.__setitem__("legacy", calls["legacy"] + 1) or True
+        ),
+        hook_log=lambda *a, **k: None,
+    )
+    try:
+        wrote = pc.run_session_improve("ds", "sid")
+    finally:
+        _restore(saved)
+    return wrote, calls
+
+
+def test_run_session_improve_happy_path_drains_then_improves():
+    wrote, calls = _run_session_improve({"ok": True})
+    assert wrote is True
+    assert calls == {"drain": 1, "improve": 1, "legacy": 0}
+
+
+def test_run_session_improve_falls_back_when_unsupported_response():
+    wrote, calls = _run_session_improve({"ok": False, "unsupported": True, "status": 404})
+    assert wrote is True
+    assert calls["improve"] == 1
+    assert calls["legacy"] == 1
+
+
+def test_run_session_improve_skips_improve_when_marker_set():
+    wrote, calls = _run_session_improve({"ok": True}, unsupported_marker=True)
+    assert wrote is True
+    assert calls["improve"] == 0  # marker short-circuits straight to legacy
+    assert calls["legacy"] == 1
+
+
+def test_run_session_improve_error_returns_false_without_legacy():
+    wrote, calls = _run_session_improve({"ok": False, "status": 500, "error": "boom"})
+    assert wrote is False
+    assert calls["legacy"] == 0  # a transient server error is not an unsupported server
+
+
+def test_improve_lock_skip_reports_busy():
+    # improve() returns {} when the per-session lock skips the run — the helper
+    # must surface that as busy, never as success.
+    orig = urllib.request.urlopen
+
+    def _fake(req, timeout=None):
+        return _Resp(b"{}")
+
+    urllib.request.urlopen = _fake
+    saved = _with_seams(_local_api_url=lambda: "http://x", _api_key=lambda: "k")
+    try:
+        res = pc.improve_session_via_http("ds", "sid")
+    finally:
+        _restore(saved)
+        urllib.request.urlopen = orig
+
+    assert res["ok"] is False
+    assert res["busy"] is True
+
+
+def test_run_session_improve_retries_busy_until_lock_frees():
+    # A lock-skipped improve may have snapshotted the cache before the latest
+    # turns — run_session_improve must re-submit until a run actually lands.
+    import os
+
+    results = [{"ok": False, "busy": True}, {"ok": False, "busy": True}, {"ok": True}]
+    calls = {"improve": 0}
+
+    def _improve(d, s, **k):
+        calls["improve"] += 1
+        return results[min(calls["improve"] - 1, len(results) - 1)]
+
+    os.environ["COGNEE_IMPROVE_BUSY_RETRY_INTERVAL"] = "0.1"
+    saved = _with_seams(
+        _local_api_url=lambda: "http://x",
+        _backend_reachable=lambda url: True,
+        drain_warmup_entries=lambda d, s: 0,
+        improve_unsupported=lambda url: False,
+        improve_session_via_http=_improve,
+        hook_log=lambda *a, **k: None,
+    )
+    try:
+        wrote = pc.run_session_improve("ds", "sid")
+    finally:
+        _restore(saved)
+        os.environ.pop("COGNEE_IMPROVE_BUSY_RETRY_INTERVAL", None)
+
+    assert wrote is True
+    assert calls["improve"] == 3
+
+
+def test_run_session_improve_busy_deadline_gives_up():
+    import os
+
+    calls = {"improve": 0}
+
+    def _always_busy(d, s, **k):
+        calls["improve"] += 1
+        return {"ok": False, "busy": True}
+
+    os.environ["COGNEE_IMPROVE_BUSY_RETRY_INTERVAL"] = "0.1"
+    os.environ["COGNEE_IMPROVE_BUSY_DEADLINE"] = "0.25"
+    saved = _with_seams(
+        _local_api_url=lambda: "http://x",
+        _backend_reachable=lambda url: True,
+        drain_warmup_entries=lambda d, s: 0,
+        improve_unsupported=lambda url: False,
+        improve_session_via_http=_always_busy,
+        hook_log=lambda *a, **k: None,
+    )
+    try:
+        wrote = pc.run_session_improve("ds", "sid")
+    finally:
+        _restore(saved)
+        os.environ.pop("COGNEE_IMPROVE_BUSY_RETRY_INTERVAL", None)
+        os.environ.pop("COGNEE_IMPROVE_BUSY_DEADLINE", None)
+
+    assert wrote is False  # still busy at deadline → reported as not-synced
+    assert calls["improve"] >= 2  # at least one retry happened
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/claude-code/tests/test_recall_http.py
+++ b/integrations/claude-code/tests/test_recall_http.py
@@ -115,21 +115,25 @@ def test_malformed_json_is_error_not_unreachable():
     assert out != rh.UNREACHABLE
 
 
-def test_no_cloud_key_sent_to_localhost():
+def test_api_key_sent_to_any_target():
     captured = {}
 
     def _capture(req, timeout=None):
         captured["xapikey"] = req.get_header("X-api-key")  # urllib title-cases header names
         return _Resp("[]")
 
-    # localhost target → cloud key must NOT be attached
-    rh.do_recall("http://localhost:8011", "cloud-key", "q", "", '["graph"]', "5", opener=_capture)
-    assert captured["xapikey"] is None
+    # localhost target → key IS attached (cognee >=1.2.2 enforces auth even on
+    # loopback; a server with auth disabled ignores the header)
+    rh.do_recall("http://localhost:8011", "local-key", "q", "", '["graph"]', "5", opener=_capture)
+    assert captured["xapikey"] == "local-key"
     # remote target → key IS attached
     rh.do_recall(
         "https://tenant.cognee.ai", "cloud-key", "q", "", '["graph"]', "5", opener=_capture
     )
     assert captured["xapikey"] == "cloud-key"
+    # no key configured → header omitted entirely
+    rh.do_recall("http://localhost:8011", "", "q", "", '["graph"]', "5", opener=_capture)
+    assert captured["xapikey"] is None
 
 
 def test_dataset_scoped_in_body():

--- a/integrations/claude-code/tests/test_sync_strict.py
+++ b/integrations/claude-code/tests/test_sync_strict.py
@@ -1,0 +1,109 @@
+"""Unit tests for sync-session-to-graph.py strict mode.
+
+The detached final-sync worker retries only on exceptions. Strict mode (used
+by that worker) makes an incomplete session sync raise so the retry loop
+re-drives the whole drain+improve, instead of silently reporting success on
+the session's LAST sync. Non-strict (manual /cognee-sync, mid-session) keeps
+the old log-and-return behavior.
+
+Run: python integrations/claude-code/tests/test_sync_strict.py (or via pytest).
+"""
+
+import asyncio
+import importlib.util
+import pathlib
+import sys
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+_spec = importlib.util.spec_from_file_location("sync_mod", _SCRIPTS / "sync-session-to-graph.py")
+m = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(m)
+
+
+def _stub(wrote, *, unregister_calls=None):
+    """Patch the module seams for one _sync run; return a restore fn."""
+    saved = {
+        k: getattr(m, k)
+        for k in (
+            "_load_resolved",
+            "load_config",
+            "http_api_ready",
+            "run_session_improve",
+            "unregister_agent_via_http",
+            "hook_log",
+        )
+    }
+    # (session_id, dataset, user_id, agent_session_name, was_registered, has_api_key, session_key)
+    m._load_resolved = lambda: ("sess1", "ds", "u1", "agent1", True, True, "key1")
+    m.load_config = lambda: {}
+    m.http_api_ready = lambda: True
+    m.run_session_improve = lambda d, s: wrote
+    m.unregister_agent_via_http = lambda **k: (
+        (unregister_calls.append(k) if unregister_calls is not None else None) or (True, 0)
+    )
+    m.hook_log = lambda *a, **k: None
+
+    def _restore():
+        for k, v in saved.items():
+            setattr(m, k, v)
+
+    return _restore
+
+
+def test_strict_raises_on_incomplete_sync():
+    restore = _stub(wrote=False)
+    try:
+        try:
+            asyncio.run(m._sync(stop_watcher=False, strict=True))
+            raise AssertionError("expected RuntimeError for incomplete strict sync")
+        except RuntimeError as exc:
+            assert "incomplete" in str(exc)
+    finally:
+        restore()
+
+
+def test_non_strict_does_not_raise():
+    restore = _stub(wrote=False)
+    try:
+        asyncio.run(m._sync(stop_watcher=False, strict=False))  # must not raise
+    finally:
+        restore()
+
+
+def test_strict_complete_sync_does_not_raise():
+    restore = _stub(wrote=True)
+    try:
+        asyncio.run(m._sync(stop_watcher=False, strict=True))  # must not raise
+    finally:
+        restore()
+
+
+def test_unregister_still_runs_when_strict_raises():
+    # The finally-block unregister must run even when strict mode raises, so a
+    # retried worker never leaves a dangling registration.
+    calls = []
+    restore = _stub(wrote=False, unregister_calls=calls)
+    try:
+        try:
+            asyncio.run(m._sync(stop_watcher=False, unregister_on_finish=True, strict=True))
+        except RuntimeError:
+            pass
+        assert len(calls) == 1
+        assert calls[0].get("agent_session_name") == "agent1"
+    finally:
+        restore()
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/claude-code/tests/test_warmup_drain.py
+++ b/integrations/claude-code/tests/test_warmup_drain.py
@@ -4,7 +4,10 @@
 Entries captured while the local server is still warming must be buffered as
 structured /remember/entry payloads and replayed IN ORDER once the server is
 ready, so the server-side session cache (which improve() bridges from) holds
-the complete session. A replay failure keeps the unreplayed tail buffered.
+the complete session. drain_warmup_entries returns (drained, remaining); a
+replay failure keeps the unreplayed tail buffered; the buffer trim is computed
+against a fresh re-read so entries appended during the replay survive; and a
+single-drainer lock prevents concurrent double-replays.
 
 Run: python integrations/claude-code/tests/test_warmup_drain.py (or via pytest).
 """
@@ -19,12 +22,13 @@ import _plugin_common as pc  # noqa: E402
 
 
 def _with_tmp_bridge(fn):
-    """Run fn() with the bridge file pointed at a temp path; return its result."""
-    saved = {k: getattr(pc, k) for k in ("_bridge_file", "hook_log")}
+    """Run fn() with the bridge file and drain lock pointed at temp paths."""
+    saved = {k: getattr(pc, k) for k in ("_bridge_file", "hook_log", "_DRAIN_LOCK")}
     with tempfile.TemporaryDirectory() as tmp:
         bridge = pathlib.Path(tmp) / "bridge_test.json"
         pc._bridge_file = lambda sid="": bridge
         pc.hook_log = lambda *a, **k: None
+        pc._DRAIN_LOCK = pathlib.Path(tmp) / "drain.lock"
         try:
             return fn()
         finally:
@@ -40,13 +44,13 @@ def test_append_and_drain_in_order():
         saved = pc.remember_entry_via_http
         pc.remember_entry_via_http = lambda d, s, entry, **k: replayed.append(entry) or {}
         try:
-            drained = pc.drain_warmup_entries("ds", "sid")
+            result = pc.drain_warmup_entries("ds", "sid")
         finally:
             pc.remember_entry_via_http = saved
-        return drained, replayed
+        return result, replayed
 
-    drained, replayed = _with_tmp_bridge(_run)
-    assert drained == 2
+    result, replayed = _with_tmp_bridge(_run)
+    assert result == (2, 0)
     assert [e["type"] for e in replayed] == ["trace", "qa"]
 
 
@@ -56,13 +60,13 @@ def test_drain_empty_buffer_is_noop():
         saved = pc.remember_entry_via_http
         pc.remember_entry_via_http = lambda *a, **k: calls.append(a) or {}
         try:
-            drained = pc.drain_warmup_entries("ds", "sid")
+            result = pc.drain_warmup_entries("ds", "sid")
         finally:
             pc.remember_entry_via_http = saved
-        return drained, calls
+        return result, calls
 
-    drained, calls = _with_tmp_bridge(_run)
-    assert drained == 0
+    result, calls = _with_tmp_bridge(_run)
+    assert result == (0, 0)
     assert calls == []
 
 
@@ -95,9 +99,60 @@ def test_partial_failure_keeps_tail_buffered():
         return first, second, replayed
 
     first, second, replayed = _with_tmp_bridge(_run)
-    assert first == 1
-    assert second == 2
+    assert first == (1, 2)
+    assert second == (2, 0)
     assert [e.get("origin_function") or e["type"] for e in replayed] == ["Read", "Edit", "qa"]
+
+
+def test_concurrent_append_during_drain_survives():
+    # An entry appended by a concurrent hook WHILE the replay is in flight must
+    # survive the buffer write-back (trim by fresh re-read, not stale snapshot).
+    def _run():
+        pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "A"})
+        pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "B"})
+        replayed = []
+
+        def _replay(dataset, session_id, entry, **k):
+            replayed.append(entry)
+            if len(replayed) == 1:
+                pc.append_warmup_entry(
+                    "ds", "sid", {"type": "qa", "question": "new", "answer": "x"}
+                )
+            return {}
+
+        saved = pc.remember_entry_via_http
+        pc.remember_entry_via_http = _replay
+        try:
+            result = pc.drain_warmup_entries("ds", "sid")
+        finally:
+            pc.remember_entry_via_http = saved
+        cache = pc._load_json_file(pc._bridge_file("sid"))
+        left = (cache.get(pc._bridge_cache_key("ds", "sid")) or {}).get("pending_entries")
+        return result, left
+
+    result, left = _with_tmp_bridge(_run)
+    assert result == (2, 1)  # both originals replayed; the mid-drain arrival remains
+    assert left == [{"type": "qa", "question": "new", "answer": "x"}]
+
+
+def test_drain_skipped_when_lock_busy():
+    def _run():
+        pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "Bash"})
+        calls = []
+        saved_http = pc.remember_entry_via_http
+        saved_lock = pc._try_acquire_drain_lock
+        pc.remember_entry_via_http = lambda *a, **k: calls.append(a) or {}
+        pc._try_acquire_drain_lock = lambda: False
+        try:
+            result = pc.drain_warmup_entries("ds", "sid")
+        finally:
+            pc.remember_entry_via_http = saved_http
+            pc._try_acquire_drain_lock = saved_lock
+        return result, calls
+
+    result, calls = _with_tmp_bridge(_run)
+    assert result == (0, 1)  # skipped, nothing replayed, entry still pending
+    assert calls == []
 
 
 def test_drain_leaves_legacy_shadow_untouched():

--- a/integrations/claude-code/tests/test_warmup_drain.py
+++ b/integrations/claude-code/tests/test_warmup_drain.py
@@ -1,0 +1,132 @@
+"""Unit tests for the warmup entry buffer
+(_plugin_common.append_warmup_entry and drain_warmup_entries).
+
+Entries captured while the local server is still warming must be buffered as
+structured /remember/entry payloads and replayed IN ORDER once the server is
+ready, so the server-side session cache (which improve() bridges from) holds
+the complete session. A replay failure keeps the unreplayed tail buffered.
+
+Run: python integrations/claude-code/tests/test_warmup_drain.py (or via pytest).
+"""
+
+import pathlib
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+
+def _with_tmp_bridge(fn):
+    """Run fn() with the bridge file pointed at a temp path; return its result."""
+    saved = {k: getattr(pc, k) for k in ("_bridge_file", "hook_log")}
+    with tempfile.TemporaryDirectory() as tmp:
+        bridge = pathlib.Path(tmp) / "bridge_test.json"
+        pc._bridge_file = lambda sid="": bridge
+        pc.hook_log = lambda *a, **k: None
+        try:
+            return fn()
+        finally:
+            for k, v in saved.items():
+                setattr(pc, k, v)
+
+
+def test_append_and_drain_in_order():
+    def _run():
+        replayed = []
+        pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "Bash"})
+        pc.append_warmup_entry("ds", "sid", {"type": "qa", "question": "q", "answer": "a"})
+        saved = pc.remember_entry_via_http
+        pc.remember_entry_via_http = lambda d, s, entry, **k: replayed.append(entry) or {}
+        try:
+            drained = pc.drain_warmup_entries("ds", "sid")
+        finally:
+            pc.remember_entry_via_http = saved
+        return drained, replayed
+
+    drained, replayed = _with_tmp_bridge(_run)
+    assert drained == 2
+    assert [e["type"] for e in replayed] == ["trace", "qa"]
+
+
+def test_drain_empty_buffer_is_noop():
+    def _run():
+        calls = []
+        saved = pc.remember_entry_via_http
+        pc.remember_entry_via_http = lambda *a, **k: calls.append(a) or {}
+        try:
+            drained = pc.drain_warmup_entries("ds", "sid")
+        finally:
+            pc.remember_entry_via_http = saved
+        return drained, calls
+
+    drained, calls = _with_tmp_bridge(_run)
+    assert drained == 0
+    assert calls == []
+
+
+def test_partial_failure_keeps_tail_buffered():
+    def _run():
+        replayed = []
+
+        def _flaky(dataset, session_id, entry, **k):
+            if len(replayed) >= 1:
+                raise OSError("server went away")
+            replayed.append(entry)
+            return {}
+
+        pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "Read"})
+        pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "Edit"})
+        pc.append_warmup_entry("ds", "sid", {"type": "qa", "question": "q", "answer": "a"})
+        saved = pc.remember_entry_via_http
+        pc.remember_entry_via_http = _flaky
+        try:
+            first = pc.drain_warmup_entries("ds", "sid")
+        finally:
+            pc.remember_entry_via_http = saved
+
+        # Second drain replays the surviving tail, in order.
+        pc.remember_entry_via_http = lambda d, s, entry, **k: replayed.append(entry) or {}
+        try:
+            second = pc.drain_warmup_entries("ds", "sid")
+        finally:
+            pc.remember_entry_via_http = saved
+        return first, second, replayed
+
+    first, second, replayed = _with_tmp_bridge(_run)
+    assert first == 1
+    assert second == 2
+    assert [e.get("origin_function") or e["type"] for e in replayed] == ["Read", "Edit", "qa"]
+
+
+def test_drain_leaves_legacy_shadow_untouched():
+    # The qa/trace text mirrors (legacy document-bridge data) must survive a drain.
+    def _run():
+        pc.append_http_bridge_entry("ds", "sid", trace="Bash [success]")
+        pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "Bash"})
+        saved = pc.remember_entry_via_http
+        pc.remember_entry_via_http = lambda *a, **k: {}
+        try:
+            pc.drain_warmup_entries("ds", "sid")
+        finally:
+            pc.remember_entry_via_http = saved
+        cache = pc._load_json_file(pc._bridge_file("sid"))
+        return cache.get(pc._bridge_cache_key("ds", "sid"), {})
+
+    session_cache = _with_tmp_bridge(_run)
+    assert session_cache.get("trace") == ["Bash [success]"]
+    assert session_cache.get("pending_entries") == []
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/claude-code/tests/test_warmup_drain.py
+++ b/integrations/claude-code/tests/test_warmup_drain.py
@@ -22,13 +22,14 @@ import _plugin_common as pc  # noqa: E402
 
 
 def _with_tmp_bridge(fn):
-    """Run fn() with the bridge file and drain lock pointed at temp paths."""
-    saved = {k: getattr(pc, k) for k in ("_bridge_file", "hook_log", "_DRAIN_LOCK")}
+    """Run fn() with the bridge file and both locks pointed at temp paths."""
+    saved = {k: getattr(pc, k) for k in ("_bridge_file", "hook_log", "_DRAIN_LOCK", "_BUFFER_LOCK")}
     with tempfile.TemporaryDirectory() as tmp:
         bridge = pathlib.Path(tmp) / "bridge_test.json"
         pc._bridge_file = lambda sid="": bridge
         pc.hook_log = lambda *a, **k: None
         pc._DRAIN_LOCK = pathlib.Path(tmp) / "drain.lock"
+        pc._BUFFER_LOCK = pathlib.Path(tmp) / "buffer.lock"
         try:
             return fn()
         finally:
@@ -153,6 +154,49 @@ def test_drain_skipped_when_lock_busy():
     result, calls = _with_tmp_bridge(_run)
     assert result == (0, 1)  # skipped, nothing replayed, entry still pending
     assert calls == []
+
+
+def test_concurrent_appends_do_not_lose_entries():
+    # Two async hooks appending at the same moment must both land: the buffer
+    # mutex serializes the read-modify-write, so the last writer no longer
+    # clobbers the other's entry.
+    import concurrent.futures
+
+    def _run():
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as ex:
+            list(
+                ex.map(
+                    lambda i: pc.append_warmup_entry(
+                        "ds", "sid", {"type": "trace", "origin_function": f"tool{i}"}
+                    ),
+                    range(8),
+                )
+            )
+        cache = pc._load_json_file(pc._bridge_file("sid"))
+        return (cache.get(pc._bridge_cache_key("ds", "sid")) or {}).get("pending_entries") or []
+
+    entries = _with_tmp_bridge(_run)
+    assert sorted(e["origin_function"] for e in entries) == [f"tool{i}" for i in range(8)]
+
+
+def test_append_fails_open_when_lock_held():
+    # A wedged lock must never make a hook hang or drop the entry: after the
+    # short wait the append proceeds without the lock.
+    def _run():
+        saved_timeout = pc._BUFFER_LOCK_TIMEOUT_SECONDS
+        pc._BUFFER_LOCK_TIMEOUT_SECONDS = 0.05
+        pc._BUFFER_LOCK.parent.mkdir(parents=True, exist_ok=True)
+        pc._BUFFER_LOCK.write_text("held")  # fresh lock held by someone else
+        try:
+            pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "X"})
+        finally:
+            pc._BUFFER_LOCK_TIMEOUT_SECONDS = saved_timeout
+            pc._BUFFER_LOCK.unlink()
+        cache = pc._load_json_file(pc._bridge_file("sid"))
+        return (cache.get(pc._bridge_cache_key("ds", "sid")) or {}).get("pending_entries")
+
+    entries = _with_tmp_bridge(_run)
+    assert entries and entries[0]["origin_function"] == "X"
 
 
 def test_drain_leaves_legacy_shadow_untouched():

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -132,13 +132,19 @@ Data added outside of Claude to the dataset (via SDK or the server for example) 
 
 ## Session sync and watchers
 
-An idle watcher runs in the background for the lifetime of each launch. It polls activity every `COGNEE_IDLE_POLL` seconds and persists the session cache when the session has been quiet for `COGNEE_IDLE_THRESHOLD` seconds, then waits at least `COGNEE_IMPROVE_COOLDOWN` seconds before the next run.
+Session→graph sync runs through Cognee's session-aware `improve` endpoint: the server bridges the session from its own session cache (feedback weights, Q&A persist, compact trace-feedback persist, distillation, enrichment) instead of the plugin re-posting the full accumulated session text — which used to trigger a complete re-cognify of the whole transcript on every sync. Servers without session-aware improve automatically fall back to the legacy document bridge.
+
+An idle watcher runs in the background for the lifetime of each launch. It polls activity every `COGNEE_IDLE_POLL` seconds and fires an improve when the session has been quiet for `COGNEE_IDLE_THRESHOLD` seconds, then waits at least `COGNEE_IMPROVE_COOLDOWN` seconds before the next run. An automatic improve also fires every `COGNEE_AUTO_IMPROVE_EVERY` stored tool calls/stops.
 
 | Env var | Default | Effect |
 |---|---|---|
 | `COGNEE_IDLE_POLL` | `10` | Poll interval in seconds |
-| `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle sync fires |
-| `COGNEE_IMPROVE_COOLDOWN` | `120` | Minimum seconds between idle sync runs |
+| `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle improve fires |
+| `COGNEE_IMPROVE_COOLDOWN` | `600` | Minimum seconds between idle improve runs |
+| `COGNEE_AUTO_IMPROVE_EVERY` | `150` | Stored tool calls/stops between automatic improves (0 disables) |
+| `COGNEE_IMPROVE_SUBMIT_TIMEOUT` | `180` | Read timeout for the improve POST (distillation runs inside the request) |
+| `COGNEE_IMPROVE_BUSY_DEADLINE` | `600` | How long to wait for a concurrent improve's session lock before giving up |
+| `COGNEE_IMPROVE_BUSY_RETRY_INTERVAL` | `15` | Seconds between re-submits while the session lock is held |
 
 Final sync on session end is triggered by the `SessionEnd` detached worker, with an exit watcher as fallback if the process exits without firing `SessionEnd`.
 
@@ -210,8 +216,10 @@ Config precedence:
 | local URL override | `COGNEE_LOCAL_API_URL` | `http://localhost:8011` | Local API base URL |
 | local LLM | `LLM_API_KEY`, `LLM_MODEL` | unset | Required for local mode runtime |
 | idle watcher poll | `COGNEE_IDLE_POLL` | `10` | Idle watcher poll interval in seconds |
-| idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle sync fires |
-| idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `120` | Minimum seconds between idle sync runs |
+| idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle improve fires |
+| idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `600` | Minimum seconds between idle improve runs |
+| auto-improve threshold | `COGNEE_AUTO_IMPROVE_EVERY` | `150` | Stored tool calls/stops between automatic improves (0 disables) |
+| improve submit timeout | `COGNEE_IMPROVE_SUBMIT_TIMEOUT` | `180` | Read timeout for the improve POST |
 
 ## Troubleshooting
 

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -1350,38 +1350,101 @@ def append_warmup_entry(dataset: str, session_id: str, entry: dict) -> None:
     _write_json_file(_bridge_file(session_id), cache)
 
 
-def drain_warmup_entries(dataset: str, session_id: str) -> int:
+_DRAIN_LOCK = _PLUGIN_DIR / "drain.lock"
+_DRAIN_LOCK_STALE_SECONDS = 60.0
+# Pause before the one in-place drain retry in run_session_improve: long enough
+# for a momentary server blip to pass, short enough not to hold up a sync.
+_DRAIN_RETRY_PAUSE_SECONDS = 2.0
+
+
+def _try_acquire_drain_lock() -> bool:
+    """Single-drainer guard: concurrent drains would double-replay entries into
+    the server cache and clobber each other's buffer write-backs."""
+    try:
+        _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+        if _DRAIN_LOCK.exists():
+            try:
+                if time.time() - _DRAIN_LOCK.stat().st_mtime > _DRAIN_LOCK_STALE_SECONDS:
+                    _DRAIN_LOCK.unlink()
+            except FileNotFoundError:
+                pass
+        fd = os.open(str(_DRAIN_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.close(fd)
+        return True
+    except FileExistsError:
+        return False
+    except Exception as exc:
+        # Fail open: a rare double replay (deduped server-side per entry write)
+        # is better than a buffer that can never drain.
+        hook_log("drain_lock_error", {"error": str(exc)[:200]})
+        return True
+
+
+def _release_drain_lock() -> None:
+    try:
+        _DRAIN_LOCK.unlink()
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        hook_log("drain_lock_release_failed", {"error": str(exc)[:200]})
+
+
+def drain_warmup_entries(dataset: str, session_id: str) -> tuple:
     """Replay warmup-buffered entries into the server session cache, in order.
 
-    Returns the number of entries replayed. Stops at the first failure so the
-    unreplayed tail stays buffered for the next attempt (order preserved).
+    Returns ``(drained, remaining)``. Stops at the first replay failure so the
+    unreplayed tail stays buffered (order preserved). Guarded by a single-drainer
+    lock, and the buffer trim is computed against a FRESH re-read of the file so
+    entries appended while the replay was in flight are never lost — the replay
+    is N sequential HTTP calls, a wide window for concurrent async hooks.
     """
     if not dataset or not session_id:
-        return 0
+        return 0, 0
     path = _bridge_file(session_id)
-    cache = _load_json_file(path)
     key = _bridge_cache_key(dataset, session_id)
-    session_cache = cache.get(key) or {}
-    pending = list(session_cache.get("pending_entries") or [])
-    if not pending:
-        return 0
-    drained = 0
-    for entry in pending:
-        try:
-            remember_entry_via_http(dataset, session_id, entry)
-            drained += 1
-        except Exception as exc:
-            hook_log("warmup_drain_error", {"error": str(exc)[:200], "drained": drained})
-            break
-    if drained:
-        session_cache["pending_entries"] = pending[drained:]
-        cache[key] = session_cache
-        _write_json_file(path, cache)
-        hook_log(
-            "warmup_drained",
-            {"session": session_id, "count": drained, "left": len(pending) - drained},
-        )
-    return drained
+    snapshot = list((_load_json_file(path).get(key) or {}).get("pending_entries") or [])
+    if not snapshot:
+        return 0, 0
+    if not _try_acquire_drain_lock():
+        hook_log("warmup_drain_skipped_locked", {"session": session_id, "pending": len(snapshot)})
+        return 0, len(snapshot)
+    try:
+        drained = 0
+        for entry in snapshot:
+            try:
+                remember_entry_via_http(dataset, session_id, entry)
+                drained += 1
+            except Exception as exc:
+                hook_log("warmup_drain_error", {"error": str(exc)[:200], "drained": drained})
+                break
+        remaining = len(snapshot) - drained
+        if drained:
+            # Re-read before trimming: hooks may have appended new pending
+            # entries (or qa/trace mirror text) during the replay; writing back
+            # the stale snapshot would silently delete them.
+            cache = _load_json_file(path)
+            session_cache = cache.get(key) or {}
+            fresh = list(session_cache.get("pending_entries") or [])
+            if fresh[:drained] == snapshot[:drained]:
+                fresh = fresh[drained:]
+            else:
+                # Unexpected interleaving — remove the replayed entries by value.
+                for entry in snapshot[:drained]:
+                    try:
+                        fresh.remove(entry)
+                    except ValueError:
+                        pass
+            session_cache["pending_entries"] = fresh
+            cache[key] = session_cache
+            _write_json_file(path, cache)
+            remaining = len(fresh)
+            hook_log(
+                "warmup_drained",
+                {"session": session_id, "count": drained, "left": remaining},
+            )
+        return drained, remaining
+    finally:
+        _release_drain_lock()
 
 
 def improve_session_via_http(dataset: str, session_id: str, *, timeout: float = None) -> dict:
@@ -1440,7 +1503,12 @@ def run_session_improve(dataset: str, session_id: str) -> bool:
     base_url = _local_api_url()
     if not _backend_reachable(base_url):
         return False
-    drain_warmup_entries(dataset, session_id)
+    _, remaining = drain_warmup_entries(dataset, session_id)
+    if remaining:
+        # One bounded retry after a short pause: the tail usually failed on a
+        # momentary blip, and improve reads only what reached the server cache.
+        time.sleep(_DRAIN_RETRY_PAUSE_SECONDS)
+        _, remaining = drain_warmup_entries(dataset, session_id)
     if improve_unsupported(base_url):
         return persist_session_cache_to_graph_via_http(dataset, session_id)
     outcome = improve_session_via_http(dataset, session_id)
@@ -1467,4 +1535,19 @@ def run_session_improve(dataset: str, session_id: str) -> bool:
             "error": str(outcome.get("error") or "")[:120],
         },
     )
+    if remaining:
+        # Buffered entries never reached the server cache, so the improve above
+        # persisted an incomplete session. Partial persist beats none (hence the
+        # improve still ran), but report not-synced so the caller's retry loop
+        # re-drives the whole drain+improve — dedup makes the re-run cheap.
+        hook_log(
+            "improve_incomplete_drain",
+            {
+                "dataset": dataset,
+                "session": session_id,
+                "remaining": remaining,
+                "improve_ok": bool(outcome.get("ok")),
+            },
+        )
+        return False
     return bool(outcome.get("ok"))

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -51,7 +52,7 @@ SAVE_KINDS = ("prompt", "trace", "answer")
 _LOG_LINE_CAP = 600
 
 # Default auto-improve threshold (tool calls + stops). Env override.
-AUTO_IMPROVE_EVERY_DEFAULT = 30
+AUTO_IMPROVE_EVERY_DEFAULT = 150
 SYNC_LOCK_STALE_SECONDS = 15 * 60
 _DEFAULT_LOCAL_SERVICE_URL = "http://localhost:8011"
 
@@ -1283,3 +1284,187 @@ def persist_session_cache_to_graph_via_http(
             {"error": str(exc)[:200], "dataset": dataset, "session": session_id},
         )
         return False
+
+
+# --- Session improve (server-side session->graph bridge) ----------------------
+# The hooks write every turn into the SERVER session cache via /remember/entry,
+# so the server can bridge a session itself: POST /api/v1/improve runs feedback
+# weights, QA persist, trace-feedback persist, distillation, and enrichment over
+# that cache. This replaces the legacy full-document bridge above, which re-sent
+# the whole accumulated session text (raw tool outputs included) for a full
+# re-cognify on every sync. The legacy path is kept only as a fallback for
+# servers without session-aware improve.
+_IMPROVE_UNSUPPORTED_MARKER = _SHARED_PLUGIN_ROOT / "improve-unsupported.json"
+_IMPROVE_UNSUPPORTED_TTL_SECONDS = 24 * 3600
+
+
+def _improve_float_env(name: str, default: float) -> float:
+    try:
+        raw = os.environ.get(name, "").strip()
+        return float(raw) if raw else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _improve_submit_timeout() -> float:
+    return _improve_float_env("COGNEE_IMPROVE_SUBMIT_TIMEOUT", 180.0)
+
+
+def mark_improve_unsupported(base_url: str) -> None:
+    """Record that this server lacks the session-aware improve endpoint."""
+    _write_json_file(
+        _IMPROVE_UNSUPPORTED_MARKER,
+        {
+            "base_url": _normalize_service_url(base_url),
+            "marked_at": datetime.now(timezone.utc).timestamp(),
+        },
+    )
+
+
+def improve_unsupported(base_url: str) -> bool:
+    """True if this server recently rejected the improve endpoint (TTL-bounded)."""
+    data = _load_json_file(_IMPROVE_UNSUPPORTED_MARKER)
+    if not data:
+        return False
+    marked_url = _normalize_service_url(str(data.get("base_url") or ""))
+    if marked_url and marked_url != _normalize_service_url(base_url):
+        return False
+    marked_at = float(data.get("marked_at", 0) or 0)
+    return datetime.now(timezone.utc).timestamp() - marked_at < _IMPROVE_UNSUPPORTED_TTL_SECONDS
+
+
+def append_warmup_entry(dataset: str, session_id: str, entry: dict) -> None:
+    """Buffer a typed QA/trace entry while the server is still warming.
+
+    Per-turn stores go to the server session cache via /remember/entry; before
+    the server serves, those writes would be lost — and improve() bridges only
+    what the server cache holds. Buffered entries are replayed in order by
+    ``drain_warmup_entries`` once the server is ready.
+    """
+    if not dataset or not session_id or not isinstance(entry, dict):
+        return
+    cache = _load_json_file(_bridge_file(session_id))
+    key = _bridge_cache_key(dataset, session_id)
+    session_cache = cache.setdefault(key, {"qa": [], "trace": []})
+    session_cache.setdefault("pending_entries", []).append(entry)
+    _write_json_file(_bridge_file(session_id), cache)
+
+
+def drain_warmup_entries(dataset: str, session_id: str) -> int:
+    """Replay warmup-buffered entries into the server session cache, in order.
+
+    Returns the number of entries replayed. Stops at the first failure so the
+    unreplayed tail stays buffered for the next attempt (order preserved).
+    """
+    if not dataset or not session_id:
+        return 0
+    path = _bridge_file(session_id)
+    cache = _load_json_file(path)
+    key = _bridge_cache_key(dataset, session_id)
+    session_cache = cache.get(key) or {}
+    pending = list(session_cache.get("pending_entries") or [])
+    if not pending:
+        return 0
+    drained = 0
+    for entry in pending:
+        try:
+            remember_entry_via_http(dataset, session_id, entry)
+            drained += 1
+        except Exception as exc:
+            hook_log("warmup_drain_error", {"error": str(exc)[:200], "drained": drained})
+            break
+    if drained:
+        session_cache["pending_entries"] = pending[drained:]
+        cache[key] = session_cache
+        _write_json_file(path, cache)
+        hook_log(
+            "warmup_drained",
+            {"session": session_id, "count": drained, "left": len(pending) - drained},
+        )
+    return drained
+
+
+def improve_session_via_http(dataset: str, session_id: str, *, timeout: float = None) -> dict:
+    """Bridge one session into the graph via POST /api/v1/improve.
+
+    The server reads its own session cache (feedback weights, QA persist,
+    trace-feedback persist, distillation, enrichment), so no session text is
+    sent. ``run_in_background=true`` backgrounds the cognify-heavy pipelines,
+    but the agent-context and distillation stages still run inside the request,
+    so the submit timeout must stay generous — this must only ever be called
+    from detached workers/async hooks, never a synchronous hook window.
+
+    A 2xx submit counts as success: improve is idempotent (unchanged session
+    content dedups server-side by content hash, and a per-session improve lock
+    makes a concurrent run a no-op).
+    """
+    if not dataset or not session_id:
+        return {"ok": False, "error": "missing dataset/session"}
+    submit_timeout = timeout if timeout is not None else _improve_submit_timeout()
+    try:
+        result = _json_http_request(
+            "/api/v1/improve",
+            {
+                "dataset_name": dataset,
+                "session_ids": [session_id],
+                "run_in_background": True,
+            },
+            timeout=submit_timeout,
+        )
+    except urllib.error.HTTPError as exc:
+        if exc.code in (404, 405, 422):
+            # Older server without session-aware improve: remember it (TTL'd)
+            # so callers fall back to the legacy document bridge.
+            mark_improve_unsupported(_local_api_url())
+            return {"ok": False, "unsupported": True, "status": exc.code}
+        return {"ok": False, "status": exc.code, "error": f"HTTP {exc.code}: {exc.reason}"}
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {"ok": False, "status": 0, "error": str(exc)[:200]}
+
+    if isinstance(result, dict) and not result:
+        # The server's per-session improve lock skipped this run ({} response):
+        # another improve is in flight. That run may have extracted the session
+        # cache BEFORE the latest turns landed, so a skip is NOT success — the
+        # caller must retry once the lock frees.
+        return {"ok": False, "busy": True}
+
+    return {"ok": True, "result": result if isinstance(result, dict) else {}}
+
+
+def run_session_improve(dataset: str, session_id: str) -> bool:
+    """API-mode session->graph sync: drain warmup entries, then improve.
+
+    Falls back to the legacy full-document bridge when the server does not
+    support session-aware improve. Returns True when a sync ran successfully.
+    """
+    base_url = _local_api_url()
+    if not _backend_reachable(base_url):
+        return False
+    drain_warmup_entries(dataset, session_id)
+    if improve_unsupported(base_url):
+        return persist_session_cache_to_graph_via_http(dataset, session_id)
+    outcome = improve_session_via_http(dataset, session_id)
+    if outcome.get("unsupported"):
+        hook_log("improve_unsupported_fallback", {"dataset": dataset, "session": session_id})
+        return persist_session_cache_to_graph_via_http(dataset, session_id)
+    # Busy = another improve holds the session lock (e.g. an idle-watcher run
+    # racing the SessionEnd sync). That run's snapshot may predate the latest
+    # turns, so wait for the lock to free and re-submit; the retried improve
+    # dedups unchanged content server-side, so this never double-processes.
+    busy_deadline = time.monotonic() + _improve_float_env("COGNEE_IMPROVE_BUSY_DEADLINE", 600.0)
+    busy_interval = max(0.1, _improve_float_env("COGNEE_IMPROVE_BUSY_RETRY_INTERVAL", 15.0))
+    while outcome.get("busy") and time.monotonic() < busy_deadline:
+        hook_log("improve_busy_retry", {"dataset": dataset, "session": session_id})
+        time.sleep(busy_interval)
+        outcome = improve_session_via_http(dataset, session_id)
+    hook_log(
+        "improve_fired",
+        {
+            "dataset": dataset,
+            "session": session_id,
+            "ok": bool(outcome.get("ok")),
+            "busy": bool(outcome.get("busy")),
+            "error": str(outcome.get("error") or "")[:120],
+        },
+    )
+    return bool(outcome.get("ok"))

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -475,6 +475,59 @@ def _bridge_file(session_id: str = "") -> Path:
     return _BRIDGE_DIR / f"{_agent_session_scope(session_id)}.json"
 
 
+# Short mutex for read-modify-write of the per-session buffer file. Appends
+# from concurrent async hooks (and the drain's trim write-back) would otherwise
+# clobber each other: os.replace keeps the file valid but last-writer-wins,
+# silently dropping the other writer's entry. Critical sections are
+# milliseconds, so waiting is cheap.
+_BUFFER_LOCK = _PLUGIN_DIR / "buffer.lock"
+_BUFFER_LOCK_STALE_SECONDS = 15.0
+_BUFFER_LOCK_TIMEOUT_SECONDS = 1.0
+_BUFFER_LOCK_POLL_SECONDS = 0.02
+
+
+@contextmanager
+def _buffer_lock():
+    """Acquire the buffer-file mutex, waiting briefly; fail open on timeout.
+
+    Yields True when the lock was acquired. On timeout/error the caller
+    proceeds WITHOUT the lock — a rare lost update beats a hook that hangs.
+    """
+    deadline = time.monotonic() + _BUFFER_LOCK_TIMEOUT_SECONDS
+    acquired = False
+    while True:
+        try:
+            _PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+            if _BUFFER_LOCK.exists():
+                try:
+                    if time.time() - _BUFFER_LOCK.stat().st_mtime > _BUFFER_LOCK_STALE_SECONDS:
+                        _BUFFER_LOCK.unlink()
+                except FileNotFoundError:
+                    pass
+            fd = os.open(str(_BUFFER_LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.close(fd)
+            acquired = True
+            break
+        except FileExistsError:
+            if time.monotonic() >= deadline:
+                hook_log("buffer_lock_timeout", {})
+                break
+            time.sleep(_BUFFER_LOCK_POLL_SECONDS)
+        except Exception as exc:
+            hook_log("buffer_lock_error", {"error": str(exc)[:200]})
+            break
+    try:
+        yield acquired
+    finally:
+        if acquired:
+            try:
+                _BUFFER_LOCK.unlink()
+            except FileNotFoundError:
+                pass
+            except Exception as exc:
+                hook_log("buffer_lock_release_failed", {"error": str(exc)[:200]})
+
+
 def append_http_bridge_entry(
     dataset: str,
     session_id: str,
@@ -494,14 +547,15 @@ def append_http_bridge_entry(
     if not (question or answer or trace):
         return
 
-    cache = _load_json_file(_bridge_file(session_id))
-    key = _bridge_cache_key(dataset, session_id)
-    session_cache = cache.setdefault(key, {"qa": [], "trace": []})
-    if question or answer:
-        session_cache.setdefault("qa", []).append({"question": question, "answer": answer})
-    if trace:
-        session_cache.setdefault("trace", []).append(trace)
-    _write_json_file(_bridge_file(session_id), cache)
+    with _buffer_lock():
+        cache = _load_json_file(_bridge_file(session_id))
+        key = _bridge_cache_key(dataset, session_id)
+        session_cache = cache.setdefault(key, {"qa": [], "trace": []})
+        if question or answer:
+            session_cache.setdefault("qa", []).append({"question": question, "answer": answer})
+        if trace:
+            session_cache.setdefault("trace", []).append(trace)
+        _write_json_file(_bridge_file(session_id), cache)
 
 
 async def resolve_user(user_id: str):
@@ -1343,11 +1397,12 @@ def append_warmup_entry(dataset: str, session_id: str, entry: dict) -> None:
     """
     if not dataset or not session_id or not isinstance(entry, dict):
         return
-    cache = _load_json_file(_bridge_file(session_id))
-    key = _bridge_cache_key(dataset, session_id)
-    session_cache = cache.setdefault(key, {"qa": [], "trace": []})
-    session_cache.setdefault("pending_entries", []).append(entry)
-    _write_json_file(_bridge_file(session_id), cache)
+    with _buffer_lock():
+        cache = _load_json_file(_bridge_file(session_id))
+        key = _bridge_cache_key(dataset, session_id)
+        session_cache = cache.setdefault(key, {"qa": [], "trace": []})
+        session_cache.setdefault("pending_entries", []).append(entry)
+        _write_json_file(_bridge_file(session_id), cache)
 
 
 _DRAIN_LOCK = _PLUGIN_DIR / "drain.lock"
@@ -1419,24 +1474,25 @@ def drain_warmup_entries(dataset: str, session_id: str) -> tuple:
                 break
         remaining = len(snapshot) - drained
         if drained:
-            # Re-read before trimming: hooks may have appended new pending
-            # entries (or qa/trace mirror text) during the replay; writing back
-            # the stale snapshot would silently delete them.
-            cache = _load_json_file(path)
-            session_cache = cache.get(key) or {}
-            fresh = list(session_cache.get("pending_entries") or [])
-            if fresh[:drained] == snapshot[:drained]:
-                fresh = fresh[drained:]
-            else:
-                # Unexpected interleaving — remove the replayed entries by value.
-                for entry in snapshot[:drained]:
-                    try:
-                        fresh.remove(entry)
-                    except ValueError:
-                        pass
-            session_cache["pending_entries"] = fresh
-            cache[key] = session_cache
-            _write_json_file(path, cache)
+            # Re-read before trimming, under the buffer mutex: hooks may append
+            # new pending entries (or qa/trace mirror text) during the replay,
+            # and writing back a stale snapshot would silently delete them.
+            with _buffer_lock():
+                cache = _load_json_file(path)
+                session_cache = cache.get(key) or {}
+                fresh = list(session_cache.get("pending_entries") or [])
+                if fresh[:drained] == snapshot[:drained]:
+                    fresh = fresh[drained:]
+                else:
+                    # Unexpected interleaving — remove the replayed entries by value.
+                    for entry in snapshot[:drained]:
+                        try:
+                            fresh.remove(entry)
+                        except ValueError:
+                            pass
+                session_cache["pending_entries"] = fresh
+                cache[key] = session_cache
+                _write_json_file(path, cache)
             remaining = len(fresh)
             hook_log(
                 "warmup_drained",

--- a/integrations/codex/plugins/cognee/scripts/_recall_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_recall_http.py
@@ -69,12 +69,6 @@ def _build_https_opener():
 _HTTPS_OPENER = _build_https_opener()
 
 
-def _is_local(url):
-    """True for a localhost/loopback target (where a cloud API key is meaningless)."""
-    host = (urllib.parse.urlparse(url).hostname or "").lower()
-    return host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
-
-
 def coerce_top_k(value, default=5):
     """Best-effort positive int; never raises (a bad value must not look like a server failure)."""
     try:
@@ -138,10 +132,10 @@ def do_recall(
     if context_profile:
         body["context_profile"] = context_profile
     headers = {"Content-Type": "application/json"}
-    # COGNEE_API_KEY is a *cloud* credential; the local single-user server needs no
-    # auth and ignores it. Only attach it for a remote/cloud target, so we don't send
-    # a meaningless (and confusing) cloud key to localhost.
-    if api_key and not _is_local(service_url):
+    # Always attach the key when present: cognee >=1.2.2 enforces auth on its
+    # API routes even on localhost (the local key is auto-minted at bootstrap),
+    # and a server running with auth disabled simply ignores the header.
+    if api_key:
         headers["X-Api-Key"] = api_key
 
     req = urllib.request.Request(

--- a/integrations/codex/plugins/cognee/scripts/_remember_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_remember_http.py
@@ -30,12 +30,6 @@ import uuid
 UNREACHABLE = "UNREACHABLE"
 
 
-def _is_local(url):
-    """True for a localhost/loopback target (where a cloud API key is meaningless)."""
-    host = (urllib.parse.urlparse(url).hostname or "").lower()
-    return host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
-
-
 def _multipart_body(fields, files):
     boundary = f"----cogneeRemember{uuid.uuid4().hex}"
     chunks = []
@@ -114,9 +108,10 @@ def do_remember(
         [("data", filename, content.encode("utf-8") if isinstance(content, str) else content)],
     )
     headers = {"Content-Type": f"multipart/form-data; boundary={boundary}"}
-    # COGNEE_API_KEY is a cloud credential; local single-user servers need no
-    # auth and ignore it. Only attach it for a remote/cloud target.
-    if api_key and not _is_local(service_url):
+    # Always attach the key when present: cognee >=1.2.2 enforces auth on its
+    # API routes even on localhost (the local key is auto-minted at bootstrap),
+    # and a server running with auth disabled simply ignores the header.
+    if api_key:
         headers["X-Api-Key"] = api_key
 
     req = urllib.request.Request(url, data=body, headers=headers, method="POST")

--- a/integrations/codex/plugins/cognee/scripts/config.py
+++ b/integrations/codex/plugins/cognee/scripts/config.py
@@ -368,6 +368,37 @@ async def sync_graph_context_to_session(dataset: str, session_id: str, user) -> 
     )
 
 
+async def improve_session_local(dataset: str, session_id: str, user) -> dict:
+    """Bridge one session into the graph via the SDK's session-aware improve.
+
+    ``cognee.improve(session_ids=[...])`` reads the session cache itself and
+    runs feedback weights, QA persist, trace-feedback persist (the compact
+    per-step feedback lines — not raw tool output), distillation, enrichment,
+    and (in foreground mode) the graph→session sync — so the explicit
+    persist+sync pair below is only kept as a fallback for older cognee
+    versions without session-aware improve.
+    """
+    if not session_id or not user:
+        return {"ok": False, "error": "missing session/user"}
+
+    import cognee
+
+    try:
+        result = await cognee.improve(
+            dataset,
+            session_ids=[session_id],
+            user=user,
+            run_in_background=False,
+        )
+        return {"ok": True, "result": result}
+    except TypeError as exc:
+        # Older cognee without session-aware improve: legacy persist + sync.
+        _config_log("improve_local_unsupported", {"error": str(exc)[:200]})
+        wrote = await persist_session_cache_to_graph(dataset, session_id, user)
+        graph_result = await sync_graph_context_to_session(dataset, session_id, user)
+        return {"ok": wrote, "legacy": True, "graph_synced": graph_result.get("synced", 0)}
+
+
 def _read_field(entry, field: str) -> str:
     if isinstance(entry, dict):
         return str(entry.get(field) or "")

--- a/integrations/codex/plugins/cognee/scripts/idle-watcher.py
+++ b/integrations/codex/plugins/cognee/scripts/idle-watcher.py
@@ -25,11 +25,11 @@ from pathlib import Path
 from typing import Optional
 
 # Tunable via env. Defaults chosen to avoid thrashing the LLM: 60s idle
-# threshold means you have to actively pause a full minute, and the 20s
-# bridge cooldown prevents back-to-back runs when activity is sporadic.
+# threshold means you have to actively pause a full minute, and the 10-minute
+# improve cooldown prevents back-to-back improve runs when activity is sporadic.
 POLL_SECONDS = float(os.environ.get("COGNEE_IDLE_POLL", "10"))
 IDLE_SECONDS = float(os.environ.get("COGNEE_IDLE_THRESHOLD", "60"))
-IMPROVE_COOLDOWN = float(os.environ.get("COGNEE_IMPROVE_COOLDOWN", "120"))
+IMPROVE_COOLDOWN = float(os.environ.get("COGNEE_IMPROVE_COOLDOWN", "600"))
 
 _PLUGIN_DIR = Path.home() / ".cognee-plugin" / "codex"
 _ACTIVITY = _PLUGIN_DIR / "activity.ts"
@@ -83,14 +83,14 @@ def _install_signal_handlers() -> None:
 
 
 async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
-    """Fire one session bridge cycle. Returns True on success."""
+    """Fire one session improve cycle. Returns True on success."""
     sys.path.insert(0, os.path.dirname(__file__))
     try:
         from _plugin_common import (  # type: ignore
             http_api_ready,
             load_resolved,
-            persist_session_cache_to_graph_via_http,
             resolve_user,
+            run_session_improve,
             set_session_key,
             sync_lock,
         )
@@ -99,6 +99,8 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
         if session_key:
             set_session_key(session_key)
         api_mode = http_api_ready()
+        # Server-side improve has its own per-session lock; only local SDK
+        # mode needs the cross-hook file lock.
         lock = nullcontext(True) if api_mode else sync_lock("idle-watcher")
     except Exception as exc:
         _log("sync_lock_import_error", error=str(exc)[:200])
@@ -115,17 +117,16 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
                 ensure_cognee_ready,
                 ensure_dataset_ready,
                 ensure_identity,
-                persist_session_cache_to_graph,
-                sync_graph_context_to_session,
+                improve_session_local,
             )
 
             if api_mode:
-                wrote = persist_session_cache_to_graph_via_http(dataset, session_id)
+                wrote = run_session_improve(dataset, session_id)
                 _log(
                     "session_bridge_done",
                     session=session_id,
                     dataset=dataset,
-                    via="http_remember",
+                    via="http_improve",
                     wrote=wrote,
                 )
                 return True
@@ -138,15 +139,14 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
             user = await resolve_user(user_id) if user_id else None
             if user:
                 await ensure_dataset_ready(dataset, user)
-                wrote = await persist_session_cache_to_graph(dataset, session_id, user)
-                graph_result = await sync_graph_context_to_session(dataset, session_id, user)
+                result = await improve_session_local(dataset, session_id, user)
                 _log(
                     "session_bridge_done",
                     session=session_id,
                     dataset=dataset,
                     user_id=str(user.id),
-                    wrote=wrote,
-                    graph_synced=graph_result.get("synced", 0),
+                    via="local_improve",
+                    ok=bool(result.get("ok")),
                 )
             return True
         except Exception as exc:

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -20,6 +20,7 @@ import time
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
+    drain_warmup_entries,
     get_session_key,
     hook_log,
     load_resolved,
@@ -36,7 +37,7 @@ from _plugin_common import (
     set_session_key,
 )
 from cognee_statusline_render import render_status_for_host
-from config import ensure_cognee_ready, get_session_id, load_config
+from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
 
 
 def _float_env(name: str, default: float) -> float:
@@ -166,9 +167,11 @@ async def _run(prompt: str) -> dict | None:
     # short /health probe and record the result. If still not ready, skip recall
     # entirely so the prompt is answered at full speed (memory turns on later).
     service_url = runtime.get("base_url", "")
+    just_became_ready = False
     if not server_ready_hint(service_url):
         if server_health_ok(service_url, timeout=_float_env("COGNEE_READY_PROBE_TIMEOUT", 1.0)):
             mark_server_ready(service_url)
+            just_became_ready = True
         else:
             hook_log("recall_skipped_warming", {"base_url": service_url})
             return None
@@ -180,6 +183,15 @@ async def _run(prompt: str) -> dict | None:
     if not session_id:
         hook_log("no_session_id", {"event": "context_lookup"})
         return None
+
+    if just_became_ready:
+        # First prompt after the server came up: replay any entries buffered
+        # while it was warming so the server session cache (which improve
+        # bridges from) holds the full session.
+        try:
+            drain_warmup_entries(get_dataset(config), session_id)
+        except Exception as exc:
+            hook_log("warmup_drain_failed", {"error": str(exc)[:200]})
 
     saves_last_turn = read_and_reset_save_counter(session_id)
 

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -93,7 +93,7 @@ _UV_BIN = _UV_DIR / ("uv.exe" if os.name == "nt" else "uv")
 _UV_PYTHON_DIR = _GLOBAL_STATE_DIR / "python"
 _UV_INSTALL_URL = "https://astral.sh/uv/install.sh"
 _PINNED_PYTHON = os.environ.get("COGNEE_PLUGIN_PYTHON", "") or "3.12"
-_PINNED_COGNEE_VERSION = "1.2.2.dev0"
+_PINNED_COGNEE_VERSION = "1.2.2"
 _INSTALL_TIMEOUT_SECONDS = float(os.environ.get("COGNEE_INSTALL_TIMEOUT", "") or 600.0)
 
 # Install single-flight. Distinct from the server boot lock (which is short): a

--- a/integrations/codex/plugins/cognee/scripts/store-to-session.py
+++ b/integrations/codex/plugins/cognee/scripts/store-to-session.py
@@ -21,6 +21,7 @@ import sys
 sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
     append_http_bridge_entry,
+    append_warmup_entry,
     bump_save_counter,
     bump_turn_counter,
     get_session_key,
@@ -28,13 +29,13 @@ from _plugin_common import (
     http_api_ready,
     load_resolved,
     notify,
-    persist_session_cache_to_graph_via_http,
     pop_pending_prompt,
     quiet_hook_output,
     remember_entry_via_http,
     resolve_runtime_mode,
     resolve_session_key_from_payload,
     resolve_user,
+    run_session_improve,
     server_ready_hint,
     set_session_key,
     touch_activity,
@@ -44,9 +45,8 @@ from config import (
     ensure_dataset_ready,
     get_dataset,
     get_session_id,
+    improve_session_local,
     load_config,
-    persist_session_cache_to_graph,
-    sync_graph_context_to_session,
 )
 
 # Hard cap per field to avoid ballooning the cache with massive tool outputs.
@@ -56,33 +56,36 @@ _MAX_ASSISTANT_BYTES = 8000
 
 
 async def _fire_improve_background(dataset: str, session_id: str, user, reason: str) -> None:
-    """Fire-and-forget session bridge; failures are logged but never raised."""
+    """Fire-and-forget session improve; failures are logged but never raised.
+
+    The server bridges the session itself from its session cache (improve),
+    instead of the old client-side full-document re-post — see run_session_improve.
+    """
     try:
         if http_api_ready():
-            wrote = persist_session_cache_to_graph_via_http(dataset, session_id)
+            wrote = run_session_improve(dataset, session_id)
             hook_log(
-                "auto_bridge_fired",
-                {"reason": reason, "session": session_id, "via": "http_remember", "wrote": wrote},
+                "auto_improve_fired",
+                {"reason": reason, "session": session_id, "via": "http_improve", "wrote": wrote},
             )
             if wrote:
-                notify(f"session bridge persisted ({reason})")
+                notify(f"session improve submitted ({reason})")
             return
 
         await ensure_dataset_ready(dataset, user)
-        wrote = await persist_session_cache_to_graph(dataset, session_id, user)
-        graph_result = await sync_graph_context_to_session(dataset, session_id, user)
+        result = await improve_session_local(dataset, session_id, user)
         hook_log(
-            "auto_bridge_fired",
+            "auto_improve_fired",
             {
                 "reason": reason,
                 "session": session_id,
-                "wrote": wrote,
-                "graph_synced": graph_result.get("synced", 0),
+                "via": "local_improve",
+                "ok": bool(result.get("ok")),
             },
         )
-        notify(f"session bridge persisted ({reason})")
+        notify(f"session improve completed ({reason})")
     except Exception as exc:
-        hook_log("auto_bridge_error", {"reason": reason, "error": str(exc)[:200]})
+        hook_log("auto_improve_error", {"reason": reason, "error": str(exc)[:200]})
 
 
 def _truncate_str(value, cap: int) -> str:
@@ -160,22 +163,6 @@ async def _store_tool_call(payload: dict) -> None:
     config = load_config()
     runtime = resolve_runtime_mode()
     use_http = runtime["mode"] == "http"
-    if not server_ready_hint(runtime.get("base_url", "")):
-        # Server still warming: don't block the tool call and don't lose the
-        # trace. Mirror it into the local bridge shadow; the session->graph
-        # sync drains it once the server is ready.
-        trace_text = (
-            f"{tool_name} [{status}]\n"
-            f"Params: {json.dumps(params, ensure_ascii=False)}\n"
-            f"Return: {return_value}"
-        )
-        append_http_bridge_entry(dataset, session_id, trace=trace_text)
-        bump_save_counter(session_id, "trace")
-        hook_log("store_buffered_warming", {"hook": "tool", "tool": tool_name})
-        return
-    if not use_http:
-        await ensure_cognee_ready(config)
-
     entry = {
         "type": "trace",
         "origin_function": tool_name,
@@ -188,6 +175,24 @@ async def _store_tool_call(payload: dict) -> None:
         # LLM summary can flip this in a future config.
         "generate_feedback_with_llm": False,
     }
+
+    if not server_ready_hint(runtime.get("base_url", "")):
+        # Server still warming: don't block the tool call and don't lose the
+        # trace. Buffer the structured entry for a later /remember/entry replay
+        # (improve bridges only what the server session cache holds), and keep
+        # the legacy text mirror for the document-bridge fallback path.
+        append_warmup_entry(dataset, session_id, entry)
+        trace_text = (
+            f"{tool_name} [{status}]\n"
+            f"Params: {json.dumps(params, ensure_ascii=False)}\n"
+            f"Return: {return_value}"
+        )
+        append_http_bridge_entry(dataset, session_id, trace=trace_text)
+        bump_save_counter(session_id, "trace")
+        hook_log("store_buffered_warming", {"hook": "tool", "tool": tool_name})
+        return
+    if not use_http:
+        await ensure_cognee_ready(config)
 
     try:
         if use_http:
@@ -262,23 +267,6 @@ async def _store_assistant_stop(payload: dict) -> None:
     config = load_config()
     runtime = resolve_runtime_mode()
     use_http = runtime["mode"] == "http"
-    if not server_ready_hint(runtime.get("base_url", "")):
-        # Server still warming: buffer the prompt+answer into the local bridge
-        # shadow instead of dropping it; the session->graph sync drains it once
-        # the server is ready.
-        pending = pop_pending_prompt(session_id, turn_id=str(payload.get("turn_id") or ""))
-        append_http_bridge_entry(
-            dataset,
-            session_id,
-            question=pending.get("prompt", ""),
-            answer=msg,
-        )
-        bump_save_counter(session_id, "answer")
-        hook_log("store_buffered_warming", {"hook": "stop"})
-        return
-    if not use_http:
-        await ensure_cognee_ready(config)
-
     pending = pop_pending_prompt(session_id, turn_id=str(payload.get("turn_id") or ""))
 
     # Codex intentionally differs from Claude here: store one paired
@@ -290,6 +278,24 @@ async def _store_assistant_stop(payload: dict) -> None:
         "answer": msg,
         "context": pending.get("context", ""),
     }
+
+    if not server_ready_hint(runtime.get("base_url", "")):
+        # Server still warming: buffer the structured entry for a later
+        # /remember/entry replay (improve bridges only what the server session
+        # cache holds), and keep the legacy text mirror for the document-bridge
+        # fallback path.
+        append_warmup_entry(dataset, session_id, entry)
+        append_http_bridge_entry(
+            dataset,
+            session_id,
+            question=pending.get("prompt", ""),
+            answer=msg,
+        )
+        bump_save_counter(session_id, "answer")
+        hook_log("store_buffered_warming", {"hook": "stop"})
+        return
+    if not use_http:
+        await ensure_cognee_ready(config)
 
     try:
         if use_http:

--- a/integrations/codex/plugins/cognee/scripts/sync-session-to-graph.py
+++ b/integrations/codex/plugins/cognee/scripts/sync-session-to-graph.py
@@ -242,7 +242,7 @@ def _load_resolved() -> tuple:
     )
 
 
-async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
+async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: bool = False):
     session_id, dataset, user_id, agent_session_name, was_registered, has_api_key, session_key = (
         _load_resolved()
     )
@@ -276,9 +276,12 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
                 hook_log("sync_no_target_sessions", {"dataset": dataset})
                 return
 
+            incomplete: list[str] = []
             if api_mode:
                 for sid in target_sessions:
                     wrote = run_session_improve(dataset, sid)
+                    if not wrote:
+                        incomplete.append(sid)
                     hook_log(
                         "sync_bridge_done",
                         {
@@ -293,6 +296,14 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
                         f"via=http_improve wrote={wrote}",
                         file=sys.stderr,
                     )
+                if strict and incomplete:
+                    # The detached final worker retries on exceptions only. This
+                    # is the session's LAST sync — an incomplete one (failed
+                    # improve or undelivered warmup entries) must re-drive the
+                    # whole drain+improve, not silently report success.
+                    raise RuntimeError(
+                        f"final session sync incomplete for: {', '.join(incomplete)}"
+                    )
                 return
 
             await ensure_cognee_ready(config)
@@ -300,6 +311,8 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
             await ensure_dataset_ready(dataset, user)
             for sid in target_sessions:
                 result = await improve_session_local(dataset, sid, user)
+                if not result.get("ok"):
+                    incomplete.append(sid)
                 hook_log(
                     "sync_bridge_done",
                     {
@@ -315,6 +328,8 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
                     f"via=local_improve ok={result.get('ok')}",
                     file=sys.stderr,
                 )
+            if strict and incomplete:
+                raise RuntimeError(f"final session sync incomplete for: {', '.join(incomplete)}")
     finally:
         if unregister_on_finish:
             if not (was_registered or has_api_key):
@@ -408,6 +423,9 @@ def main():
                 _sync(
                     stop_watcher=False,
                     unregister_on_finish=unregister_on_finish,
+                    # The detached-final run is the session's last sync: an
+                    # incomplete result raises so this loop retries it.
+                    strict=detached_final,
                 )
             )
             return

--- a/integrations/codex/plugins/cognee/scripts/sync-session-to-graph.py
+++ b/integrations/codex/plugins/cognee/scripts/sync-session-to-graph.py
@@ -27,10 +27,10 @@ from _plugin_common import (
     hook_log,
     http_api_ready,
     load_resolved,
-    persist_session_cache_to_graph_via_http,
     resolve_session_key_from_payload,
     resolve_user,
     resolved_http_endpoint_auth,
+    run_session_improve,
     set_session_key,
     sync_lock,
     unregister_agent_via_http,
@@ -40,9 +40,8 @@ from config import (
     ensure_dataset_ready,
     get_dataset,
     get_session_id,
+    improve_session_local,
     load_config,
-    persist_session_cache_to_graph,
-    sync_graph_context_to_session,
 )
 
 _STATE_DIR = Path.home() / ".cognee-plugin" / "codex"
@@ -216,7 +215,10 @@ def _load_resolved() -> tuple:
             os.environ["COGNEE_USER_ID"] = str(data.get("user_id"))
         return (
             env_session_id or data.get("session_id", ""),
-            env_dataset or data.get("dataset", ""),
+            # load_resolved() carries no dataset key, so without the env
+            # override (only the exit watcher sets it) this must fall back to
+            # config, or the SessionEnd worker syncs with an empty dataset.
+            env_dataset or data.get("dataset", "") or get_dataset(load_config()),
             data.get("user_id", ""),
             env_agent_session_name or data.get("agent_session_name", ""),
             bool(data.get("registered", False)),
@@ -276,19 +278,19 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
 
             if api_mode:
                 for sid in target_sessions:
-                    wrote = persist_session_cache_to_graph_via_http(dataset, sid)
+                    wrote = run_session_improve(dataset, sid)
                     hook_log(
                         "sync_bridge_done",
                         {
                             "session": sid,
                             "dataset": dataset,
-                            "via": "http_remember",
+                            "via": "http_improve",
                             "wrote": wrote,
                         },
                     )
                     print(
                         f"cognee-sync: dataset={dataset} session={sid} "
-                        f"via=http_remember wrote={wrote}",
+                        f"via=http_improve wrote={wrote}",
                         file=sys.stderr,
                     )
                 return
@@ -297,21 +299,20 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False):
             user = await resolve_user(user_id)
             await ensure_dataset_ready(dataset, user)
             for sid in target_sessions:
-                wrote = await persist_session_cache_to_graph(dataset, sid, user)
-                graph_result = await sync_graph_context_to_session(dataset, sid, user)
+                result = await improve_session_local(dataset, sid, user)
                 hook_log(
                     "sync_bridge_done",
                     {
                         "session": sid,
                         "dataset": dataset,
                         "user_id": str(getattr(user, "id", "")),
-                        "wrote": wrote,
-                        "graph_synced": graph_result.get("synced", 0),
+                        "via": "local_improve",
+                        "ok": bool(result.get("ok")),
                     },
                 )
                 print(
-                    f"cognee-sync: dataset={dataset} session={sid} wrote={wrote} "
-                    f"graph_synced={graph_result.get('synced', 0)}",
+                    f"cognee-sync: dataset={dataset} session={sid} "
+                    f"via=local_improve ok={result.get('ok')}",
                     file=sys.stderr,
                 )
     finally:

--- a/integrations/codex/tests/test_improve_sync.py
+++ b/integrations/codex/tests/test_improve_sync.py
@@ -119,12 +119,24 @@ def test_improve_network_error_is_graceful():
     assert "error" in res
 
 
-def _run_session_improve(improve_result, *, unsupported_marker=False):
+def _run_session_improve(improve_result, *, unsupported_marker=False, drain_results=None):
+    """Drive run_session_improve with all seams mocked; return (result, calls).
+
+    ``drain_results`` is an optional list of (drained, remaining) tuples returned
+    per drain call, defaulting to a clean (0, 0).
+    """
     calls = {"drain": 0, "improve": 0, "legacy": 0}
+
+    def _drain(d, s):
+        calls["drain"] += 1
+        if drain_results:
+            return drain_results[min(calls["drain"] - 1, len(drain_results) - 1)]
+        return (0, 0)
+
     saved = _with_seams(
         _local_api_url=lambda: "http://x",
         _backend_reachable=lambda url: True,
-        drain_warmup_entries=lambda d, s: calls.__setitem__("drain", calls["drain"] + 1) or 0,
+        drain_warmup_entries=_drain,
         improve_unsupported=lambda url: unsupported_marker,
         improve_session_via_http=lambda d, s, **k: (
             calls.__setitem__("improve", calls["improve"] + 1) or improve_result
@@ -133,6 +145,7 @@ def _run_session_improve(improve_result, *, unsupported_marker=False):
             calls.__setitem__("legacy", calls["legacy"] + 1) or True
         ),
         hook_log=lambda *a, **k: None,
+        _DRAIN_RETRY_PAUSE_SECONDS=0.0,
     )
     try:
         wrote = pc.run_session_improve("ds", "sid")
@@ -203,7 +216,7 @@ def test_run_session_improve_retries_busy_until_lock_frees():
     saved = _with_seams(
         _local_api_url=lambda: "http://x",
         _backend_reachable=lambda url: True,
-        drain_warmup_entries=lambda d, s: 0,
+        drain_warmup_entries=lambda d, s: (0, 0),
         improve_unsupported=lambda url: False,
         improve_session_via_http=_improve,
         hook_log=lambda *a, **k: None,
@@ -216,6 +229,32 @@ def test_run_session_improve_retries_busy_until_lock_frees():
 
     assert wrote is True
     assert calls["improve"] == 3
+
+
+def test_incomplete_drain_returns_false_but_improve_still_runs():
+    # Undelivered warmup entries mean the improve persisted an incomplete
+    # session: the improve must still run (partial persist beats none), but the
+    # sync must report failure so the caller's retry loop re-drives it.
+    wrote, calls = _run_session_improve({"ok": True}, drain_results=[(0, 3), (0, 3)])
+    assert wrote is False
+    assert calls["improve"] == 1  # improve ran despite the incomplete drain
+    assert calls["drain"] == 2  # one in-place retry happened
+    assert calls["legacy"] == 0
+
+
+def test_drain_retry_recovers_and_sync_succeeds():
+    # First drain fails on a blip, the in-place retry delivers the tail →
+    # the sync is complete and reports success.
+    wrote, calls = _run_session_improve({"ok": True}, drain_results=[(0, 3), (3, 0)])
+    assert wrote is True
+    assert calls["drain"] == 2
+    assert calls["improve"] == 1
+
+
+def test_clean_drain_skips_retry():
+    wrote, calls = _run_session_improve({"ok": True}, drain_results=[(2, 0)])
+    assert wrote is True
+    assert calls["drain"] == 1  # nothing remaining → no retry
 
 
 def test_run_session_improve_busy_deadline_gives_up():
@@ -232,7 +271,7 @@ def test_run_session_improve_busy_deadline_gives_up():
     saved = _with_seams(
         _local_api_url=lambda: "http://x",
         _backend_reachable=lambda url: True,
-        drain_warmup_entries=lambda d, s: 0,
+        drain_warmup_entries=lambda d, s: (0, 0),
         improve_unsupported=lambda url: False,
         improve_session_via_http=_always_busy,
         hook_log=lambda *a, **k: None,

--- a/integrations/codex/tests/test_improve_sync.py
+++ b/integrations/codex/tests/test_improve_sync.py
@@ -1,0 +1,261 @@
+"""Unit tests for the codex session->graph improve bridge
+(_plugin_common.improve_session_via_http and run_session_improve).
+
+Mirrors the claude-code suite, minus status polling (the codex helper is
+submit-only): the sync POSTs /api/v1/improve with {dataset_name, session_ids,
+run_in_background}; a 2xx submit counts as success; 404/405/422 marks the
+server improve-unsupported and falls back to the legacy document bridge;
+warmup entries drain before improve.
+
+Run: python integrations/codex/tests/test_improve_sync.py (or via pytest).
+"""
+
+import json
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+
+sys.path.insert(
+    0, str(pathlib.Path(__file__).resolve().parents[1] / "plugins" / "cognee" / "scripts")
+)
+
+import _plugin_common as pc  # noqa: E402
+
+
+class _Resp:
+    def __init__(self, body=b"{}", status=200):
+        self._body = body
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def _with_seams(**overrides):
+    saved = {k: getattr(pc, k) for k in overrides}
+    for k, v in overrides.items():
+        setattr(pc, k, v)
+    return saved
+
+
+def _restore(saved):
+    for k, v in saved.items():
+        setattr(pc, k, v)
+
+
+def test_improve_posts_expected_json_payload():
+    captured = {}
+    orig = urllib.request.urlopen
+
+    def _fake(req, timeout=None):
+        captured["req"] = req
+        captured["timeout"] = timeout
+        return _Resp(b'{"status":"running"}')
+
+    urllib.request.urlopen = _fake
+    saved = _with_seams(_local_api_url=lambda: "http://x", _api_key=lambda: "k")
+    try:
+        res = pc.improve_session_via_http("ds", "sid")
+    finally:
+        _restore(saved)
+        urllib.request.urlopen = orig
+
+    assert res["ok"] is True
+    assert captured["req"].full_url.endswith("/api/v1/improve")
+    body = json.loads(captured["req"].data.decode("utf-8"))
+    assert body == {"dataset_name": "ds", "session_ids": ["sid"], "run_in_background": True}
+    # Distillation/agent-context run inside the request even in background
+    # mode, so the submit timeout must be generous (default 180s).
+    assert captured["timeout"] >= 60
+
+
+def test_improve_404_marks_unsupported():
+    marker_writes = {}
+    orig = urllib.request.urlopen
+
+    def _raise(req, timeout=None):
+        raise urllib.error.HTTPError("http://x", 404, "Not Found", {}, None)
+
+    urllib.request.urlopen = _raise
+    saved = _with_seams(
+        _local_api_url=lambda: "http://x",
+        _api_key=lambda: "k",
+        _write_json_file=lambda p, data: marker_writes.update({str(p): data}),
+    )
+    try:
+        res = pc.improve_session_via_http("ds", "sid")
+    finally:
+        _restore(saved)
+        urllib.request.urlopen = orig
+
+    assert res["ok"] is False
+    assert res["unsupported"] is True
+    assert any("improve-unsupported" in p for p in marker_writes)
+
+
+def test_improve_network_error_is_graceful():
+    orig = urllib.request.urlopen
+
+    def _raise(req, timeout=None):
+        raise urllib.error.URLError("connection refused")
+
+    urllib.request.urlopen = _raise
+    saved = _with_seams(_local_api_url=lambda: "http://x", _api_key=lambda: "k")
+    try:
+        res = pc.improve_session_via_http("ds", "sid")
+    finally:
+        _restore(saved)
+        urllib.request.urlopen = orig
+
+    assert res["ok"] is False
+    assert res["status"] == 0
+    assert "error" in res
+
+
+def _run_session_improve(improve_result, *, unsupported_marker=False):
+    calls = {"drain": 0, "improve": 0, "legacy": 0}
+    saved = _with_seams(
+        _local_api_url=lambda: "http://x",
+        _backend_reachable=lambda url: True,
+        drain_warmup_entries=lambda d, s: calls.__setitem__("drain", calls["drain"] + 1) or 0,
+        improve_unsupported=lambda url: unsupported_marker,
+        improve_session_via_http=lambda d, s, **k: (
+            calls.__setitem__("improve", calls["improve"] + 1) or improve_result
+        ),
+        persist_session_cache_to_graph_via_http=lambda d, s: (
+            calls.__setitem__("legacy", calls["legacy"] + 1) or True
+        ),
+        hook_log=lambda *a, **k: None,
+    )
+    try:
+        wrote = pc.run_session_improve("ds", "sid")
+    finally:
+        _restore(saved)
+    return wrote, calls
+
+
+def test_run_session_improve_happy_path_drains_then_improves():
+    wrote, calls = _run_session_improve({"ok": True})
+    assert wrote is True
+    assert calls == {"drain": 1, "improve": 1, "legacy": 0}
+
+
+def test_run_session_improve_falls_back_when_unsupported_response():
+    wrote, calls = _run_session_improve({"ok": False, "unsupported": True, "status": 404})
+    assert wrote is True
+    assert calls["improve"] == 1
+    assert calls["legacy"] == 1
+
+
+def test_run_session_improve_skips_improve_when_marker_set():
+    wrote, calls = _run_session_improve({"ok": True}, unsupported_marker=True)
+    assert wrote is True
+    assert calls["improve"] == 0  # marker short-circuits straight to legacy
+    assert calls["legacy"] == 1
+
+
+def test_run_session_improve_error_returns_false_without_legacy():
+    wrote, calls = _run_session_improve({"ok": False, "status": 500, "error": "boom"})
+    assert wrote is False
+    assert calls["legacy"] == 0  # a transient server error is not an unsupported server
+
+
+def test_improve_lock_skip_reports_busy():
+    # improve() returns {} when the per-session lock skips the run — the helper
+    # must surface that as busy, never as success.
+    orig = urllib.request.urlopen
+
+    def _fake(req, timeout=None):
+        return _Resp(b"{}")
+
+    urllib.request.urlopen = _fake
+    saved = _with_seams(_local_api_url=lambda: "http://x", _api_key=lambda: "k")
+    try:
+        res = pc.improve_session_via_http("ds", "sid")
+    finally:
+        _restore(saved)
+        urllib.request.urlopen = orig
+
+    assert res["ok"] is False
+    assert res["busy"] is True
+
+
+def test_run_session_improve_retries_busy_until_lock_frees():
+    # A lock-skipped improve may have snapshotted the cache before the latest
+    # turns — run_session_improve must re-submit until a run actually lands.
+    import os
+
+    results = [{"ok": False, "busy": True}, {"ok": False, "busy": True}, {"ok": True}]
+    calls = {"improve": 0}
+
+    def _improve(d, s, **k):
+        calls["improve"] += 1
+        return results[min(calls["improve"] - 1, len(results) - 1)]
+
+    os.environ["COGNEE_IMPROVE_BUSY_RETRY_INTERVAL"] = "0.1"
+    saved = _with_seams(
+        _local_api_url=lambda: "http://x",
+        _backend_reachable=lambda url: True,
+        drain_warmup_entries=lambda d, s: 0,
+        improve_unsupported=lambda url: False,
+        improve_session_via_http=_improve,
+        hook_log=lambda *a, **k: None,
+    )
+    try:
+        wrote = pc.run_session_improve("ds", "sid")
+    finally:
+        _restore(saved)
+        os.environ.pop("COGNEE_IMPROVE_BUSY_RETRY_INTERVAL", None)
+
+    assert wrote is True
+    assert calls["improve"] == 3
+
+
+def test_run_session_improve_busy_deadline_gives_up():
+    import os
+
+    calls = {"improve": 0}
+
+    def _always_busy(d, s, **k):
+        calls["improve"] += 1
+        return {"ok": False, "busy": True}
+
+    os.environ["COGNEE_IMPROVE_BUSY_RETRY_INTERVAL"] = "0.1"
+    os.environ["COGNEE_IMPROVE_BUSY_DEADLINE"] = "0.25"
+    saved = _with_seams(
+        _local_api_url=lambda: "http://x",
+        _backend_reachable=lambda url: True,
+        drain_warmup_entries=lambda d, s: 0,
+        improve_unsupported=lambda url: False,
+        improve_session_via_http=_always_busy,
+        hook_log=lambda *a, **k: None,
+    )
+    try:
+        wrote = pc.run_session_improve("ds", "sid")
+    finally:
+        _restore(saved)
+        os.environ.pop("COGNEE_IMPROVE_BUSY_RETRY_INTERVAL", None)
+        os.environ.pop("COGNEE_IMPROVE_BUSY_DEADLINE", None)
+
+    assert wrote is False  # still busy at deadline → reported as not-synced
+    assert calls["improve"] >= 2  # at least one retry happened
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/tests/test_sync_strict.py
+++ b/integrations/codex/tests/test_sync_strict.py
@@ -1,0 +1,109 @@
+"""Unit tests for sync-session-to-graph.py strict mode.
+
+The detached final-sync worker retries only on exceptions. Strict mode (used
+by that worker) makes an incomplete session sync raise so the retry loop
+re-drives the whole drain+improve, instead of silently reporting success on
+the session's LAST sync. Non-strict (manual /cognee-sync, mid-session) keeps
+the old log-and-return behavior.
+
+Run: python integrations/codex/tests/test_sync_strict.py (or via pytest).
+"""
+
+import asyncio
+import importlib.util
+import pathlib
+import sys
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "plugins" / "cognee" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+_spec = importlib.util.spec_from_file_location("sync_mod", _SCRIPTS / "sync-session-to-graph.py")
+m = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(m)
+
+
+def _stub(wrote, *, unregister_calls=None):
+    """Patch the module seams for one _sync run; return a restore fn."""
+    saved = {
+        k: getattr(m, k)
+        for k in (
+            "_load_resolved",
+            "load_config",
+            "http_api_ready",
+            "run_session_improve",
+            "unregister_agent_via_http",
+            "hook_log",
+        )
+    }
+    # (session_id, dataset, user_id, agent_session_name, was_registered, has_api_key, session_key)
+    m._load_resolved = lambda: ("sess1", "ds", "u1", "agent1", True, True, "key1")
+    m.load_config = lambda: {}
+    m.http_api_ready = lambda: True
+    m.run_session_improve = lambda d, s: wrote
+    m.unregister_agent_via_http = lambda **k: (
+        (unregister_calls.append(k) if unregister_calls is not None else None) or (True, 0)
+    )
+    m.hook_log = lambda *a, **k: None
+
+    def _restore():
+        for k, v in saved.items():
+            setattr(m, k, v)
+
+    return _restore
+
+
+def test_strict_raises_on_incomplete_sync():
+    restore = _stub(wrote=False)
+    try:
+        try:
+            asyncio.run(m._sync(stop_watcher=False, strict=True))
+            raise AssertionError("expected RuntimeError for incomplete strict sync")
+        except RuntimeError as exc:
+            assert "incomplete" in str(exc)
+    finally:
+        restore()
+
+
+def test_non_strict_does_not_raise():
+    restore = _stub(wrote=False)
+    try:
+        asyncio.run(m._sync(stop_watcher=False, strict=False))  # must not raise
+    finally:
+        restore()
+
+
+def test_strict_complete_sync_does_not_raise():
+    restore = _stub(wrote=True)
+    try:
+        asyncio.run(m._sync(stop_watcher=False, strict=True))  # must not raise
+    finally:
+        restore()
+
+
+def test_unregister_still_runs_when_strict_raises():
+    # The finally-block unregister must run even when strict mode raises, so a
+    # retried worker never leaves a dangling registration.
+    calls = []
+    restore = _stub(wrote=False, unregister_calls=calls)
+    try:
+        try:
+            asyncio.run(m._sync(stop_watcher=False, unregister_on_finish=True, strict=True))
+        except RuntimeError:
+            pass
+        assert len(calls) == 1
+        assert calls[0].get("agent_session_name") == "agent1"
+    finally:
+        restore()
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/tests/test_warmup_drain.py
+++ b/integrations/codex/tests/test_warmup_drain.py
@@ -4,7 +4,10 @@
 Entries captured while the local server is still warming must be buffered as
 structured /remember/entry payloads and replayed IN ORDER once the server is
 ready, so the server-side session cache (which improve() bridges from) holds
-the complete session. A replay failure keeps the unreplayed tail buffered.
+the complete session. drain_warmup_entries returns (drained, remaining); a
+replay failure keeps the unreplayed tail buffered; the buffer trim is computed
+against a fresh re-read so entries appended during the replay survive; and a
+single-drainer lock prevents concurrent double-replays.
 
 Run: python integrations/codex/tests/test_warmup_drain.py (or via pytest).
 """
@@ -21,12 +24,13 @@ import _plugin_common as pc  # noqa: E402
 
 
 def _with_tmp_bridge(fn):
-    """Run fn() with the bridge file pointed at a temp path; return its result."""
-    saved = {k: getattr(pc, k) for k in ("_bridge_file", "hook_log")}
+    """Run fn() with the bridge file and drain lock pointed at temp paths."""
+    saved = {k: getattr(pc, k) for k in ("_bridge_file", "hook_log", "_DRAIN_LOCK")}
     with tempfile.TemporaryDirectory() as tmp:
         bridge = pathlib.Path(tmp) / "bridge_test.json"
         pc._bridge_file = lambda sid="": bridge
         pc.hook_log = lambda *a, **k: None
+        pc._DRAIN_LOCK = pathlib.Path(tmp) / "drain.lock"
         try:
             return fn()
         finally:
@@ -42,13 +46,13 @@ def test_append_and_drain_in_order():
         saved = pc.remember_entry_via_http
         pc.remember_entry_via_http = lambda d, s, entry, **k: replayed.append(entry) or {}
         try:
-            drained = pc.drain_warmup_entries("ds", "sid")
+            result = pc.drain_warmup_entries("ds", "sid")
         finally:
             pc.remember_entry_via_http = saved
-        return drained, replayed
+        return result, replayed
 
-    drained, replayed = _with_tmp_bridge(_run)
-    assert drained == 2
+    result, replayed = _with_tmp_bridge(_run)
+    assert result == (2, 0)
     assert [e["type"] for e in replayed] == ["trace", "qa"]
 
 
@@ -58,13 +62,13 @@ def test_drain_empty_buffer_is_noop():
         saved = pc.remember_entry_via_http
         pc.remember_entry_via_http = lambda *a, **k: calls.append(a) or {}
         try:
-            drained = pc.drain_warmup_entries("ds", "sid")
+            result = pc.drain_warmup_entries("ds", "sid")
         finally:
             pc.remember_entry_via_http = saved
-        return drained, calls
+        return result, calls
 
-    drained, calls = _with_tmp_bridge(_run)
-    assert drained == 0
+    result, calls = _with_tmp_bridge(_run)
+    assert result == (0, 0)
     assert calls == []
 
 
@@ -97,9 +101,60 @@ def test_partial_failure_keeps_tail_buffered():
         return first, second, replayed
 
     first, second, replayed = _with_tmp_bridge(_run)
-    assert first == 1
-    assert second == 2
+    assert first == (1, 2)
+    assert second == (2, 0)
     assert [e.get("origin_function") or e["type"] for e in replayed] == ["Read", "Edit", "qa"]
+
+
+def test_concurrent_append_during_drain_survives():
+    # An entry appended by a concurrent hook WHILE the replay is in flight must
+    # survive the buffer write-back (trim by fresh re-read, not stale snapshot).
+    def _run():
+        pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "A"})
+        pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "B"})
+        replayed = []
+
+        def _replay(dataset, session_id, entry, **k):
+            replayed.append(entry)
+            if len(replayed) == 1:
+                pc.append_warmup_entry(
+                    "ds", "sid", {"type": "qa", "question": "new", "answer": "x"}
+                )
+            return {}
+
+        saved = pc.remember_entry_via_http
+        pc.remember_entry_via_http = _replay
+        try:
+            result = pc.drain_warmup_entries("ds", "sid")
+        finally:
+            pc.remember_entry_via_http = saved
+        cache = pc._load_json_file(pc._bridge_file("sid"))
+        left = (cache.get(pc._bridge_cache_key("ds", "sid")) or {}).get("pending_entries")
+        return result, left
+
+    result, left = _with_tmp_bridge(_run)
+    assert result == (2, 1)  # both originals replayed; the mid-drain arrival remains
+    assert left == [{"type": "qa", "question": "new", "answer": "x"}]
+
+
+def test_drain_skipped_when_lock_busy():
+    def _run():
+        pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "Bash"})
+        calls = []
+        saved_http = pc.remember_entry_via_http
+        saved_lock = pc._try_acquire_drain_lock
+        pc.remember_entry_via_http = lambda *a, **k: calls.append(a) or {}
+        pc._try_acquire_drain_lock = lambda: False
+        try:
+            result = pc.drain_warmup_entries("ds", "sid")
+        finally:
+            pc.remember_entry_via_http = saved_http
+            pc._try_acquire_drain_lock = saved_lock
+        return result, calls
+
+    result, calls = _with_tmp_bridge(_run)
+    assert result == (0, 1)  # skipped, nothing replayed, entry still pending
+    assert calls == []
 
 
 def test_drain_leaves_legacy_shadow_untouched():

--- a/integrations/codex/tests/test_warmup_drain.py
+++ b/integrations/codex/tests/test_warmup_drain.py
@@ -1,0 +1,134 @@
+"""Unit tests for the warmup entry buffer
+(_plugin_common.append_warmup_entry and drain_warmup_entries).
+
+Entries captured while the local server is still warming must be buffered as
+structured /remember/entry payloads and replayed IN ORDER once the server is
+ready, so the server-side session cache (which improve() bridges from) holds
+the complete session. A replay failure keeps the unreplayed tail buffered.
+
+Run: python integrations/codex/tests/test_warmup_drain.py (or via pytest).
+"""
+
+import pathlib
+import sys
+import tempfile
+
+sys.path.insert(
+    0, str(pathlib.Path(__file__).resolve().parents[1] / "plugins" / "cognee" / "scripts")
+)
+
+import _plugin_common as pc  # noqa: E402
+
+
+def _with_tmp_bridge(fn):
+    """Run fn() with the bridge file pointed at a temp path; return its result."""
+    saved = {k: getattr(pc, k) for k in ("_bridge_file", "hook_log")}
+    with tempfile.TemporaryDirectory() as tmp:
+        bridge = pathlib.Path(tmp) / "bridge_test.json"
+        pc._bridge_file = lambda sid="": bridge
+        pc.hook_log = lambda *a, **k: None
+        try:
+            return fn()
+        finally:
+            for k, v in saved.items():
+                setattr(pc, k, v)
+
+
+def test_append_and_drain_in_order():
+    def _run():
+        replayed = []
+        pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "Bash"})
+        pc.append_warmup_entry("ds", "sid", {"type": "qa", "question": "q", "answer": "a"})
+        saved = pc.remember_entry_via_http
+        pc.remember_entry_via_http = lambda d, s, entry, **k: replayed.append(entry) or {}
+        try:
+            drained = pc.drain_warmup_entries("ds", "sid")
+        finally:
+            pc.remember_entry_via_http = saved
+        return drained, replayed
+
+    drained, replayed = _with_tmp_bridge(_run)
+    assert drained == 2
+    assert [e["type"] for e in replayed] == ["trace", "qa"]
+
+
+def test_drain_empty_buffer_is_noop():
+    def _run():
+        calls = []
+        saved = pc.remember_entry_via_http
+        pc.remember_entry_via_http = lambda *a, **k: calls.append(a) or {}
+        try:
+            drained = pc.drain_warmup_entries("ds", "sid")
+        finally:
+            pc.remember_entry_via_http = saved
+        return drained, calls
+
+    drained, calls = _with_tmp_bridge(_run)
+    assert drained == 0
+    assert calls == []
+
+
+def test_partial_failure_keeps_tail_buffered():
+    def _run():
+        replayed = []
+
+        def _flaky(dataset, session_id, entry, **k):
+            if len(replayed) >= 1:
+                raise OSError("server went away")
+            replayed.append(entry)
+            return {}
+
+        pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "Read"})
+        pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "Edit"})
+        pc.append_warmup_entry("ds", "sid", {"type": "qa", "question": "q", "answer": "a"})
+        saved = pc.remember_entry_via_http
+        pc.remember_entry_via_http = _flaky
+        try:
+            first = pc.drain_warmup_entries("ds", "sid")
+        finally:
+            pc.remember_entry_via_http = saved
+
+        # Second drain replays the surviving tail, in order.
+        pc.remember_entry_via_http = lambda d, s, entry, **k: replayed.append(entry) or {}
+        try:
+            second = pc.drain_warmup_entries("ds", "sid")
+        finally:
+            pc.remember_entry_via_http = saved
+        return first, second, replayed
+
+    first, second, replayed = _with_tmp_bridge(_run)
+    assert first == 1
+    assert second == 2
+    assert [e.get("origin_function") or e["type"] for e in replayed] == ["Read", "Edit", "qa"]
+
+
+def test_drain_leaves_legacy_shadow_untouched():
+    # The qa/trace text mirrors (legacy document-bridge data) must survive a drain.
+    def _run():
+        pc.append_http_bridge_entry("ds", "sid", trace="Bash [success]")
+        pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "Bash"})
+        saved = pc.remember_entry_via_http
+        pc.remember_entry_via_http = lambda *a, **k: {}
+        try:
+            pc.drain_warmup_entries("ds", "sid")
+        finally:
+            pc.remember_entry_via_http = saved
+        cache = pc._load_json_file(pc._bridge_file("sid"))
+        return cache.get(pc._bridge_cache_key("ds", "sid"), {})
+
+    session_cache = _with_tmp_bridge(_run)
+    assert session_cache.get("trace") == ["Bash [success]"]
+    assert session_cache.get("pending_entries") == []
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/tests/test_warmup_drain.py
+++ b/integrations/codex/tests/test_warmup_drain.py
@@ -24,13 +24,14 @@ import _plugin_common as pc  # noqa: E402
 
 
 def _with_tmp_bridge(fn):
-    """Run fn() with the bridge file and drain lock pointed at temp paths."""
-    saved = {k: getattr(pc, k) for k in ("_bridge_file", "hook_log", "_DRAIN_LOCK")}
+    """Run fn() with the bridge file and both locks pointed at temp paths."""
+    saved = {k: getattr(pc, k) for k in ("_bridge_file", "hook_log", "_DRAIN_LOCK", "_BUFFER_LOCK")}
     with tempfile.TemporaryDirectory() as tmp:
         bridge = pathlib.Path(tmp) / "bridge_test.json"
         pc._bridge_file = lambda sid="": bridge
         pc.hook_log = lambda *a, **k: None
         pc._DRAIN_LOCK = pathlib.Path(tmp) / "drain.lock"
+        pc._BUFFER_LOCK = pathlib.Path(tmp) / "buffer.lock"
         try:
             return fn()
         finally:
@@ -155,6 +156,49 @@ def test_drain_skipped_when_lock_busy():
     result, calls = _with_tmp_bridge(_run)
     assert result == (0, 1)  # skipped, nothing replayed, entry still pending
     assert calls == []
+
+
+def test_concurrent_appends_do_not_lose_entries():
+    # Two async hooks appending at the same moment must both land: the buffer
+    # mutex serializes the read-modify-write, so the last writer no longer
+    # clobbers the other's entry.
+    import concurrent.futures
+
+    def _run():
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as ex:
+            list(
+                ex.map(
+                    lambda i: pc.append_warmup_entry(
+                        "ds", "sid", {"type": "trace", "origin_function": f"tool{i}"}
+                    ),
+                    range(8),
+                )
+            )
+        cache = pc._load_json_file(pc._bridge_file("sid"))
+        return (cache.get(pc._bridge_cache_key("ds", "sid")) or {}).get("pending_entries") or []
+
+    entries = _with_tmp_bridge(_run)
+    assert sorted(e["origin_function"] for e in entries) == [f"tool{i}" for i in range(8)]
+
+
+def test_append_fails_open_when_lock_held():
+    # A wedged lock must never make a hook hang or drop the entry: after the
+    # short wait the append proceeds without the lock.
+    def _run():
+        saved_timeout = pc._BUFFER_LOCK_TIMEOUT_SECONDS
+        pc._BUFFER_LOCK_TIMEOUT_SECONDS = 0.05
+        pc._BUFFER_LOCK.parent.mkdir(parents=True, exist_ok=True)
+        pc._BUFFER_LOCK.write_text("held")  # fresh lock held by someone else
+        try:
+            pc.append_warmup_entry("ds", "sid", {"type": "trace", "origin_function": "X"})
+        finally:
+            pc._BUFFER_LOCK_TIMEOUT_SECONDS = saved_timeout
+            pc._BUFFER_LOCK.unlink()
+        cache = pc._load_json_file(pc._bridge_file("sid"))
+        return (cache.get(pc._bridge_cache_key("ds", "sid")) or {}).get("pending_entries")
+
+    entries = _with_tmp_bridge(_run)
+    assert entries and entries[0]["origin_function"] == "X"
 
 
 def test_drain_leaves_legacy_shadow_untouched():


### PR DESCRIPTION
This PR improves the way we sync sessions to graphs. Instead of an expensive remember call, we use improve which should drastically reduce the cost of our integrations.

Main changes are using `improve` instead of `remember` on session end, and in the idle and exit watchers, both in the Claude and Codex integrations, as well as increasing the cooldowns of when the idle-watcher fires its sync.