### PR TITLE
feat: add versioning to Claude and Codex. add update messages

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "author": {
         "name": "Cognee"
       },

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "author": {
     "name": "Cognee"
   },

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+All notable changes to the **cognee-memory** Claude Code plugin are documented here.
+
+The version here must match the `version` field in both `.claude-plugin/plugin.json`
+and the plugin's entry in the repository-root `.claude-plugin/marketplace.json` — Claude
+Code only offers an update when that string changes. Tag releases as
+`cognee-memory-vX.Y.Z` (matching the repo's per-plugin tag convention).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
+project adheres to [Semantic Versioning](https://semver.org/).
+
+## [1.0.0]
+
+First release under formal semantic versioning — marks the official start of
+versioning for this plugin. Supersedes the unversioned `0.2.0` baseline and
+bundles all changes since, from the automatic install/server-bootstrap work
+onward.
+
+### Added
+- **Automatic Cognee installation + server bootstrap.** A self-managed,
+  `uv`-provisioned virtualenv under `~/.cognee-plugin/venv`, with data pinned to
+  `~/.cognee` so it survives venv rebuilds and cognee upgrades.
+- **Lazy bootstrap.** SessionStart spawns a detached worker to boot the local
+  server (including DB migrations), so the hook returns fast and never times out.
+- **Automatic status-line setup.** The plugin writes/enables its status line into
+  `~/.claude/settings.json` on first run — no manual configuration.
+- **Server-first recall client** with a circuit breaker and bounded timeouts;
+  falls back to the CLI only on a genuine failure, never on an empty result.
+- **Background remember + cognify status polling.** Writes enqueue and poll to
+  completion instead of holding one request open past the cloud's request ceiling.
+- **Memory-preference steer.** SessionStart asserts Cognee as the preferred
+  memory over Claude Code's native `MEMORY.md` (opt out with `COGNEE_PREFER_MEMORY`).
+- **Status-line cleanup on uninstall/disable.** The renderer self-evicts its
+  `statusLine` entry from `~/.claude/settings.json` when the plugin is no longer
+  enabled, and the entry is written as an existence-guarded command so an
+  uninstalled plugin never leaves a broken status-line command behind.
+
+### Changed
+- **Single-principal / session-id model.** Session IDs are the point of contact
+  with agents; removed per-agent user creation.
+- **Dataset-scoped model.** Removed session switching in favor of datasets, with
+  one shared default dataset (`agent_sessions`) across the Claude and Codex plugins.
+- **Deterministic session naming** as `{agent}_{host_session_id}`.
+- **Session→graph sync via session-aware `improve`**, replacing full-transcript
+  re-cognify on every sync; the legacy document bridge remains as a fallback.
+- **New session distillation logic.**
+- **Cloud mode is now a pure thin client.** The cloud/remote setup path (health
+  check, `/users/me`, dataset ensure, default-user key mint) uses stdlib `urllib`
+  instead of `aiohttp`, so connecting to Cognee Cloud no longer requires the
+  plugin's local virtualenv. The venv is now built only in local mode.
+- Renamed the `service_url` config/env to `base_url`.
+
+### Fixed
+- **TLS certificate verification for cloud/HTTPS.** All `urllib` HTTPS calls now
+  share a certifi-backed SSL context (falling back to `SSL_CERT_FILE` / system
+  cert bundles), fixing `CERTIFICATE_VERIFY_FAILED` against Cognee Cloud on macOS
+  Python builds that lack root CAs in the default context.
+- Concurrency-safe pending-prompt and bridge buffers (per-session files, no
+  lost-update races).
+- `base_url` handling and connecting to an existing dataset; dataset name/config
+  resolution; `/users/me` identity resolution; and bridge-POST network/HTTP-error
+  handling with bounded poll deadlines.
+
+## [0.2.0]
+
+- Baseline release: session-aware capture (prompts, tool traces, assistant
+  responses), auto-routing recall on prompt submit, session→graph sync on
+  session end, local and Cognee Cloud modes, and automatic Cognee bootstrap for
+  local mode.

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -239,25 +239,66 @@ Shared state (used by both Claude Code and Codex plugins):
 ~/.cognee-plugin/venv/            # shared Cognee virtualenv
 ```
 
-## Update or remove
+## Updating
 
-Reinstall the plugin to pick up marketplace updates (run inside Claude Code chat):
+The plugin is versioned with [semver](https://semver.org/) — see
+[`CHANGELOG.md`](./CHANGELOG.md). Claude Code offers an update only when the
+plugin's `version` changes (it's pinned in the marketplace entry), so a plain
+reinstall of the same version reuses the cached copy.
+
+**Update on demand:**
+
+```
+/plugin marketplace update cognee     # refresh the marketplace catalog
+/plugin update cognee-memory@cognee   # apply a newer version if one exists
+```
+
+`/plugin update` reports "already at the latest version" when your installed
+version matches the published one.
+
+**Automatic updates (recommended):** Claude Code can refresh marketplaces and
+update installed plugins in the background after startup, then prompt you to run
+`/reload-plugins`. Auto-update is **enabled by default only for official
+Anthropic marketplaces** — for the third-party `cognee` marketplace you must opt
+in via Claude Code's per-marketplace auto-update setting (see the "Configure
+auto-updates" section of the Claude Code plugin docs). With it on, new releases
+land without any manual `/plugin update`.
+
+**If updates still don't appear**, re-add the marketplace source and reinstall:
 
 ```
 /plugin uninstall cognee-memory@cognee
-/plugin install cognee-memory@cognee
-```
-
-To also refresh the marketplace source:
-
-```
-/plugin uninstall cognee-memory@cognee
-/plugin marketplace remove topoteretes/cognee-integrations
+/plugin marketplace remove cognee
 /plugin marketplace add topoteretes/cognee-integrations
 /plugin install cognee-memory@cognee
 ```
 
-There is no automatic update mechanism — reinstall is the only way to pull in new plugin versions.
+### Update notifications
+
+When a newer version is published, the plugin surfaces it automatically — no
+configuration needed to receive them:
+
+- **Status line:** an amber `⬆ Cognee update available <installed>→<latest>`
+  segment appears, and disappears once you update.
+- **SessionStart:** a one-time message per new version, e.g. *"Cognee update
+  available 1.0.0 → 1.2.0 — run `/plugin update cognee-memory@cognee`."*
+
+A background check in the idle watcher runs **at most once per day** and fetches a
+single public file — the marketplace manifest on the tracked git ref, via
+`raw.githubusercontent.com` — to read the published version. It sends no data and
+no telemetry, uses a conditional (ETag) request, fails silently when offline, and
+skips local-path (dev) installs. Turn it off with `COGNEE_UPDATE_CHECK=false`.
+
+| Env var | Default | Effect |
+|---|---|---|
+| `COGNEE_UPDATE_CHECK` | `true` | Background "update available" check + status-line/SessionStart nudges |
+| `COGNEE_UPDATE_CHECK_INTERVAL` | `86400` | Minimum seconds between checks |
+
+## Remove
+
+```
+/plugin uninstall cognee-memory@cognee
+```
 
 ## Troubleshooting
 

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1108,6 +1108,196 @@ def server_ready_hint(service_url: str = "") -> bool:
     return True
 
 
+# --- Plugin update check (Phase 2) -------------------------------------------
+# A background, once-a-day check comparing the installed plugin version against
+# the version published on the marketplace's git ref. The network call runs only
+# here (in the background idle watcher); the hot path (SessionStart message,
+# status line) merely READS the marker file this writes — never the network.
+# Talks only to raw.githubusercontent (CDN, no API rate limit) over the shared
+# certifi TLS context. Opt out with COGNEE_UPDATE_CHECK=off.
+_UPDATE_CHECK_FILE = _PLUGIN_DIR / "update-check.json"
+_UPDATE_CHECK_INTERVAL_DEFAULT = 86400.0
+_UPDATE_DEFAULT_REPO = "topoteretes/cognee-integrations"
+_UPDATE_DEFAULT_REF = "main"
+_UPDATE_PLUGIN_ENTRY = "cognee-memory"
+_KNOWN_MARKETPLACES = Path.home() / ".claude" / "plugins" / "known_marketplaces.json"
+
+
+def _update_check_enabled() -> bool:
+    return os.environ.get("COGNEE_UPDATE_CHECK", "").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+def _parse_semver(value: str):
+    """Parse the numeric X.Y.Z core (ignoring any -pre/+build suffix); None if not X.Y.Z."""
+    core = str(value or "").strip().lstrip("vV").split("-", 1)[0].split("+", 1)[0]
+    parts = core.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        return tuple(int(p) for p in parts)
+    except ValueError:
+        return None
+
+
+def _semver_gt(a: str, b: str) -> bool:
+    pa, pb = _parse_semver(a), _parse_semver(b)
+    return bool(pa and pb and pa > pb)
+
+
+def _installed_plugin_version() -> str:
+    candidates = []
+    root = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
+    if root:
+        candidates.append(Path(root) / ".claude-plugin" / "plugin.json")
+    candidates.append(Path(__file__).resolve().parent.parent / ".claude-plugin" / "plugin.json")
+    for path in candidates:
+        try:
+            version = str(json.loads(path.read_text(encoding="utf-8")).get("version") or "").strip()
+            if version:
+                return version
+        except Exception:
+            continue
+    return ""
+
+
+def _update_source() -> Optional[tuple]:
+    """Return (repo, ref) to read the published version from, or None to skip.
+
+    Reads the 'cognee' marketplace source from Claude's known_marketplaces.json.
+    A non-github source (e.g. a local-path dev install) returns None so local
+    checkouts never nag themselves; a missing/odd file falls back to the default
+    repo (the normal published case).
+    """
+    try:
+        data = json.loads(_KNOWN_MARKETPLACES.read_text(encoding="utf-8"))
+        entry = data.get("cognee") if isinstance(data, dict) else None
+        source = entry.get("source") if isinstance(entry, dict) else None
+        if isinstance(source, dict):
+            if source.get("source") == "github" and source.get("repo"):
+                return str(source["repo"]), str(source.get("ref") or _UPDATE_DEFAULT_REF)
+            return None  # non-github (local path / other): skip, don't self-nag
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        hook_log("update_source_read_failed", {"error": str(exc)[:200]})
+    return _UPDATE_DEFAULT_REPO, _UPDATE_DEFAULT_REF
+
+
+def _fetch_published_version(repo: str, ref: str, etag: str) -> tuple:
+    """GET the raw marketplace.json and read the plugin entry's version.
+
+    Returns (version, new_etag, error). version is '' on 304/not-found/error so
+    the caller keeps the previously-known latest.
+    """
+    url = f"https://raw.githubusercontent.com/{repo}/{ref}/.claude-plugin/marketplace.json"
+    req = urllib.request.Request(url, method="GET")
+    if etag:
+        req.add_header("If-None-Match", etag)
+    try:
+        with urllib.request.urlopen(req, timeout=5.0, context=_https_context()) as resp:
+            body = resp.read().decode("utf-8")
+            new_etag = resp.headers.get("ETag", "") or etag
+            data = json.loads(body)
+            plugins = data.get("plugins", []) if isinstance(data, dict) else []
+            for plugin in plugins:
+                if isinstance(plugin, dict) and plugin.get("name") == _UPDATE_PLUGIN_ENTRY:
+                    return str(plugin.get("version") or ""), new_etag, ""
+            return "", new_etag, "entry_not_found"
+    except urllib.error.HTTPError as exc:
+        if exc.code == 304:
+            return "", etag, ""  # unchanged since last check
+        return "", etag, f"http_{exc.code}"
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
+        return "", etag, str(exc)[:120]
+
+
+def maybe_check_for_update() -> None:
+    """Background, ≤once-a-day update check. Writes the marker. Never raises.
+
+    Call from a background process (the idle watcher) — never a synchronous hook,
+    since it may make a network call (bounded to 5s, ≤ once per interval).
+    """
+    try:
+        if not _update_check_enabled():
+            return
+        marker = _load_json_file(_UPDATE_CHECK_FILE)
+        interval = _float_env("COGNEE_UPDATE_CHECK_INTERVAL", _UPDATE_CHECK_INTERVAL_DEFAULT)
+        now = datetime.now(timezone.utc).timestamp()
+        if now - float(marker.get("last_checked_at", 0) or 0) < interval:
+            return  # checked recently
+        source = _update_source()
+        if source is None:
+            return  # local-dev / unknown source
+        repo, ref = source
+        installed = _installed_plugin_version()
+        latest, etag, error = _fetch_published_version(repo, ref, str(marker.get("etag") or ""))
+        if not latest:
+            latest = str(marker.get("latest_version") or "")  # 304/error: keep prior
+        update_available = bool(installed and latest and _semver_gt(latest, installed))
+        _write_json_file(
+            _UPDATE_CHECK_FILE,
+            {
+                "last_checked_at": now,
+                "installed_version": installed,
+                "latest_version": latest,
+                "update_available": update_available,
+                "etag": etag,
+                "source": f"{repo}@{ref}",
+                "error": error,
+                # preserved so the SessionStart message shows once per new version
+                "notified_version": str(marker.get("notified_version") or ""),
+            },
+        )
+        hook_log(
+            "update_check",
+            {
+                "installed": installed,
+                "latest": latest,
+                "available": update_available,
+                "error": error,
+            },
+        )
+    except Exception as exc:
+        hook_log("update_check_failed", {"error": str(exc)[:200]})
+
+
+def read_update_status() -> dict:
+    """Zero-network read of the update marker for surfacing.
+
+    Returns the marker dict only when an update is genuinely available; {} when
+    disabled, absent, or already current (so callers can treat truthiness as
+    "should nudge").
+    """
+    if not _update_check_enabled():
+        return {}
+    marker = _load_json_file(_UPDATE_CHECK_FILE)
+    if (
+        isinstance(marker, dict)
+        and marker.get("update_available")
+        and marker.get("installed_version")
+        and marker.get("latest_version")
+    ):
+        return marker
+    return {}
+
+
+def mark_update_notified(version: str) -> None:
+    """Record that the one-time SessionStart message for `version` has been shown."""
+    try:
+        marker = _load_json_file(_UPDATE_CHECK_FILE)
+        if not marker:
+            return
+        marker["notified_version"] = str(version or "")
+        _write_json_file(_UPDATE_CHECK_FILE, marker)
+    except Exception as exc:
+        hook_log("update_notified_write_failed", {"error": str(exc)[:200]})
+
+
 def resolve_runtime_mode() -> dict:
     """Resolve hook runtime mode from effective endpoint auth."""
     service_url_raw, url_source = _local_api_url_with_source()

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -20,6 +20,7 @@ _SHARED_ROOT = Path.home() / ".cognee-plugin"
 _CONFIG_PATH = _SHARED_ROOT / "claude-code" / "config.json"
 _SERVER_READY_PATH = _SHARED_ROOT / "server-ready.json"
 _BREAKER_PATH = _SHARED_ROOT / "recall-breaker.json"
+_UPDATE_CHECK_PATH = _SHARED_ROOT / "claude-code" / "update-check.json"
 _DEFAULT_DATASET = "agent_sessions"
 
 # Self-eviction: when the plugin is uninstalled/disabled but its files still
@@ -75,6 +76,30 @@ def _health_prefix() -> str:
     if _SERVER_READY_PATH.exists():
         return "● "
     return ""
+
+
+def _update_segment() -> str:
+    """Amber 'update available' segment, or '' — read purely from the marker.
+
+    The background idle watcher writes the marker; this stays network-free and
+    plugin-runtime-free (no ``_plugin_common`` import), consistent with the
+    renderer's pure-local design. Uses `\\033[1;33m` (bold + amber); terminals
+    that ignore bold still apply the amber, and the trailing reset prevents
+    color bleed into the rest of the bar.
+    """
+    if os.environ.get("COGNEE_UPDATE_CHECK", "").strip().lower() in ("0", "false", "no", "off"):
+        return ""
+    try:
+        marker = json.loads(_UPDATE_CHECK_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    if not (isinstance(marker, dict) and marker.get("update_available")):
+        return ""
+    installed = str(marker.get("installed_version") or "")
+    latest = str(marker.get("latest_version") or "")
+    if not (installed and latest):
+        return ""
+    return f"   \033[1;33m⬆ Cognee update available {installed}→{latest}\033[0m"
 
 
 def _read_json(path: Path) -> dict:
@@ -153,7 +178,9 @@ def main() -> None:
         _evict_own_statusline()
         return
 
-    sys.stdout.write(f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}")
+    sys.stdout.write(
+        f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}{_update_segment()}"
+    )
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/scripts/idle-watcher.py
+++ b/integrations/claude-code/scripts/idle-watcher.py
@@ -154,6 +154,17 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
             return False
 
 
+def _run_update_check() -> None:
+    """Fire the background, daily-guarded plugin update check (best-effort)."""
+    try:
+        sys.path.insert(0, os.path.dirname(__file__))
+        from _plugin_common import maybe_check_for_update  # type: ignore
+
+        maybe_check_for_update()
+    except Exception as exc:
+        _log("update_check_error", error=str(exc)[:200])
+
+
 async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
     _log(
         "started",
@@ -163,6 +174,9 @@ async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
         poll=POLL_SECONDS,
         idle=IDLE_SECONDS,
     )
+    # Runs once per watcher launch (≈ once per session); the check itself is
+    # internally rate-limited to ≤ once per COGNEE_UPDATE_CHECK_INTERVAL.
+    _run_update_check()
     last_improved_at = 0.0
     exit_reason = "loop_complete"
     bridge_disabled = False

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -1208,6 +1208,45 @@ def _apply_memory_preference(output: dict) -> dict:
     return result
 
 
+def _apply_update_nudge(output: dict) -> dict:
+    """Append a one-time 'update available' systemMessage (once per new version).
+
+    The version comparison + marker are produced by the background check in the
+    idle watcher; here we only READ the marker (no network). The status line
+    surfaces the same info ambiently on every refresh — this message is the
+    actionable, one-shot nudge. Shown once per newly-detected version (tracked
+    via ``notified_version``) so it never nags, and auto-stops once updated.
+    """
+    try:
+        from _plugin_common import mark_update_notified, read_update_status
+
+        status = read_update_status()
+    except Exception:
+        return output
+    if not status:
+        return output
+    installed = str(status.get("installed_version") or "")
+    latest = str(status.get("latest_version") or "")
+    if not (installed and latest) or status.get("notified_version") == latest:
+        return output
+
+    message = (
+        f"Cognee update available {installed} → {latest} — run "
+        "`/plugin update cognee-memory@cognee` (or enable marketplace auto-update)."
+    )
+    result = dict(output or {})
+    hso = dict(result.get("hookSpecificOutput") or {})
+    hso.setdefault("hookEventName", "SessionStart")
+    existing = str(hso.get("systemMessage") or "").strip()
+    hso["systemMessage"] = f"{existing}\n\n{message}" if existing else message
+    result["hookSpecificOutput"] = hso
+    try:
+        mark_update_notified(latest)
+    except Exception:
+        pass
+    return result
+
+
 async def _start(payload: dict | None = None) -> dict:
     _ensure_statusline_configured()
     config = load_config()
@@ -1368,6 +1407,7 @@ def main():
     except Exception as exc:
         hook_log("session_start_exception", {"error": str(exc)[:200]})
     output = _apply_memory_preference(output)
+    output = _apply_update_nudge(output)
     print(json.dumps(output or {}))
 
 

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -181,16 +181,56 @@ tail -f ~/.cognee-plugin/codex/exit-watcher.log
 tail -f ~/.cognee-plugin/codex/watcher.log
 ```
 
-## Update or remove
+## Updating
 
-Reinstall plugin after marketplace/plugin changes:
+The `cognee` marketplace tracks the repository's `main` branch (`git-subdir`,
+`ref: main`), so updates arrive as new commits — they are **not** gated by the
+plugin `version` field. Pull the latest with:
+
+```bash
+codex plugin marketplace upgrade cognee
+```
+
+`marketplace upgrade` resolves `main` to its current commit and force-reinstalls
+when it has moved; if nothing changed it reports no upgrade. Note there is **no
+per-plugin `codex plugin update`, and no automatic background updates** for
+user-added marketplaces — run `upgrade` when you want the latest.
+
+The `version` in `.codex-plugin/plugin.json` (see
+[`CHANGELOG.md`](./plugins/cognee/CHANGELOG.md)) follows semver and is bumped each
+release. It is the cache key and lets a normal load reinstall when it changes,
+but the commit ref above is what actually drives updates.
+
+If a stale cached copy persists, remove and re-add:
 
 ```bash
 codex plugin remove cognee@cognee
 codex plugin add cognee@cognee
 ```
 
-Remove plugin and marketplace:
+### Update notifications
+
+When a newer version is published, the plugin surfaces it automatically:
+
+- **In-context status:** a short `⬆ Cognee update available <installed>→<latest>`
+  segment appears in Cognee's status line (which Codex injects into the model's
+  context) and disappears once you update.
+- **SessionStart:** a one-time note per new version — *"Cognee update available
+  1.0.3 → 1.1.0 — run `codex plugin marketplace upgrade cognee`."*
+
+A background check in the idle watcher runs **at most once per day** and fetches a
+single public file — the plugin manifest on `main`, via `raw.githubusercontent.com`
+— to read the published version. It sends no data and no telemetry, uses a
+conditional (ETag) request, and fails silently when offline. Because Codex tracks
+`main`, the nudge fires on version bumps (releases), not on every commit. Turn it
+off with `COGNEE_UPDATE_CHECK=false`.
+
+| Env var | Default | Effect |
+|---|---|---|
+| `COGNEE_UPDATE_CHECK` | `true` | Background "update available" check + status/SessionStart nudges |
+| `COGNEE_UPDATE_CHECK_INTERVAL` | `86400` | Minimum seconds between checks |
+
+## Remove
 
 ```bash
 codex plugin remove cognee@cognee

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.0.3-local",
+  "version": "1.1.0",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to the **cognee** Codex CLI plugin are documented here.
+
+The version here matches the `version` field in `.codex-plugin/plugin.json`. Note
+the `cognee` marketplace is `git-subdir`-pinned to `main`, so updates are actually
+delivered per-commit via `codex plugin marketplace upgrade cognee` — this `version`
+is the cache key and semver record, bumped on each release, not the update trigger.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
+project adheres to [Semantic Versioning](https://semver.org/).
+
+## [1.1.0]
+
+Bundles the arc since the automatic install/server-bootstrap work. Shares most
+changes with the Claude Code plugin; Claude-only items (native `MEMORY.md`
+memory-preference steer, `settings.json` status-line self-eviction) do not apply
+to Codex, which renders its status inline.
+
+### Added
+- **Automatic Cognee installation + server bootstrap** for Codex, with the Codex
+  marketplace. Uses the same self-managed `uv` virtualenv (`~/.cognee-plugin/venv`)
+  and data pinned to `~/.cognee`, shared with the Claude Code plugin.
+- **Lazy bootstrap.** SessionStart spawns a detached worker to boot the local
+  server (including DB migrations) so the hook returns fast.
+- **Server-first recall client** with a circuit breaker and bounded timeouts;
+  falls back to the CLI only on a genuine failure, never on an empty result.
+- **Background remember + cognify status polling.** Writes enqueue and poll to
+  completion instead of holding one request open past the cloud's request ceiling.
+
+### Changed
+- **Single-principal / session-id model.** Session IDs are the point of contact
+  with agents; removed per-agent user creation.
+- **Dataset-scoped model.** Removed session switching in favor of datasets, with
+  one shared default dataset (`agent_sessions`) across the Codex and Claude plugins.
+- **Deterministic session naming** as `{agent}_{host_session_id}`.
+- **Session→graph sync via session-aware `improve`**, replacing full-transcript
+  re-cognify on every sync; the legacy document bridge remains as a fallback.
+- **New session distillation logic.**
+- **Cloud mode is now a pure thin client.** The cloud/remote setup path (health
+  check, `/users/me`, dataset ensure, default-user key mint) uses stdlib `urllib`
+  instead of `aiohttp`, so connecting to Cognee Cloud no longer requires the
+  plugin's local virtualenv.
+- Renamed the `service_url` config/env to `base_url`.
+
+### Fixed
+- **TLS certificate verification for cloud/HTTPS.** All `urllib` HTTPS calls now
+  share a certifi-backed SSL context (falling back to `SSL_CERT_FILE` / system
+  cert bundles), fixing `CERTIFICATE_VERIFY_FAILED` against Cognee Cloud on macOS
+  Python builds that lack root CAs in the default context.
+- Concurrency-safe pending-prompt and bridge buffers (per-session files, no
+  lost-update races).
+- `base_url` handling and connecting to an existing dataset; dataset name/config
+  resolution; `/users/me` identity resolution; and bridge-POST network/HTTP-error
+  handling with bounded poll deadlines.
+
+## [1.0.3]
+
+- Baseline: session-aware capture (session starts, user prompts, tool results,
+  assistant stops) into Cognee session memory, recall on each prompt, inline
+  status visibility, and local and Cognee Cloud modes.

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -1097,6 +1097,178 @@ def server_ready_hint(service_url: str = "") -> bool:
     return True
 
 
+# --- Plugin update check (Phase 2) -------------------------------------------
+# Background, once-a-day check comparing the installed plugin version against the
+# version published on the tracked git ref. The network call runs only here (in
+# the background idle watcher); the hot path (in-context status via
+# render_status_for_host, SessionStart nudge) merely READS the marker this
+# writes. Codex tracks the marketplace's git ref (main) rather than a version
+# pin, so the nudge is driven by comparing the published .codex-plugin/plugin.json
+# version to the installed one. Talks only to raw.githubusercontent over the
+# shared certifi TLS context. Opt out with COGNEE_UPDATE_CHECK=off.
+_UPDATE_CHECK_FILE = _PLUGIN_DIR / "update-check.json"
+_UPDATE_CHECK_INTERVAL_DEFAULT = 86400.0
+_UPDATE_DEFAULT_REPO = "topoteretes/cognee-integrations"
+_UPDATE_DEFAULT_REF = "main"
+_UPDATE_MANIFEST_PATH = "integrations/codex/plugins/cognee/.codex-plugin/plugin.json"
+
+
+def _update_check_enabled() -> bool:
+    return os.environ.get("COGNEE_UPDATE_CHECK", "").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+def _parse_semver(value: str):
+    """Parse the numeric X.Y.Z core (ignoring any -pre/+build suffix); None if not X.Y.Z."""
+    core = str(value or "").strip().lstrip("vV").split("-", 1)[0].split("+", 1)[0]
+    parts = core.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        return tuple(int(p) for p in parts)
+    except ValueError:
+        return None
+
+
+def _semver_gt(a: str, b: str) -> bool:
+    pa, pb = _parse_semver(a), _parse_semver(b)
+    return bool(pa and pb and pa > pb)
+
+
+def _installed_plugin_version() -> str:
+    candidates = []
+    root = os.environ.get("PLUGIN_ROOT", "").strip()
+    if root:
+        candidates.append(Path(root) / ".codex-plugin" / "plugin.json")
+    candidates.append(Path(__file__).resolve().parent.parent / ".codex-plugin" / "plugin.json")
+    for path in candidates:
+        try:
+            version = str(json.loads(path.read_text(encoding="utf-8")).get("version") or "").strip()
+            if version:
+                return version
+        except Exception:
+            continue
+    return ""
+
+
+def _update_source() -> Optional[tuple]:
+    """(repo, ref) to read the published version from.
+
+    Codex stores marketplace config in ~/.codex/config.toml (not a JSON we parse
+    here) and tracks the ref rather than a version pin, so we read the published
+    version from the default repo/ref. The nudge is purely a version comparison,
+    so a local checkout only nags when it is behind the published version.
+    """
+    return _UPDATE_DEFAULT_REPO, _UPDATE_DEFAULT_REF
+
+
+def _fetch_published_version(repo: str, ref: str, etag: str) -> tuple:
+    """GET the raw .codex-plugin/plugin.json and read its version.
+
+    Returns (version, new_etag, error). version is '' on 304/missing/error so the
+    caller keeps the previously-known latest.
+    """
+    url = f"https://raw.githubusercontent.com/{repo}/{ref}/{_UPDATE_MANIFEST_PATH}"
+    req = urllib.request.Request(url, method="GET")
+    if etag:
+        req.add_header("If-None-Match", etag)
+    try:
+        with urllib.request.urlopen(req, timeout=5.0, context=_https_context()) as resp:
+            body = resp.read().decode("utf-8")
+            new_etag = resp.headers.get("ETag", "") or etag
+            data = json.loads(body)
+            version = str(data.get("version") or "") if isinstance(data, dict) else ""
+            return version, new_etag, ("" if version else "version_missing")
+    except urllib.error.HTTPError as exc:
+        if exc.code == 304:
+            return "", etag, ""  # unchanged since last check
+        return "", etag, f"http_{exc.code}"
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
+        return "", etag, str(exc)[:120]
+
+
+def maybe_check_for_update() -> None:
+    """Background, ≤once-a-day update check. Writes the marker. Never raises.
+
+    Call from a background process (the idle watcher) — never a synchronous hook,
+    since it may make a network call (bounded to 5s, ≤ once per interval).
+    """
+    try:
+        if not _update_check_enabled():
+            return
+        marker = _load_json_file(_UPDATE_CHECK_FILE)
+        interval = _improve_float_env(
+            "COGNEE_UPDATE_CHECK_INTERVAL", _UPDATE_CHECK_INTERVAL_DEFAULT
+        )
+        now = datetime.now(timezone.utc).timestamp()
+        if now - float(marker.get("last_checked_at", 0) or 0) < interval:
+            return  # checked recently
+        source = _update_source()
+        if source is None:
+            return
+        repo, ref = source
+        installed = _installed_plugin_version()
+        latest, etag, error = _fetch_published_version(repo, ref, str(marker.get("etag") or ""))
+        if not latest:
+            latest = str(marker.get("latest_version") or "")  # 304/error: keep prior
+        update_available = bool(installed and latest and _semver_gt(latest, installed))
+        _write_json_file(
+            _UPDATE_CHECK_FILE,
+            {
+                "last_checked_at": now,
+                "installed_version": installed,
+                "latest_version": latest,
+                "update_available": update_available,
+                "etag": etag,
+                "source": f"{repo}@{ref}",
+                "error": error,
+                "notified_version": str(marker.get("notified_version") or ""),
+            },
+        )
+        hook_log(
+            "update_check",
+            {
+                "installed": installed,
+                "latest": latest,
+                "available": update_available,
+                "error": error,
+            },
+        )
+    except Exception as exc:
+        hook_log("update_check_failed", {"error": str(exc)[:200]})
+
+
+def read_update_status() -> dict:
+    """Zero-network read of the update marker; {} when disabled/absent/current."""
+    if not _update_check_enabled():
+        return {}
+    marker = _load_json_file(_UPDATE_CHECK_FILE)
+    if (
+        isinstance(marker, dict)
+        and marker.get("update_available")
+        and marker.get("installed_version")
+        and marker.get("latest_version")
+    ):
+        return marker
+    return {}
+
+
+def mark_update_notified(version: str) -> None:
+    """Record that the one-time SessionStart nudge for `version` has been shown."""
+    try:
+        marker = _load_json_file(_UPDATE_CHECK_FILE)
+        if not marker:
+            return
+        marker["notified_version"] = str(version or "")
+        _write_json_file(_UPDATE_CHECK_FILE, marker)
+    except Exception as exc:
+        hook_log("update_notified_write_failed", {"error": str(exc)[:200]})
+
+
 def resolve_runtime_mode() -> dict:
     """Resolve hook runtime mode from effective endpoint auth."""
     service_url, api_key = resolved_http_endpoint_auth()

--- a/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
@@ -20,6 +20,7 @@ _SHARED_ROOT = Path.home() / ".cognee-plugin"
 _CONFIG_PATH = _SHARED_ROOT / "config.json"
 _SERVER_READY_PATH = _SHARED_ROOT / "server-ready.json"
 _BREAKER_PATH = _SHARED_ROOT / "recall-breaker.json"
+_UPDATE_CHECK_PATH = _SHARED_ROOT / "codex" / "update-check.json"
 _DEFAULT_DATASET = "agent_sessions"
 
 
@@ -64,9 +65,31 @@ def _health_prefix() -> str:
     return ""
 
 
+def _update_segment() -> str:
+    """Plain-text 'update available' segment, or '' — read purely from the marker.
+
+    Codex surfaces status inside the model's context (not a terminal bar), so this
+    stays plain text (no ANSI). The idle watcher's background check writes the
+    marker; this remains network-free and free of any ``_plugin_common`` import.
+    """
+    if os.environ.get("COGNEE_UPDATE_CHECK", "").strip().lower() in ("0", "false", "no", "off"):
+        return ""
+    try:
+        marker = json.loads(_UPDATE_CHECK_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    if not (isinstance(marker, dict) and marker.get("update_available")):
+        return ""
+    installed = str(marker.get("installed_version") or "")
+    latest = str(marker.get("latest_version") or "")
+    if not (installed and latest):
+        return ""
+    return f"  ⬆ Cognee update available {installed}→{latest}"
+
+
 def render_status_for_host(host_id: str) -> str:
     """Return the status string (host_id is unused; kept for call-site compat)."""
-    return f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}"
+    return f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}{_update_segment()}"
 
 
 def main() -> None:
@@ -74,7 +97,9 @@ def main() -> None:
         json.load(sys.stdin)  # consume stdin as required by the host
     except Exception:
         pass
-    sys.stdout.write(f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}")
+    sys.stdout.write(
+        f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}{_update_segment()}"
+    )
 
 
 if __name__ == "__main__":

--- a/integrations/codex/plugins/cognee/scripts/idle-watcher.py
+++ b/integrations/codex/plugins/cognee/scripts/idle-watcher.py
@@ -154,6 +154,17 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
             return False
 
 
+def _run_update_check() -> None:
+    """Fire the background, daily-guarded plugin update check (best-effort)."""
+    try:
+        sys.path.insert(0, os.path.dirname(__file__))
+        from _plugin_common import maybe_check_for_update  # type: ignore
+
+        maybe_check_for_update()
+    except Exception as exc:
+        _log("update_check_error", error=str(exc)[:200])
+
+
 async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
     _log(
         "started",
@@ -163,6 +174,9 @@ async def _main_loop(session_id: str, dataset: str, config: dict) -> None:
         poll=POLL_SECONDS,
         idle=IDLE_SECONDS,
     )
+    # Runs once per watcher launch (≈ once per session); the check itself is
+    # internally rate-limited to ≤ once per COGNEE_UPDATE_CHECK_INTERVAL.
+    _run_update_check()
     last_improved_at = 0.0
     exit_reason = "loop_complete"
     bridge_disabled = False

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -1211,9 +1211,39 @@ async def _start(payload: dict | None = None) -> dict:
     return {
         "hookSpecificOutput": {
             "hookEventName": "SessionStart",
-            "additionalContext": status_line,
+            "additionalContext": status_line + _update_nudge_suffix(),
         },
     }
+
+
+def _update_nudge_suffix() -> str:
+    """One-time 'update available' line appended to SessionStart context.
+
+    Reads the marker written by the idle watcher's background check (no network),
+    shown once per newly-detected version (tracked via ``notified_version``). The
+    per-turn in-context status (render_status_for_host) carries the short ambient
+    segment; this is the actionable one-shot nudge with the update command.
+    """
+    try:
+        from _plugin_common import mark_update_notified, read_update_status
+
+        status = read_update_status()
+    except Exception:
+        return ""
+    if not status:
+        return ""
+    installed = str(status.get("installed_version") or "")
+    latest = str(status.get("latest_version") or "")
+    if not (installed and latest) or status.get("notified_version") == latest:
+        return ""
+    try:
+        mark_update_notified(latest)
+    except Exception:
+        pass
+    return (
+        f"\n\nCognee update available {installed} → {latest} — run "
+        "`codex plugin marketplace upgrade cognee` to update."
+    )
 
 
 def main():


### PR DESCRIPTION
This PR adds the start of versioning of Claude and Codex integrations. Claude starts at 1.0.0 officially, and Codex with 1.1.0 since there was already a 1.0.3 version.
This PR also adds the a way to check whether a new version of the integration is available, and notifies the user so they can update the integration if they want. Docs also added in the README, as well as CHANGELOGs.