### PR TITLE
ci(pins): validate only the integrations a PR changes

### DIFF
--- a/.github/actions/changed-integrations/action.yml
+++ b/.github/actions/changed-integrations/action.yml
@@ -1,0 +1,59 @@
+name: Detect changed integrations
+description: >-
+  Classify the integration directories changed vs the PR base (or the previous
+  push) into JSON arrays of Python and TypeScript slugs. Requires the repo to be
+  checked out with fetch-depth 0 first. Shared by ci.yml and check-pinning.yml so
+  the change-detection logic lives in one place.
+
+outputs:
+  python:
+    description: JSON array of changed Python integration slugs (dirs with a pyproject.toml).
+    value: ${{ steps.classify.outputs.python }}
+  typescript:
+    description: JSON array of changed TypeScript integration slugs (dirs with a package.json).
+    value: ${{ steps.classify.outputs.typescript }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect and classify changed integrations
+      id: classify
+      shell: bash
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          BASE=${{ github.event.pull_request.base.sha }}
+        else
+          BASE=${{ github.event.before }}
+        fi
+
+        # Find changed integration directories (exclude dotfiles like inventory.yml edits)
+        CHANGED_DIRS=$(git diff --name-only "$BASE" HEAD -- integrations/ \
+          | grep -E '^integrations/[^/]+/' \
+          | cut -d/ -f2 | sort -u || true)
+
+        PY_LIST=""
+        TS_LIST=""
+
+        for dir in $CHANGED_DIRS; do
+          [ ! -d "integrations/$dir" ] && continue
+          if [ -f "integrations/$dir/pyproject.toml" ]; then
+            PY_LIST="${PY_LIST}\"${dir}\","
+          elif [ -f "integrations/$dir/package.json" ]; then
+            TS_LIST="${TS_LIST}\"${dir}\","
+          fi
+        done
+
+        # Build JSON arrays
+        if [ -n "$PY_LIST" ]; then
+          echo "python=[${PY_LIST%,}]" >> "$GITHUB_OUTPUT"
+        else
+          echo "python=[]" >> "$GITHUB_OUTPUT"
+        fi
+
+        if [ -n "$TS_LIST" ]; then
+          echo "typescript=[${TS_LIST%,}]" >> "$GITHUB_OUTPUT"
+        else
+          echo "typescript=[]" >> "$GITHUB_OUTPUT"
+        fi
+
+        echo "Changed dirs: $CHANGED_DIRS"

--- a/.github/workflows/check-pinning.yml
+++ b/.github/workflows/check-pinning.yml
@@ -16,11 +16,24 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect and classify changed integrations
+        id: changes
+        uses: ./.github/actions/changed-integrations
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
-      - name: Check cognee version pinning
-        run: python scripts/check_version_pins.py
+      # Validate only the Python integrations this push/PR changed (via the same
+      # detect-changes action ci.yml uses), so a PR is not blocked by pre-existing
+      # pinning debt in integrations it doesn't touch. check_version_pins.py with
+      # no args still audits every integration for a manual/scheduled full sweep.
+      - name: Check cognee version pinning (changed integrations only)
+        if: ${{ steps.changes.outputs.python != '[]' }}
+        env:
+          CHANGED: ${{ join(fromJSON(steps.changes.outputs.python), ' ') }}
+        run: python scripts/check_version_pins.py $CHANGED

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,44 +28,7 @@ jobs:
 
       - name: Detect and classify changed integrations
         id: classify
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE=${{ github.event.pull_request.base.sha }}
-          else
-            BASE=${{ github.event.before }}
-          fi
-
-          # Find changed integration directories (exclude dotfiles like inventory.yml edits)
-          CHANGED_DIRS=$(git diff --name-only "$BASE" HEAD -- integrations/ \
-            | grep -E '^integrations/[^/]+/' \
-            | cut -d/ -f2 | sort -u || true)
-
-          PY_LIST=""
-          TS_LIST=""
-
-          for dir in $CHANGED_DIRS; do
-            [ ! -d "integrations/$dir" ] && continue
-            if [ -f "integrations/$dir/pyproject.toml" ]; then
-              PY_LIST="${PY_LIST}\"${dir}\","
-            elif [ -f "integrations/$dir/package.json" ]; then
-              TS_LIST="${TS_LIST}\"${dir}\","
-            fi
-          done
-
-          # Build JSON arrays
-          if [ -n "$PY_LIST" ]; then
-            echo "python=[${PY_LIST%,}]" >> "$GITHUB_OUTPUT"
-          else
-            echo "python=[]" >> "$GITHUB_OUTPUT"
-          fi
-
-          if [ -n "$TS_LIST" ]; then
-            echo "typescript=[${TS_LIST%,}]" >> "$GITHUB_OUTPUT"
-          else
-            echo "typescript=[]" >> "$GITHUB_OUTPUT"
-          fi
-
-          echo "Changed dirs: $CHANGED_DIRS"
+        uses: ./.github/actions/changed-integrations
 
   test-python:
     needs: detect-changes

--- a/scripts/check_version_pins.py
+++ b/scripts/check_version_pins.py
@@ -14,14 +14,22 @@ Non-Python integrations (TypeScript, etc.) are skipped — they may depend on
 Cognee via HTTP API rather than a Python package.
 
 Usage:
-    python scripts/check_version_pins.py
+    python scripts/check_version_pins.py                       # check every integration
+    python scripts/check_version_pins.py integrations/vellum/pyproject.toml ...
+    python scripts/check_version_pins.py vellum strands        # by slug or dir
+
+With no arguments every integration is checked. Given one or more targets
+(a slug, an integration dir, or a pyproject.toml path) only those are checked —
+CI uses this to validate just the integrations a PR changes, so a PR is not
+blocked by pre-existing pinning debt in integrations it does not touch.
 """
 
-import sys
 import re
+import sys
 from pathlib import Path
 
 INTEGRATIONS_DIR = Path(__file__).resolve().parent.parent / "integrations"
+REPO_ROOT = INTEGRATIONS_DIR.parent
 
 # Matches cognee dependency with optional extras: "cognee..." or "cognee[extra]..."
 # The negative lookahead (?![\w-]) prevents matching longer names like "cognee-dify-plugin".
@@ -82,7 +90,35 @@ def check_pyproject(pyproject_path: Path) -> list[str]:
     return errors
 
 
-def main():
+def _pyproject_for(target: str) -> Path:
+    """Resolve a target (slug, integration dir, or pyproject.toml path) to its pyproject."""
+    path = Path(target)
+    if not path.is_absolute():
+        path = REPO_ROOT / path
+    if path.name == "pyproject.toml":
+        return path
+    if path.is_dir():
+        return path / "pyproject.toml"
+    # Bare slug, e.g. "vellum".
+    return INTEGRATIONS_DIR / target / "pyproject.toml"
+
+
+def _pyprojects_to_check(argv):
+    """The pyproject files to check: the given targets, or every integration."""
+    if argv:
+        seen = set()
+        for target in argv:
+            pyproject = _pyproject_for(target)
+            if pyproject not in seen:
+                seen.add(pyproject)
+                yield pyproject
+        return
+    for integration_dir in sorted(INTEGRATIONS_DIR.iterdir()):
+        if integration_dir.is_dir():
+            yield integration_dir / "pyproject.toml"
+
+
+def main(argv):
     if not INTEGRATIONS_DIR.exists():
         print(f"Integrations directory not found: {INTEGRATIONS_DIR}")
         sys.exit(1)
@@ -91,24 +127,21 @@ def main():
     checked = 0
     skipped = 0
 
-    for integration_dir in sorted(INTEGRATIONS_DIR.iterdir()):
-        if not integration_dir.is_dir():
-            continue
-
-        pyproject = integration_dir / "pyproject.toml"
+    for pyproject in _pyprojects_to_check(argv):
         if not pyproject.exists():
-            # Non-Python integration (e.g., TypeScript/OpenClaw plugin) — skip
+            # Non-Python integration (e.g. TypeScript plugin) or a changed path
+            # that isn't a Python integration — nothing to check.
             skipped += 1
             continue
 
         checked += 1
-        errors = check_pyproject(pyproject)
-        all_errors.extend(errors)
+        all_errors.extend(check_pyproject(pyproject))
 
-    print(f"Checked {checked} Python integration(s), skipped {skipped} non-Python.")
+    scope = "changed" if argv else "all"
+    print(f"Checked {checked} Python integration(s), skipped {skipped} ({scope} scope).")
 
     if checked == 0:
-        print("No Python integrations with pyproject.toml found.")
+        print("No Python integrations with pyproject.toml to check.")
         sys.exit(0)
 
     if all_errors:
@@ -117,9 +150,9 @@ def main():
             print(f"  - {error}")
         sys.exit(1)
     else:
-        print("All Python integrations have properly bounded cognee dependencies.")
+        print("All checked integrations have properly bounded cognee dependencies.")
         sys.exit(0)
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])


### PR DESCRIPTION
## Problem

`check-pinning.yml` runs `scripts/check_version_pins.py` with **no arguments**, which validates the cognee pin of **every** integration. Because the workflow triggers whenever any `integrations/*/pyproject.toml` changes, a PR that touches one integration is blocked by **pre-existing pinning debt in unrelated, unchanged integrations**.

Concretely: a compliant new integration (`cognee>=1.2.2,<1.3.0`) fails `check-pins` today only because `crewai` still declares an unbounded `cognee>=0.4.0`.

## Fix — reuse the existing change-detection, don't duplicate it

`ci.yml` already scopes its per-integration jobs to what changed via an inline `detect-changes` step. Rather than copy that `git diff` logic into `check-pinning.yml`, this extracts it into a **shared composite action** — matching the `.github/actions/*` convention the `cognee` repo uses (`cognee_setup`) — and points both workflows at it:

- **`.github/actions/changed-integrations`** (new) — the change-detection, verbatim from `ci.yml`'s `detect-changes`; outputs `python` / `typescript` slug arrays.
- **`ci.yml`** — `detect-changes` now just `uses:` the action. Same step id, same outputs → **behaviour unchanged** (one-step swap, see the diff).
- **`check-pinning.yml`** — `uses:` the same action and runs the script on only the changed Python integration slugs (`join(fromJSON(...))`); no-op when none changed. Kept as its own workflow so the `check-pins` status is preserved.
- **`check_version_pins.py`** — now takes optional targets (slug / dir / `pyproject.toml` path); **with no args it still audits every integration**, so a manual/scheduled full-repo sweep is unchanged. Imports sorted so it's ruff-clean (`scripts/` isn't in the lint job's scope today).

## Why this shape

- **No duplication:** one change-detection definition, shared — the smell of hand-rolling a second `git diff` is gone.
- **Follows established patterns:** composite action = `cognee`'s `.github/actions` idiom; `check-pins` still consumes the same detection `ci.yml`'s `test-python` matrix does.
- **Still strict:** a violation in a *changed* integration fails; pre-existing debt (crewai) stays flagged the next time that integration is touched, and a no-arg full sweep still catches it.

## Verification (local)

```
# only a compliant changed integration → passes
$ python scripts/check_version_pins.py integrations/strands/pyproject.toml   # exit 0
$ python scripts/check_version_pins.py langgraph google-adk                  # exit 0
# a changed non-compliant integration → still fails
$ python scripts/check_version_pins.py integrations/crewai/pyproject.toml    # exit 1
# no args (full audit) → unchanged, still catches crewai
$ python scripts/check_version_pins.py                                       # exit 1
```

All three workflow/action YAMLs parse and are wired correctly (verified); `ruff check` clean. This PR changes no integration, so `check-pins` correctly doesn't run here, and `ci.yml`'s `detect-changes` exercises the new action (resolving to empty → tests skip).

Unblocks the compliant [#234](https://github.com/topoteretes/cognee-integrations/pull/234) (Vellum). Separate follow-up worth doing: bound crewai's cognee pin and give it a smoke test.
