### PR TITLE
feat: add dataset-name sanitization parity across all integrations (#…

### DIFF
--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -106,6 +106,22 @@ def _sanitize_session_key(value: str) -> str:
     return "".join(safe).strip("._")[:120]
 
 
+def sanitize_dataset_name(name: str, default: str) -> str:
+    """Apply the same character rules as _sanitize_session_key to a dataset name.
+
+    Keeps ASCII alphanumerics and ``-`` ``_`` ``.'``; replaces everything else
+    with ``_``; strips leading/trailing ``'.'`` and ``'_'``; caps at 120 chars.
+    Falls back to *default* when the result is empty (e.g. "###" or "___").
+    """
+    safe = []
+    for ch in str(name or ""):
+        if (ch.isascii() and ch.isalnum()) or ch in ("-", "_", "."):
+            safe.append(ch)
+        else:
+            safe.append("_")
+    return "".join(safe).strip("._")[:120] or default
+
+
 def get_session_key() -> str:
     candidates = [
         os.environ.get("COGNEE_SESSION_KEY"),

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -189,8 +189,10 @@ def get_session_id(config: dict, cwd: Optional[str] = None) -> str:
 
 
 def get_dataset(config: dict) -> str:
-    """Get the dataset name from config."""
-    return config.get("dataset", "agent_sessions")
+    """Get the sanitized dataset name from config."""
+    from _plugin_common import sanitize_dataset_name  # noqa: PLC0415
+
+    return sanitize_dataset_name(config.get("dataset") or "", "agent_sessions")
 
 
 def is_cloud_mode(config: dict) -> bool:

--- a/integrations/claude-code/tests/test_dataset_name.py
+++ b/integrations/claude-code/tests/test_dataset_name.py
@@ -1,0 +1,78 @@
+"""Regression tests for sanitize_dataset_name in the claude-code integration.
+
+Run:
+    python integrations/claude-code/tests/test_dataset_name.py
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+DEFAULT = "agent_sessions"
+
+CASES = [
+    # ── valid names ──
+    ("mydataset",    "mydataset"),
+    ("project_01",   "project_01"),
+    ("company-prod", "company-prod"),
+    ("test.v1",      "test.v1"),
+    # ── invalid names ──
+    ("My Dataset",   "My_Dataset"),
+    ("My@Data",      "My_Data"),
+    ("!!hello!!",    "hello"),
+    ("###",          DEFAULT),
+    ("........",     DEFAULT),
+    ("___",          DEFAULT),
+    ("a" * 200,      "a" * 120),
+    ("你好 Dataset",  "Dataset"),
+    # ── edge cases ──
+    ("",             DEFAULT),
+    ("  ",           DEFAULT),
+    ("-leading",     "-leading"),
+    (".leading",     "leading"),
+    ("_leading",     "leading"),
+    ("trailing.",    "trailing"),
+]
+
+
+def test_sanitize_dataset_name_issue_cases() -> None:
+    for name, expected in CASES:
+        result = pc.sanitize_dataset_name(name, DEFAULT)
+        assert result == expected, (
+            f"sanitize_dataset_name({name!r}) = {result!r}, want {expected!r}"
+        )
+
+
+def test_matches_session_key_sanitizer_for_valid_chars() -> None:
+    """For ASCII-only valid names, both sanitizers must agree."""
+    valid = ["mydataset", "project_01", "company-prod", "test.v1"]
+    for name in valid:
+        assert pc.sanitize_dataset_name(name, DEFAULT) == pc._sanitize_session_key(name), (
+            f"sanitizers disagree on {name!r}"
+        )
+
+
+def test_fallback_only_when_empty_after_sanitization() -> None:
+    assert pc.sanitize_dataset_name("ok", "fb") == "ok"
+    assert pc.sanitize_dataset_name("###", "fb") == "fb"
+
+
+def test_max_length() -> None:
+    result = pc.sanitize_dataset_name("x" * 200, DEFAULT)
+    assert len(result) == 120
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, "→", exc)
+    raise SystemExit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -106,6 +106,22 @@ def _sanitize_session_key(value: str) -> str:
     return "".join(safe).strip("._")[:120]
 
 
+def sanitize_dataset_name(name: str, default: str) -> str:
+    """Apply the same character rules as _sanitize_session_key to a dataset name.
+
+    Keeps ASCII alphanumerics and ``-`` ``_`` ``.'``; replaces everything else
+    with ``_``; strips leading/trailing ``'.'`` and ``'_'``; caps at 120 chars.
+    Falls back to *default* when the result is empty (e.g. "###" or "___").
+    """
+    safe = []
+    for ch in str(name or ""):
+        if (ch.isascii() and ch.isalnum()) or ch in ("-", "_", "."):
+            safe.append(ch)
+        else:
+            safe.append("_")
+    return "".join(safe).strip("._")[:120] or default
+
+
 def get_session_key() -> str:
     candidates = [
         os.environ.get("COGNEE_SESSION_KEY"),

--- a/integrations/codex/plugins/cognee/scripts/config.py
+++ b/integrations/codex/plugins/cognee/scripts/config.py
@@ -169,8 +169,10 @@ def get_session_id(config: dict, cwd: Optional[str] = None) -> str:
 
 
 def get_dataset(config: dict) -> str:
-    """Get the dataset name from config."""
-    return config.get("dataset", "agent_sessions")
+    """Get the sanitized dataset name from config."""
+    from _plugin_common import sanitize_dataset_name  # noqa: PLC0415
+
+    return sanitize_dataset_name(config.get("dataset") or "", "agent_sessions")
 
 
 def is_cloud_mode(config: dict) -> bool:

--- a/integrations/codex/plugins/cognee/tests/test_dataset_name.py
+++ b/integrations/codex/plugins/cognee/tests/test_dataset_name.py
@@ -1,0 +1,78 @@
+"""Regression tests for sanitize_dataset_name in the codex integration.
+
+Run:
+    python integrations/codex/plugins/cognee/tests/test_dataset_name.py
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+DEFAULT = "agent_sessions"
+
+CASES = [
+    # ── valid names ──
+    ("mydataset",    "mydataset"),
+    ("project_01",   "project_01"),
+    ("company-prod", "company-prod"),
+    ("test.v1",      "test.v1"),
+    # ── invalid names ──
+    ("My Dataset",   "My_Dataset"),
+    ("My@Data",      "My_Data"),
+    ("!!hello!!",    "hello"),
+    ("###",          DEFAULT),
+    ("........",     DEFAULT),
+    ("___",          DEFAULT),
+    ("a" * 200,      "a" * 120),
+    ("你好 Dataset",  "Dataset"),
+    # ── edge cases ──
+    ("",             DEFAULT),
+    ("  ",           DEFAULT),
+    ("-leading",     "-leading"),
+    (".leading",     "leading"),
+    ("_leading",     "leading"),
+    ("trailing.",    "trailing"),
+]
+
+
+def test_sanitize_dataset_name_issue_cases() -> None:
+    for name, expected in CASES:
+        result = pc.sanitize_dataset_name(name, DEFAULT)
+        assert result == expected, (
+            f"sanitize_dataset_name({name!r}) = {result!r}, want {expected!r}"
+        )
+
+
+def test_matches_session_key_sanitizer_for_valid_chars() -> None:
+    """For ASCII-only valid names, both sanitizers must agree."""
+    valid = ["mydataset", "project_01", "company-prod", "test.v1"]
+    for name in valid:
+        assert pc.sanitize_dataset_name(name, DEFAULT) == pc._sanitize_session_key(name), (
+            f"sanitizers disagree on {name!r}"
+        )
+
+
+def test_fallback_only_when_empty_after_sanitization() -> None:
+    assert pc.sanitize_dataset_name("ok", "fb") == "ok"
+    assert pc.sanitize_dataset_name("###", "fb") == "fb"
+
+
+def test_max_length() -> None:
+    result = pc.sanitize_dataset_name("x" * 200, DEFAULT)
+    assert len(result) == 120
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, "→", exc)
+    raise SystemExit(1 if failures else 0)

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -88,6 +88,20 @@ def _safe_session_component(value: str) -> str:
     return safe.strip("._")[:120] or "session"
 
 
+def _sanitize_dataset_name(name: str, default: str) -> str:
+    """Apply the same character rules as _safe_session_component to a dataset name.
+
+    Keeps ASCII alphanumerics and ``-`` ``_`` ``.'``; replaces everything else
+    with ``_``; strips leading/trailing ``'.'`` and ``'_'``; caps at 120 chars.
+    Falls back to *default* when the result is empty (e.g. "###" or "___").
+    """
+    safe = "".join(
+        ch if (ch.isascii() and ch.isalnum()) or ch in ("-", "_", ".") else "_"
+        for ch in str(name or "")
+    )
+    return safe.strip("._")[:120] or default
+
+
 def _format_turn(user_content: str, assistant_content: str) -> str:
     return f"User: {user_content}\nAssistant: {assistant_content}"
 
@@ -282,7 +296,9 @@ class CogneeMemoryProvider(MemoryProvider):
         self._hermes_home = kwargs.get("hermes_home")
         self._config = load_config(self._hermes_home)
         self._session_id = session_id
-        self._dataset = str(self._config.get("dataset") or DEFAULT_DATASET)
+        self._dataset = _sanitize_dataset_name(
+            str(self._config.get("dataset") or ""), DEFAULT_DATASET
+        )
         self._top_k = int(self._config.get("top_k") or 5)
         self._auto_route = str_to_bool(self._config.get("auto_route"), True)
         self._improve_on_end = str_to_bool(self._config.get("improve_on_end"), True)
@@ -741,7 +757,7 @@ class CogneeMemoryProvider(MemoryProvider):
         content = str(args.get("content") or "").strip()
         if not content:
             return json.dumps({"error": "Missing required parameter: content"})
-        dataset = str(args.get("dataset") or self._dataset)
+        dataset = _sanitize_dataset_name(str(args.get("dataset") or ""), self._dataset)
 
         try:
             result = self._bridge.run(
@@ -756,7 +772,8 @@ class CogneeMemoryProvider(MemoryProvider):
             return json.dumps({"error": f"Cognee remember failed: {exc}"})
 
     def _handle_forget(self, args: dict[str, Any]) -> str:
-        dataset = args.get("dataset")
+        _raw_dataset = args.get("dataset")
+        dataset = _sanitize_dataset_name(str(_raw_dataset), self._dataset) if _raw_dataset else None
         everything = bool(args.get("everything", False))
         memory_only = bool(args.get("memory_only", False))
         if not dataset and not everything:

--- a/integrations/hermes-agent/tests/test_dataset_name.py
+++ b/integrations/hermes-agent/tests/test_dataset_name.py
@@ -1,0 +1,86 @@
+"""Regression tests for _sanitize_dataset_name in the hermes-agent integration.
+
+Covers every valid/invalid input from issue #3549 and verifies that the
+hermes-agent sanitizer produces exactly the expected output.
+
+Run:
+    python integrations/hermes-agent/tests/test_dataset_name.py
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from cognee_integration_hermes.provider import _sanitize_dataset_name  # noqa: E402
+
+DEFAULT = "hermes"
+
+# (input_name, expected_output)
+# When expected_output is DEFAULT the sanitizer must fall back to the default.
+CASES = [
+    # ── valid names — must pass through unchanged ──
+    ("mydataset",    "mydataset"),
+    ("project_01",   "project_01"),
+    ("company-prod", "company-prod"),
+    ("test.v1",      "test.v1"),
+    # ── invalid names — must be normalised ──
+    ("My Dataset",   "My_Dataset"),     # space → _
+    ("My@Data",      "My_Data"),        # @ → _
+    ("!!hello!!",    "hello"),          # leading/trailing _ stripped
+    ("###",          DEFAULT),          # all _ after replace → stripped → empty → fallback
+    ("........",     DEFAULT),          # all . stripped → empty → fallback
+    ("___",          DEFAULT),          # all _ stripped → empty → fallback
+    ("a" * 200,      "a" * 120),        # truncated to 120
+    ("你好 Dataset",  "Dataset"),        # non-ASCII → _, then stripped
+    # ── edge cases ──
+    ("",             DEFAULT),          # empty string → fallback
+    ("  ",           DEFAULT),          # spaces only → __ → stripped → fallback
+    ("-leading",     "-leading"),       # leading - is NOT stripped (only . and _ are)
+    (".leading",     "leading"),        # leading . stripped
+    ("_leading",     "leading"),        # leading _ stripped
+    ("trailing.",    "trailing"),       # trailing . stripped
+    ("a" * 120,      "a" * 120),        # exactly at the limit — unchanged
+    ("a" * 121,      "a" * 120),        # one over the limit — truncated
+]
+
+
+def test_sanitize_dataset_name_valid_names() -> None:
+    for name, expected in CASES[:4]:
+        result = _sanitize_dataset_name(name, DEFAULT)
+        assert result == expected, (
+            f"[valid] _sanitize_dataset_name({name!r}) = {result!r}, want {expected!r}"
+        )
+
+
+def test_sanitize_dataset_name_invalid_names() -> None:
+    for name, expected in CASES[4:]:
+        result = _sanitize_dataset_name(name, DEFAULT)
+        assert result == expected, (
+            f"[invalid] _sanitize_dataset_name({name!r}) = {result!r}, want {expected!r}"
+        )
+
+
+def test_fallback_used_only_when_empty_after_sanitization() -> None:
+    """Fallback must NOT fire for names that are non-empty after sanitization."""
+    assert _sanitize_dataset_name("ok_name", "fallback") == "ok_name"
+    assert _sanitize_dataset_name("###", "fallback") == "fallback"
+
+
+def test_max_length_is_120() -> None:
+    long = "x" * 200
+    result = _sanitize_dataset_name(long, DEFAULT)
+    assert len(result) == 120, f"expected length 120, got {len(result)}"
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, "→", exc)
+    raise SystemExit(1 if failures else 0)

--- a/integrations/openclaw/__tests__/test_datasetName.ts
+++ b/integrations/openclaw/__tests__/test_datasetName.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression tests for sanitizeDatasetName() and its integration into
+ * datasetNameForScope() — issue #3549.
+ *
+ * Place this file at:
+ *   integrations/openclaw/__tests__/test_datasetName.ts
+ *
+ * Run with the existing test runner (e.g. npx jest or npm test).
+ */
+
+import { sanitizeDatasetName, datasetNameForScope } from "../src/scope.js";
+import type { CogneePluginConfig, MemoryScope } from "../src/types.js";
+
+// ---------------------------------------------------------------------------
+// Shared fixture — minimal Required<CogneePluginConfig>
+// ---------------------------------------------------------------------------
+function makeCfg(overrides: Partial<CogneePluginConfig> = {}): Required<CogneePluginConfig> {
+  return {
+    baseUrl: "http://localhost:8000",
+    datasetName: "openclaw",
+    searchType: "GRAPH_COMPLETION",
+    minScore: 0.3,
+    topK: 5,
+    requestTimeout: 60_000,
+    ingestionTimeout: 300_000,
+    deleteMode: "soft",
+    maxTokens: 512,
+    autoRecall: true,
+    autoRecallScope: ["agent", "user", "company"],
+    scopeRouting: [],
+    defaultScope: "agent" as MemoryScope,
+    companyDataset: "",
+    userDatasetPrefix: "",
+    agentDatasetPrefix: "",
+    agentDatasetTemplate: "",
+    userId: "user1",
+    agentId: "agent1",
+    perAgentMemory: false,
+    recallInjectionPosition: "system",
+    persistSession: false,
+    ...overrides,
+  } as unknown as Required<CogneePluginConfig>;
+}
+
+// ---------------------------------------------------------------------------
+// Issue #3549 canonical test cases — identical across all integrations
+// ---------------------------------------------------------------------------
+const CASES: [string, string, string][] = [
+  // [input, fallback, expected]
+  ["mydataset",    "fb", "mydataset"],
+  ["project_01",   "fb", "project_01"],
+  ["company-prod", "fb", "company-prod"],
+  ["test.v1",      "fb", "test.v1"],
+  ["My Dataset",   "fb", "My_Dataset"],
+  ["My@Data",      "fb", "My_Data"],
+  ["!!hello!!",    "fb", "hello"],
+  ["###",          "fb", "fb"],
+  ["........",     "fb", "fb"],
+  ["___",          "fb", "fb"],
+  ["a".repeat(200), "fb", "a".repeat(120)],
+  ["你好 Dataset",  "fb", "Dataset"],
+  ["",             "fb", "fb"],
+  ["-leading",     "fb", "-leading"],
+  [".leading",     "fb", "leading"],
+  ["_leading",     "fb", "leading"],
+  ["trailing.",    "fb", "trailing"],
+];
+
+describe("sanitizeDatasetName", () => {
+  test("issue #3549 canonical cases", () => {
+    for (const [input, fallback, expected] of CASES) {
+      expect(sanitizeDatasetName(input, fallback)).toBe(expected);
+    }
+  });
+
+  test("max length is 120", () => {
+    expect(sanitizeDatasetName("x".repeat(200), "fb")).toHaveLength(120);
+  });
+
+  test("fallback fires only when result is empty after sanitization", () => {
+    expect(sanitizeDatasetName("ok_name", "fb")).toBe("ok_name");
+    expect(sanitizeDatasetName("###",     "fb")).toBe("fb");
+  });
+
+  test("null/undefined treated as empty string", () => {
+    expect(sanitizeDatasetName(undefined as unknown as string, "fb")).toBe("fb");
+    expect(sanitizeDatasetName(null as unknown as string, "fb")).toBe("fb");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// datasetNameForScope — verifies sanitization is applied in every branch
+// ---------------------------------------------------------------------------
+describe("datasetNameForScope sanitizes composite names", () => {
+  test("company scope: bad companyDataset is sanitised", () => {
+    const cfg = makeCfg({ companyDataset: "My Company!" });
+    expect(datasetNameForScope("company", cfg)).toBe("My_Company");
+  });
+
+  test("company scope: bad datasetName propagates and is sanitised", () => {
+    const cfg = makeCfg({ datasetName: "my@claw", companyDataset: "" });
+    // composite = "my@claw-company" → "my_claw-company"
+    expect(datasetNameForScope("company", cfg)).toBe("my_claw-company");
+  });
+
+  test("user scope: userId with special chars is sanitised", () => {
+    const cfg = makeCfg({ userId: "user@example.com", userDatasetPrefix: "" });
+    // "openclaw-user-user@example.com" → "openclaw-user-user_example.com"
+    expect(datasetNameForScope("user", cfg)).toBe("openclaw-user-user_example.com");
+  });
+
+  test("agent scope: agentDatasetTemplate with special chars is sanitised", () => {
+    const cfg = makeCfg({ agentDatasetTemplate: "!!{agentId}!!", agentId: "bot" });
+    // "!!bot!!" → "__bot__" → strip → "bot"
+    expect(datasetNameForScope("agent", cfg)).toBe("bot");
+  });
+
+  test("agent scope: fully-invalid template falls back", () => {
+    const cfg = makeCfg({ agentDatasetTemplate: "###", agentId: "bot" });
+    expect(datasetNameForScope("agent", cfg)).toBe("openclaw-agent-default");
+  });
+
+  test("valid config produces unchanged dataset names", () => {
+    const cfg = makeCfg({ datasetName: "openclaw", agentId: "bot" });
+    expect(datasetNameForScope("company", cfg)).toBe("openclaw-company");
+    expect(datasetNameForScope("user",    cfg)).toBe("openclaw-user-user1");
+    expect(datasetNameForScope("agent",   cfg)).toBe("openclaw-agent-bot");
+  });
+});

--- a/integrations/openclaw/src/scope.ts
+++ b/integrations/openclaw/src/scope.ts
@@ -134,6 +134,25 @@ function sanitizeSessionKey(value: string): string {
 }
 
 /**
+ * Sanitize a Cognee dataset name using the same character rules as sanitizeSessionKey.
+ *
+ * Keeps ASCII alphanumerics plus `-` `_` `.`; replaces everything else with `_`;
+ * strips leading/trailing `.` and `_`; caps at 120 characters.
+ * Falls back to *fallback* when the result is empty (e.g. input was "###").
+ *
+ * All branches of datasetNameForScope() pass their composite name through here so
+ * that the same invalid input normalises identically regardless of which memory
+ * scope is active, and identically to the Python integrations.
+ */
+export function sanitizeDatasetName(name: string, fallback: string): string {
+  let safe = "";
+  for (const ch of String(name ?? ""))
+    safe += /[A-Za-z0-9\-_.]/.test(ch) ? ch : "_";
+  const sanitized = safe.replace(/^[._]+/, "").replace(/[._]+$/, "").slice(0, 120);
+  return sanitized || fallback;
+}
+
+/**
  * Build the Cognee session id from the host (OpenClaw) session id, following the
  * cross-integration convention `{agent}_{native_session_id}` —
  * e.g. `open_claw_<openclaw-session-id>`. Keeps the session self-describing in the
@@ -160,11 +179,16 @@ export function datasetNameForScope(
 ): string {
   switch (scope) {
     case "company":
-      return cfg.companyDataset || `${cfg.datasetName}-company`;
-    case "user":
-      return cfg.userDatasetPrefix
+      return sanitizeDatasetName(
+        cfg.companyDataset || `${cfg.datasetName}-company`,
+        "openclaw-company",
+      );
+    case "user": {
+      const name = cfg.userDatasetPrefix
         ? `${cfg.userDatasetPrefix}-${cfg.userId || "default"}`
         : `${cfg.datasetName}-user-${cfg.userId || "default"}`;
+      return sanitizeDatasetName(name, "openclaw-user-default");
+    }
     case "agent": {
       const rawId = runtimeAgentId?.trim() || cfg.agentId || "default";
       // Lowercase ONLY in per-agent mode, so existing single-agent / non-per-agent
@@ -172,12 +196,15 @@ export function datasetNameForScope(
       // OpenClaw already lowercases the runtime ctx.agentId, so per-agent mode
       // stays internally consistent across startup-seed and runtime hooks.
       const id = cfg.perAgentMemory ? rawId.toLowerCase() : rawId;
+      let name: string;
       if (cfg.agentDatasetTemplate) {
-        return cfg.agentDatasetTemplate.replace(/\{agentId\}/g, id);
+        name = cfg.agentDatasetTemplate.replace(/\{agentId\}/g, id);
+      } else {
+        name = cfg.agentDatasetPrefix
+          ? `${cfg.agentDatasetPrefix}-${id}`
+          : `${cfg.datasetName}-agent-${id}`;
       }
-      return cfg.agentDatasetPrefix
-        ? `${cfg.agentDatasetPrefix}-${id}`
-        : `${cfg.datasetName}-agent-${id}`;
+      return sanitizeDatasetName(name, "openclaw-agent-default");
     }
   }
 }

--- a/tests/test_cross_integration_parity.py
+++ b/tests/test_cross_integration_parity.py
@@ -1,0 +1,149 @@
+"""Cross-integration parity test — issue #3549.
+
+Asserts that the dataset-name sanitizer produces **identical output** across
+all three Python integrations (hermes-agent, codex, claude-code) for every
+canonical input from the issue.  The TypeScript openclaw sanitizer uses the
+same algorithm; its parity is verified independently in:
+    integrations/openclaw/__tests__/test_datasetName.ts
+
+Run from the cognee-integrations repo root:
+    python tests/test_cross_integration_parity.py
+or:
+    pytest tests/test_cross_integration_parity.py
+"""
+
+import importlib.util
+import pathlib
+import sys
+import types
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent  # cognee-integrations/
+
+
+def _load_module(label: str, file_path: pathlib.Path) -> types.ModuleType:
+    """Load a Python file by absolute path under a unique module label.
+
+    Using a unique label per integration avoids sys.modules key collisions
+    between codex and claude-code, which both expose a module named
+    `_plugin_common`.
+    """
+    spec = importlib.util.spec_from_file_location(label, file_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+# ── hermes-agent ─────────────────────────────────────────────────────────────
+_hermes_root = REPO_ROOT / "integrations" / "hermes-agent"
+sys.path.insert(0, str(_hermes_root))
+try:
+    from cognee_integration_hermes.provider import _sanitize_dataset_name as hermes_sanitize  # noqa: E402,I001
+finally:
+    sys.path.pop(0)
+
+# ── codex ─────────────────────────────────────────────────────────────────────
+_codex_pc = _load_module(
+    "codex__plugin_common",
+    REPO_ROOT / "integrations" / "codex" / "plugins" / "cognee" / "scripts" / "_plugin_common.py",
+)
+codex_sanitize = _codex_pc.sanitize_dataset_name  # type: ignore[attr-defined]
+
+# ── claude-code ───────────────────────────────────────────────────────────────
+_claude_pc = _load_module(
+    "claude_code__plugin_common",
+    REPO_ROOT / "integrations" / "claude-code" / "scripts" / "_plugin_common.py",
+)
+claude_sanitize = _claude_pc.sanitize_dataset_name  # type: ignore[attr-defined]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Canonical test cases — expected output is integration-agnostic.
+# Use a sentinel string as the fallback so we can detect when a sanitizer
+# correctly falls back (rather than accidentally matching "hermes" or
+# "agent_sessions").
+# ─────────────────────────────────────────────────────────────────────────────
+FALLBACK = "DEFAULT"
+
+CASES: list[tuple[str, str]] = [
+    # valid names — pass through unchanged
+    ("mydataset",    "mydataset"),
+    ("project_01",   "project_01"),
+    ("company-prod", "company-prod"),
+    ("test.v1",      "test.v1"),
+    # invalid names — must be normalised identically
+    ("My Dataset",   "My_Dataset"),   # space → _
+    ("My@Data",      "My_Data"),      # @ → _
+    ("!!hello!!",    "hello"),        # leading/trailing _ stripped
+    ("###",          FALLBACK),       # all _ after replace → stripped → empty → fallback
+    ("........",     FALLBACK),       # all . stripped → empty → fallback
+    ("___",          FALLBACK),       # all _ stripped → empty → fallback
+    ("a" * 200,      "a" * 120),      # truncated to 120
+    ("你好 Dataset",  "Dataset"),      # non-ASCII → _, then stripped
+    # edge cases
+    ("",             FALLBACK),       # empty → fallback
+    ("  ",           FALLBACK),       # spaces only → __ → stripped → fallback
+    ("-leading",     "-leading"),     # leading - is NOT stripped (only . and _ are)
+    (".leading",     "leading"),      # leading . stripped
+    ("_leading",     "leading"),      # leading _ stripped
+    ("trailing.",    "trailing"),     # trailing . stripped
+]
+
+SANITIZERS: dict[str, object] = {
+    "hermes-agent": hermes_sanitize,
+    "codex":        codex_sanitize,
+    "claude-code":  claude_sanitize,
+}
+
+
+def test_all_integrations_agree() -> None:
+    """Every sanitizer must produce the exact same string for every canonical input."""
+    for raw_input, expected in CASES:
+        results = {name: fn(raw_input, FALLBACK) for name, fn in SANITIZERS.items()}  # type: ignore[operator]
+        unique = set(results.values())
+        assert len(unique) == 1, (
+            f"Input {raw_input!r}: integrations disagree — {results}"
+        )
+        actual = unique.pop()
+        assert actual == expected, (
+            f"Input {raw_input!r}: all integrations agreed on {actual!r} but expected {expected!r}"
+        )
+
+
+def test_each_integration_individually() -> None:
+    """Belt-and-suspenders: run the full canonical table per integration."""
+    for int_name, fn in SANITIZERS.items():
+        for raw_input, expected in CASES:
+            result = fn(raw_input, FALLBACK)  # type: ignore[operator]
+            assert result == expected, (
+                f"[{int_name}] sanitize({raw_input!r}) = {result!r}, want {expected!r}"
+            )
+
+
+def test_fallback_only_when_empty() -> None:
+    """Fallback must NOT fire when the sanitised name is non-empty."""
+    for int_name, fn in SANITIZERS.items():
+        assert fn("ok_name", "fb") == "ok_name", f"[{int_name}] fired fallback for valid name"  # type: ignore[operator]
+        result = fn("###", "fb")  # type: ignore[operator]
+        assert result == "fb", f"[{int_name}] did not fire fallback for invalid name"
+
+
+def test_max_length_is_120() -> None:
+    """All integrations must cap the sanitised name at 120 characters."""
+    long_input = "x" * 200
+    for int_name, fn in SANITIZERS.items():
+        result = fn(long_input, FALLBACK)  # type: ignore[operator]
+        assert len(result) == 120, (
+            f"[{int_name}] expected length 120, got {len(result)}"
+        )
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _test_name, _fn in sorted(globals().items()):
+        if _test_name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _test_name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _test_name, "→", exc)
+    raise SystemExit(1 if failures else 0)


### PR DESCRIPTION
## Summary

Fixes #3549  dataset names were not sanitized consistently across the four
integrations, allowing invalid characters to reach the Cognee API.

hermes-agent: added `_sanitize_dataset_name()` in `provider.py`, applied at `initialize()`, `_handle_remember()`, and `_handle_forget()`
- codex: added `sanitize_dataset_name()` in `_plugin_common.py`, wired into `get_dataset()` in `config.py`
- claude-code: same as codex
- openclaw*
<img width="559" height="355" alt="sanittization" src="https://github.com/user-attachments/assets/64fc7f21-7112-44e0-a27f-c4ace491e5e6" />

 added `sanitizeDatasetName()` in `scope.ts`, applied in all three branches of `datasetNameForScope()`

Same rule everywhere: keep ASCII `[A-Za-z0-9\-_.]`, replace anything else with `_`, strip leading/trailing `._`, cap at 120 chars, fall back to integration default if empty.

## Test plan

- [x] Per-integration regression tests: `test_dataset_name.py` for each Python integration, `test_datasetName.ts` for openclaw
- [x] Cross-integration parity test imports all three Python sanitizers and asserts byte-identical output for every canonical input
- [x] Full openclaw Jest suite passes (55 tests including pre-existing `test_syncFiles.ts`)
- [x] All pre-existing claude-code tests pass (76 total, 0 failures)
- [x] Ruff linter clean on all changed files
- [x] TypeScript type-check (`tsc --noEmit --skipLibCheck`) passes
