### PR TITLE
feat(vscode): project-memory extension — remember/recall + ask my project memory

### DIFF
--- a/integrations/vscode/.gitignore
+++ b/integrations/vscode/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+out/
+*.vsix
+.vscode-test/
+coverage/
+*.log

--- a/integrations/vscode/.vscodeignore
+++ b/integrations/vscode/.vscodeignore
@@ -1,0 +1,10 @@
+.vscode/**
+src/**
+node_modules/**
+**/*.test.ts
+**/*.map
+esbuild.js
+tsconfig.json
+vitest.config.ts
+.gitignore
+**/tsconfig.*

--- a/integrations/vscode/CHANGELOG.md
+++ b/integrations/vscode/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to the Cognee VS Code extension are documented here.
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] - Unreleased
+
+### Added
+- Editor-agnostic core (`src/core`) with a typed Cognee HTTP client, deterministic
+  per-repository dataset scoping, configuration validation, and Evidence/citation parsing.
+- Commands: **Ask My Project Memory**, **Recall**, **Remember Selection**, **Remember File**,
+  **Index Workspace**, **Forget Project Memory**, and **Set Up**.
+- "Ask my project memory" webview panel that renders answers with clickable citations to source files.
+- Direct citation resolution via a per-workspace path index: files you remember are recorded with
+  their exact relative path, so a citation resolves straight to the file you ingested — even when the
+  workspace has several files of that name. Falls back to snippet-content matching, then a user pick.
+- Unit tests running against a mocked Cognee backend (no live keys, no LLM in CI).

--- a/integrations/vscode/LICENSE
+++ b/integrations/vscode/LICENSE
@@ -1,0 +1,14 @@
+Copyright (c) Cognee / Topoteretes and contributors.
+
+This package is part of the Cognee project and is licensed under the
+Apache License, Version 2.0. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+The full license text is provided in the repository root LICENSE file.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/integrations/vscode/README.md
+++ b/integrations/vscode/README.md
@@ -1,0 +1,95 @@
+# Cognee — Project Memory (VS Code)
+
+Give your editor a persistent, **citable memory** of the project. Remember and recall
+knowledge without leaving VS Code, and **ask your project memory** — get answers grounded in
+what Cognee knows about the current repository, with links back to the source files.
+
+> Powered by [Cognee](https://github.com/topoteretes/cognee). Works against a local Cognee
+> server or a Cognee Cloud tenant.
+
+## Features
+
+- **Remember Selection / Remember File / Remember Note** — store code, files, or a free-form note into per-repository memory.
+- **Ask My Project Memory** — a panel that answers questions about the repo, with ranked, clickable citations that open the exact source file.
+- **Recall** — a quick query from the command palette.
+- **Index Workspace** — opt-in bulk ingest, respecting `.gitignore`/`.cogneeignore` (and always skipping dependency/build directories), with a preflight summary.
+- **Forget Project Memory** — clear the graph (keep files) or delete the dataset.
+- **Per-repository isolation** — each repo maps to a stable `vscode_<hash>` dataset (from the git remote, or the workspace path as a fallback).
+
+## Requirements
+
+A reachable Cognee backend — either of:
+
+- **Cognee Cloud** (no local setup): your tenant URL (e.g. `https://<tenant>.cognee.ai`) and an API key.
+- **Local server**: a Cognee server running on `http://localhost:8011`
+  (see the [Cognee docs](https://docs.cognee.ai/)); this path needs its own `.env` (e.g. `LLM_API_KEY`).
+
+The extension itself needs **no environment variables** — it is configured entirely through VS Code
+settings and secret storage.
+
+## Quick start
+
+1. Run **`Cognee: Set Up`** from the command palette.
+   - Enter your endpoint (`http://localhost:8011` or your Cloud tenant URL).
+   - Enter your API key if using Cloud (stored securely in the OS keychain, not in settings).
+   - The command runs a health check so you know the connection works.
+2. Open a file, select some code, and run **`Cognee: Remember Selection`**.
+3. Run **`Cognee: Ask My Project Memory`** and ask a question — the answer appears with its sources.
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `Cognee: Ask My Project Memory` | Open the panel and query the repo's memory with citations. |
+| `Cognee: Recall` | One-off query from the palette. |
+| `Cognee: Remember Selection` | Store the current selection (or the whole file). |
+| `Cognee: Remember File` | Store a file (also on the explorer context menu). |
+| `Cognee: Remember Note` | Store a free-form note typed into an input box. |
+| `Cognee: Index Workspace` | Bulk-ingest eligible files after a preflight confirmation. |
+| `Cognee: Forget Project Memory` | Clear memory (keep files) or delete the dataset. |
+| `Cognee: Set Up` | Configure endpoint + key and run a health check. |
+
+## Settings
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `cognee.endpoint` | `http://localhost:8011` | Cognee backend base URL. |
+| `cognee.apiKey` | `""` | API key (`X-Api-Key`). Prefer `Cognee: Set Up`, which uses secret storage. |
+| `cognee.datasetOverride` | `""` | Fixed dataset name; empty derives `vscode_<hash>` per repo. |
+| `cognee.searchType` | `auto` | Recall strategy; `auto` lets Cognee route the query. |
+| `cognee.topK` | `15` | Max recall results. |
+| `cognee.includeReferences` | `true` | Attach source citations to answers. |
+| `cognee.ingestion.respectGitignore` | `true` | Skip `.gitignore`/`.cogneeignore` files when indexing (dependency/build dirs are always skipped). |
+| `cognee.ingestion.maxFileSizeKb` | `512` | Skip files larger than this when indexing. |
+| `cognee.requestTimeoutMs` | `300000` | HTTP request timeout. |
+
+## How it works
+
+The extension talks to Cognee over the HTTP API:
+
+- **Ask / Recall** → `POST /api/v1/recall` with `include_references: true`, scoped to the workspace dataset.
+  Citations are parsed from the answer's `Evidence` block (chunk/document level today), then ranked by
+  relevance to the query and de-duplicated so each source file appears once. Everything the extension
+  ingests carries a `Source: <path>` header, so a citation resolves straight to the exact file — even when
+  several files share a name. It falls back to a per-workspace path index (the exact path of each file you
+  remember), then snippet-content matching, then a user pick, only when genuinely ambiguous.
+- **Remember / Index** → `POST /api/v1/remember` (ingest + graph build in one call).
+- **Forget** → `POST /api/v1/forget`.
+
+All editor-agnostic logic lives in [`src/core`](src/core) (no `vscode` imports), so it is unit-tested
+against a mocked backend and can back other editors (e.g. a JetBrains sidecar) unchanged.
+
+## Development
+
+```bash
+npm install
+npm run build      # bundle to dist/extension.js (esbuild)
+npm run typecheck  # tsc --noEmit
+npm test           # vitest — runs against a mocked backend, no live keys
+```
+
+Press **F5** in this folder to launch an Extension Development Host with the extension loaded.
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE).

--- a/integrations/vscode/esbuild.js
+++ b/integrations/vscode/esbuild.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const esbuild = require("esbuild");
+
+const production = process.argv.includes("--production");
+const watch = process.argv.includes("--watch");
+
+/**
+ * Build the extension into a single CommonJS bundle that VS Code can load.
+ * `vscode` is provided by the host at runtime and must stay external.
+ */
+async function main() {
+  const context = await esbuild.context({
+    entryPoints: ["src/extension/extension.ts"],
+    bundle: true,
+    format: "cjs",
+    platform: "node",
+    target: "node18",
+    outfile: "dist/extension.js",
+    external: ["vscode"],
+    sourcemap: !production,
+    minify: production,
+    logLevel: "info",
+  });
+
+  if (watch) {
+    await context.watch();
+  } else {
+    await context.rebuild();
+    await context.dispose();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/integrations/vscode/package-lock.json
+++ b/integrations/vscode/package-lock.json
@@ -1,0 +1,4256 @@
+{
+  "name": "cognee-vscode",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cognee-vscode",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ignore": "^5.3.2"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "@types/vscode": "^1.85.0",
+        "@vscode/vsce": "^2.29.0",
+        "esbuild": "^0.21.5",
+        "typescript": "^5.4.5",
+        "vitest": "^1.6.0"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.2.tgz",
+      "integrity": "sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
+      "integrity": "sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.16.0.tgz",
+      "integrity": "sha512-Wc75FGnQgYpsm5jsOqn1H8AXsh8vXruA6vwip1nhjrJxwby7juxKAIVLr7csepmHiwdZGr6EwI5BlSc3PizEtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.11.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.0.tgz",
+      "integrity": "sha512-UikJOtMwkFpZNzTH6Dqk8UTUPbow15zH3e0UjGYZy69lYENW/S05gMLhbxI2eonz66uALhIljvhsSMEb6+O30g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.3.1.tgz",
+      "integrity": "sha512-sqqv3L1UOI4KDXonNtbxPYUgbSWVXqxvmmb6BUw9n4P/UXgG+cVur3dLWQN4Cz7qQ+UJROCCxMXlksm7gIq0Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.11.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.6.tgz",
+      "integrity": "sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vscode/vsce": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.32.0.tgz",
+      "integrity": "sha512-3EFJfsgrSftIqt3EtdRcAygy/OJ3hstyI1cDmIgkU9CFZW5C+3djr6mfosndCUqcVYuyjmxOK1xmFp/Bq7+NIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/identity": "^4.1.0",
+        "@vscode/vsce-sign": "^2.0.0",
+        "azure-devops-node-api": "^12.5.0",
+        "chalk": "^2.4.2",
+        "cheerio": "^1.0.0-rc.9",
+        "cockatiel": "^3.1.2",
+        "commander": "^6.2.1",
+        "form-data": "^4.0.0",
+        "glob": "^7.0.6",
+        "hosted-git-info": "^4.0.2",
+        "jsonc-parser": "^3.2.0",
+        "leven": "^3.1.0",
+        "markdown-it": "^12.3.2",
+        "mime": "^1.3.4",
+        "minimatch": "^3.0.3",
+        "parse-semver": "^1.1.1",
+        "read": "^1.0.7",
+        "semver": "^7.5.2",
+        "tmp": "^0.2.1",
+        "typed-rest-client": "^1.8.4",
+        "url-join": "^4.0.1",
+        "xml2js": "^0.5.0",
+        "yauzl": "^2.3.1",
+        "yazl": "^2.2.2"
+      },
+      "bin": {
+        "vsce": "vsce"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "optionalDependencies": {
+        "keytar": "^7.7.0"
+      }
+    },
+    "node_modules/@vscode/vsce-sign": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.9.tgz",
+      "integrity": "sha512-8IvaRvtFyzUnGGl3f5+1Cnor3LqaUWvhaUjAYO8Y39OUYlOf3cRd+dowuQYLpZcP3uwSG+mURwjEBOSq4SOJ0g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optionalDependencies": {
+        "@vscode/vsce-sign-alpine-arm64": "2.0.6",
+        "@vscode/vsce-sign-alpine-x64": "2.0.6",
+        "@vscode/vsce-sign-darwin-arm64": "2.0.6",
+        "@vscode/vsce-sign-darwin-x64": "2.0.6",
+        "@vscode/vsce-sign-linux-arm": "2.0.6",
+        "@vscode/vsce-sign-linux-arm64": "2.0.6",
+        "@vscode/vsce-sign-linux-x64": "2.0.6",
+        "@vscode/vsce-sign-win32-arm64": "2.0.6",
+        "@vscode/vsce-sign-win32-x64": "2.0.6"
+      }
+    },
+    "node_modules/@vscode/vsce-sign-alpine-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
+      "integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-alpine-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
+      "integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
+      "integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
+      "integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
+      "integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
+      "integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz",
+      "integrity": "sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
+      "integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
+      "integrity": "sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/azure-devops-node-api": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+      "integrity": "sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/cockatiel": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
+      "integrity": "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keytar": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-semver": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+      "integrity": "sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.1.0"
+      }
+    },
+    "node_modules/parse-semver/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+      "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -1,0 +1,177 @@
+{
+  "name": "cognee-vscode",
+  "displayName": "Cognee — Project Memory",
+  "description": "Give your editor a persistent, citable memory of the project. Remember and recall knowledge without leaving VS Code, and ask your project memory with answers linked back to source files — powered by Cognee.",
+  "version": "0.1.0",
+  "publisher": "cognee",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Anjali Garhwal"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/topoteretes/cognee-integrations.git",
+    "directory": "integrations/vscode"
+  },
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Machine Learning",
+    "Other"
+  ],
+  "keywords": [
+    "cognee",
+    "memory",
+    "knowledge graph",
+    "rag",
+    "ai",
+    "context"
+  ],
+  "main": "./dist/extension.js",
+  "activationEvents": [],
+  "contributes": {
+    "commands": [
+      {
+        "command": "cognee.askProjectMemory",
+        "title": "Ask My Project Memory",
+        "category": "Cognee"
+      },
+      {
+        "command": "cognee.recall",
+        "title": "Recall",
+        "category": "Cognee"
+      },
+      {
+        "command": "cognee.rememberSelection",
+        "title": "Remember Selection",
+        "category": "Cognee"
+      },
+      {
+        "command": "cognee.rememberFile",
+        "title": "Remember File",
+        "category": "Cognee"
+      },
+      {
+        "command": "cognee.rememberNote",
+        "title": "Remember Note",
+        "category": "Cognee"
+      },
+      {
+        "command": "cognee.indexWorkspace",
+        "title": "Index Workspace",
+        "category": "Cognee"
+      },
+      {
+        "command": "cognee.forgetProject",
+        "title": "Forget Project Memory",
+        "category": "Cognee"
+      },
+      {
+        "command": "cognee.setup",
+        "title": "Set Up",
+        "category": "Cognee"
+      }
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "cognee.rememberSelection",
+          "when": "editorHasSelection",
+          "group": "cognee@1"
+        },
+        {
+          "command": "cognee.askProjectMemory",
+          "group": "cognee@2"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "cognee.rememberFile",
+          "when": "!explorerResourceIsFolder",
+          "group": "cognee@1"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "Cognee",
+      "properties": {
+        "cognee.endpoint": {
+          "type": "string",
+          "default": "http://localhost:8011",
+          "markdownDescription": "Base URL of the Cognee backend. Use the local server (`http://localhost:8011`) or a Cognee Cloud tenant URL (`https://<tenant>.cognee.ai`)."
+        },
+        "cognee.apiKey": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "API key sent as the `X-Api-Key` header. Required for Cognee Cloud; usually empty for a local single-user server. Prefer storing this in your OS keychain via `Cognee: Set Up` rather than in synced settings."
+        },
+        "cognee.datasetOverride": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Optional fixed dataset name for this workspace. When empty, the dataset is derived deterministically from the git remote (or workspace path) as `vscode_<hash>`, isolating each repository's memory."
+        },
+        "cognee.searchType": {
+          "type": "string",
+          "default": "auto",
+          "enum": [
+            "auto",
+            "GRAPH_COMPLETION",
+            "GRAPH_COMPLETION_COT",
+            "RAG_COMPLETION",
+            "CHUNKS",
+            "SUMMARIES"
+          ],
+          "markdownDescription": "Recall strategy. `auto` lets Cognee route the query to the best strategy; the others force a specific `search_type`."
+        },
+        "cognee.topK": {
+          "type": "number",
+          "default": 15,
+          "minimum": 1,
+          "maximum": 100,
+          "description": "Maximum number of results returned by a recall."
+        },
+        "cognee.includeReferences": {
+          "type": "boolean",
+          "default": true,
+          "description": "Ask Cognee to attach source citations (the Evidence block) to answers so results can link back to files."
+        },
+        "cognee.ingestion.respectGitignore": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "When indexing the workspace, skip files matched by the project's `.gitignore` and `.cogneeignore`. Common dependency and build directories (`node_modules`, `.git`, `dist`, …) are always skipped regardless of this setting."
+        },
+        "cognee.ingestion.maxFileSizeKb": {
+          "type": "number",
+          "default": 512,
+          "description": "Skip files larger than this size (in KB) during workspace indexing."
+        },
+        "cognee.requestTimeoutMs": {
+          "type": "number",
+          "default": 300000,
+          "description": "HTTP request timeout in milliseconds for Cognee calls."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run build",
+    "build": "node esbuild.js --production",
+    "watch": "node esbuild.js --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "package": "vsce package --no-dependencies"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "@types/vscode": "^1.85.0",
+    "@vscode/vsce": "^2.29.0",
+    "esbuild": "^0.21.5",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  },
+  "dependencies": {
+    "ignore": "^5.3.2"
+  }
+}

--- a/integrations/vscode/src/core/client.ts
+++ b/integrations/vscode/src/core/client.ts
@@ -1,0 +1,67 @@
+import type { RecallResponseItem, RememberResult } from "./types";
+
+/**
+ * Transport-agnostic contract for talking to a Cognee backend.
+ *
+ * The VS Code layer depends only on this interface, so tests inject a mock and
+ * a future JetBrains sidecar can share the same core with a different concrete
+ * client. `HttpCogneeClient` is the shipped implementation.
+ */
+export interface CogneeClient {
+  /** Liveness probe against `GET /health`. Never throws; resolves to false on failure. */
+  health(signal?: AbortSignal): Promise<boolean>;
+
+  /** Query project memory. Maps to `POST /api/v1/recall`. */
+  recall(query: string, options?: RecallOptions): Promise<RecallResponseItem[]>;
+
+  /** Ingest text and build the graph in one call. Maps to `POST /api/v1/remember`. */
+  remember(data: string, options: RememberOptions): Promise<RememberResult>;
+
+  /** Delete project memory. Maps to `POST /api/v1/forget`. */
+  forget(options: ForgetOptions): Promise<Record<string, unknown>>;
+
+  /** Enrich the graph (prune/reinforce). Maps to `POST /api/v1/improve`. */
+  improve(options?: ImproveOptions): Promise<Record<string, unknown>>;
+}
+
+export interface RecallOptions {
+  /** Dataset names to search within (the workspace's derived dataset). */
+  datasets?: string[];
+  /** Explicit strategy, or `null` to auto-route. Omit to use the server default. */
+  searchType?: string | null;
+  topK?: number;
+  includeReferences?: boolean;
+  sessionId?: string;
+  scope?: string | string[];
+  systemPrompt?: string;
+  signal?: AbortSignal;
+}
+
+export interface RememberOptions {
+  /** Target dataset (required by the server). */
+  datasetName: string;
+  sessionId?: string;
+  runInBackground?: boolean;
+  /** Filename to attach to the uploaded text (helps document naming/citations). */
+  filename?: string;
+  /** Node sets to tag the ingested data with. */
+  nodeSet?: string[];
+  signal?: AbortSignal;
+}
+
+export interface ForgetOptions {
+  dataset?: string;
+  datasetId?: string;
+  dataId?: string;
+  everything?: boolean;
+  /** Clear graph + vectors but keep raw files, so the dataset can be re-cognified. */
+  memoryOnly?: boolean;
+  signal?: AbortSignal;
+}
+
+export interface ImproveOptions {
+  datasetName?: string;
+  datasetId?: string;
+  runInBackground?: boolean;
+  signal?: AbortSignal;
+}

--- a/integrations/vscode/src/core/config.test.ts
+++ b/integrations/vscode/src/core/config.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeEndpoint, resolveSearchType, validateConfig, type CogneeConfig } from "./config";
+
+const BASE: CogneeConfig = {
+  endpoint: "http://localhost:8011",
+  searchType: "auto",
+  topK: 15,
+  includeReferences: true,
+  respectGitignore: true,
+  maxFileSizeKb: 512,
+  requestTimeoutMs: 300000,
+};
+
+describe("validateConfig", () => {
+  it("accepts a valid configuration", () => {
+    expect(validateConfig(BASE)).toEqual({ ok: true, errors: [] });
+  });
+
+  it("rejects an endpoint without an http(s) scheme", () => {
+    expect(validateConfig({ ...BASE, endpoint: "localhost:8011" }).ok).toBe(false);
+  });
+
+  it("rejects an out-of-range topK", () => {
+    expect(validateConfig({ ...BASE, topK: 0 }).ok).toBe(false);
+    expect(validateConfig({ ...BASE, topK: 500 }).ok).toBe(false);
+  });
+
+  it("rejects non-positive timeouts and sizes", () => {
+    expect(validateConfig({ ...BASE, requestTimeoutMs: 0 }).ok).toBe(false);
+    expect(validateConfig({ ...BASE, maxFileSizeKb: -1 }).ok).toBe(false);
+  });
+});
+
+describe("resolveSearchType", () => {
+  it("maps auto (or empty) to null for server-side routing", () => {
+    expect(resolveSearchType("auto")).toBeNull();
+    expect(resolveSearchType("")).toBeNull();
+  });
+
+  it("passes an explicit strategy through", () => {
+    expect(resolveSearchType("CHUNKS")).toBe("CHUNKS");
+  });
+});
+
+describe("normalizeEndpoint", () => {
+  it("trims whitespace and trailing slashes", () => {
+    expect(normalizeEndpoint("  http://localhost:8011///  ")).toBe("http://localhost:8011");
+  });
+});

--- a/integrations/vscode/src/core/config.ts
+++ b/integrations/vscode/src/core/config.ts
@@ -1,0 +1,72 @@
+/**
+ * Editor-agnostic configuration for the Cognee client.
+ *
+ * The VS Code layer reads these values from workspace settings; the core layer
+ * only depends on this plain object so it can be reused by other editors (e.g. a
+ * JetBrains sidecar) without change.
+ */
+export interface CogneeConfig {
+  /** Base URL of the Cognee backend, e.g. http://localhost:8011 or a Cloud tenant URL. */
+  endpoint: string;
+  /** Optional API key, sent as the `X-Api-Key` header. Required for Cognee Cloud. */
+  apiKey?: string;
+  /** Fixed dataset name for the workspace; when empty, the dataset is derived by hash. */
+  datasetOverride?: string;
+  /** Recall strategy; "auto" (or empty) enables server-side auto-routing. */
+  searchType: string;
+  /** Maximum recall results (1–100). */
+  topK: number;
+  /** Ask the backend to attach source citations to answers. */
+  includeReferences: boolean;
+  /** Skip .gitignore/.cogneeignore entries when indexing the workspace. */
+  respectGitignore: boolean;
+  /** Skip files larger than this (KB) during workspace indexing. */
+  maxFileSizeKb: number;
+  /** HTTP request timeout in milliseconds. */
+  requestTimeoutMs: number;
+}
+
+export interface ConfigValidation {
+  ok: boolean;
+  errors: string[];
+}
+
+/** Validate a config, returning a flat list of human-readable problems. */
+export function validateConfig(config: CogneeConfig): ConfigValidation {
+  const errors: string[] = [];
+
+  const endpoint = config.endpoint?.trim() ?? "";
+  if (!endpoint) {
+    errors.push("Cognee endpoint is not set.");
+  } else if (!/^https?:\/\//i.test(endpoint)) {
+    errors.push("Cognee endpoint must start with http:// or https://.");
+  }
+
+  if (!Number.isFinite(config.topK) || config.topK < 1 || config.topK > 100) {
+    errors.push("topK must be between 1 and 100.");
+  }
+
+  if (!Number.isFinite(config.requestTimeoutMs) || config.requestTimeoutMs <= 0) {
+    errors.push("requestTimeoutMs must be a positive number.");
+  }
+
+  if (!Number.isFinite(config.maxFileSizeKb) || config.maxFileSizeKb <= 0) {
+    errors.push("maxFileSizeKb must be a positive number.");
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+/**
+ * Resolve the configured search type to what the API expects: `null` for
+ * auto-routing, or the explicit strategy name otherwise.
+ */
+export function resolveSearchType(searchType: string): string | null {
+  const value = searchType?.trim().toLowerCase();
+  return !value || value === "auto" ? null : searchType.trim();
+}
+
+/** Normalize the endpoint URL by trimming trailing slashes. */
+export function normalizeEndpoint(endpoint: string): string {
+  return endpoint.trim().replace(/\/+$/, "");
+}

--- a/integrations/vscode/src/core/errors.ts
+++ b/integrations/vscode/src/core/errors.ts
@@ -1,0 +1,43 @@
+/** Raised when the Cognee backend returns a non-2xx HTTP response. */
+export class CogneeApiError extends Error {
+  readonly status: number;
+  readonly body: string;
+
+  constructor(message: string, status: number, body: string) {
+    super(message);
+    this.name = "CogneeApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/** Raised when the request never reaches the backend (DNS, connection, timeout). */
+export class CogneeNetworkError extends Error {
+  readonly cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "CogneeNetworkError";
+    this.cause = cause;
+  }
+}
+
+/**
+ * Produce a short, human-readable reason for a failed Cognee call, suitable for
+ * surfacing in an editor notification.
+ */
+export function describeError(error: unknown): string {
+  if (error instanceof CogneeApiError) {
+    if (error.status === 401 || error.status === 403) {
+      return "Authentication failed — check the endpoint and API key (Cognee: Set Up).";
+    }
+    if (error.status === 422) {
+      return "No memory to recall yet — remember or index something first.";
+    }
+    return `Cognee returned ${error.status}. ${error.message}`;
+  }
+  if (error instanceof CogneeNetworkError) {
+    return `${error.message} Is the Cognee server running and reachable?`;
+  }
+  return error instanceof Error ? error.message : String(error);
+}

--- a/integrations/vscode/src/core/evidence.test.ts
+++ b/integrations/vscode/src/core/evidence.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAnswer } from "./evidence";
+
+const WITH_EVIDENCE =
+  "Revenue grew 12 percent.\n\nEvidence:\n" +
+  "- chunk 3 of document report.pdf (chunk_id: chunk-1): Revenue grew 12 percent year over year.\n" +
+  "- chunk 5 of document notes.md (chunk_id: chunk-2): More detail here.";
+
+// Verbatim shape returned by Cognee Cloud today: the parenthetical leads with
+// `data_id:` before `chunk_id:`, and the snippet is wrapped in double quotes.
+const CLOUD_EVIDENCE =
+  "The checkout canary is rotated every Friday.\n\nEvidence:\n" +
+  "- chunk 1 of document smoke (data_id: 9b6475c0-5e22-52f9-a629-46159aeb60a9, " +
+  'chunk_id: 5fecd7fc-51c1-52a0-9b47-74ff9024bd09): "Project note: the deployment ' +
+  'canary token for the checkout service is SMOKE-1. It is rotated every Friday."';
+
+describe("parseAnswer", () => {
+  it("returns the answer verbatim when there is no Evidence block", () => {
+    const result = parseAnswer("Just a plain answer.");
+    expect(result.answer).toBe("Just a plain answer.");
+    expect(result.citations).toHaveLength(0);
+  });
+
+  it("splits the answer from the Evidence block and parses each citation", () => {
+    const result = parseAnswer(WITH_EVIDENCE);
+    expect(result.answer).toBe("Revenue grew 12 percent.");
+    expect(result.citations).toHaveLength(2);
+    expect(result.citations[0]).toMatchObject({
+      chunkLabel: "3",
+      documentName: "report.pdf",
+      chunkId: "chunk-1",
+      snippet: "Revenue grew 12 percent year over year.",
+    });
+    expect(result.citations[1]).toMatchObject({
+      chunkLabel: "5",
+      documentName: "notes.md",
+      chunkId: "chunk-2",
+    });
+  });
+
+  it("parses the real Cognee Cloud format (data_id before chunk_id, quoted snippet)", () => {
+    const result = parseAnswer(CLOUD_EVIDENCE);
+    expect(result.answer).toBe("The checkout canary is rotated every Friday.");
+    expect(result.citations).toHaveLength(1);
+    expect(result.citations[0]).toMatchObject({
+      chunkLabel: "1",
+      documentName: "smoke",
+      dataId: "9b6475c0-5e22-52f9-a629-46159aeb60a9",
+      chunkId: "5fecd7fc-51c1-52a0-9b47-74ff9024bd09",
+    });
+    // Surrounding quotes are stripped so snippet matching works against file text.
+    expect(result.citations[0].snippet).toBe(
+      "Project note: the deployment canary token for the checkout service is " +
+        "SMOKE-1. It is rotated every Friday.",
+    );
+  });
+
+  it("ignores malformed lines inside the Evidence block", () => {
+    const result = parseAnswer("Answer.\n\nEvidence:\n- not a citation line\nrandom text");
+    expect(result.answer).toBe("Answer.");
+    expect(result.citations).toHaveLength(0);
+  });
+});

--- a/integrations/vscode/src/core/evidence.ts
+++ b/integrations/vscode/src/core/evidence.ts
@@ -1,0 +1,145 @@
+/**
+ * Parsing of Cognee's answer-grounded "Evidence" block into structured citations.
+ *
+ * When recall is called with `include_references=true`, completion strategies
+ * append a block to the answer text in this shape:
+ *
+ *   <answer>
+ *
+ *   Evidence:
+ *   - chunk 1 of document report.pdf (data_id: <uuid>, chunk_id: <uuid>): "<snippet>"
+ *   - chunk 5 of document notes.md (chunk_id: chunk-2): <snippet>
+ *
+ * The parenthetical carries one or more comma-separated `key: value` pairs. The
+ * current server emits `(data_id: …, chunk_id: …)`; older builds emitted just
+ * `(chunk_id: …)`, and the snippet may or may not be wrapped in quotes — so we
+ * capture the whole parenthetical, pull ids out of it by name, and unwrap the
+ * snippet. This keeps parsing resilient to key order and additive metadata.
+ *
+ * Citations are chunk/document-level today because `DocumentChunk` carries a
+ * `chunk_index` and `document_name` but no line offsets. The VS Code layer
+ * resolves a citation to a location by opening the document and revealing the
+ * best text match for the snippet.
+ */
+
+export interface Citation {
+  /** The chunk ordinal as printed by the server (e.g. "3"). */
+  chunkLabel: string;
+  /** The source document name (basename), used to resolve a file in the workspace. */
+  documentName: string;
+  /** The chunk id, when present. */
+  chunkId?: string;
+  /** The source data id, when present. */
+  dataId?: string;
+  /** A short snippet of the cited chunk, used to reveal the region in-file. */
+  snippet?: string;
+  /** The raw citation line, preserved verbatim. */
+  raw: string;
+}
+
+export interface ParsedAnswer {
+  /** The answer text with the Evidence block removed. */
+  answer: string;
+  /** The raw Evidence block, when present. */
+  evidenceText?: string;
+  /** Structured citations parsed from the Evidence block. */
+  citations: Citation[];
+}
+
+const EVIDENCE_MARKER = "\n\nEvidence:\n";
+
+/**
+ * A single citation line. The metadata parenthetical is optional and captured as
+ * a whole (`[^)]*`) so ids can be extracted by name regardless of order; the
+ * snippet is everything after the trailing colon.
+ */
+const CITATION_RE =
+  /^-\s+chunk\s+(\S+)\s+of\s+document\s+(.+?)(?:\s+\(([^)]*)\))?:\s*([\s\S]*)$/i;
+
+const CHUNK_ID_RE = /chunk_id:\s*([^,)\s]+)/i;
+const DATA_ID_RE = /data_id:\s*([^,)\s]+)/i;
+
+/** Split an answer string into its prose answer and structured citations. */
+export function parseAnswer(text: string): ParsedAnswer {
+  if (typeof text !== "string") {
+    return { answer: text == null ? "" : String(text), citations: [] };
+  }
+
+  const markerIndex = text.indexOf(EVIDENCE_MARKER);
+  if (markerIndex === -1) {
+    return { answer: text, citations: [] };
+  }
+
+  const answer = text.slice(0, markerIndex);
+  const evidenceText = text.slice(markerIndex + EVIDENCE_MARKER.length);
+  return { answer, evidenceText, citations: parseEvidenceBlock(evidenceText) };
+}
+
+/** Parse the citation lines of an Evidence block. Non-matching lines are ignored. */
+export function parseEvidenceBlock(block: string): Citation[] {
+  const citations: Citation[] = [];
+  let buffer: string[] = [];
+
+  const flush = (): void => {
+    if (buffer.length === 0) {
+      return;
+    }
+    const raw = buffer.join("\n").trim();
+    buffer = [];
+    const match = CITATION_RE.exec(raw);
+    if (!match) {
+      return;
+    }
+    const [, chunkLabel, documentName, metadata, snippet] = match;
+    const citation: Citation = {
+      chunkLabel: chunkLabel.trim(),
+      documentName: documentName.trim(),
+      raw,
+    };
+    const chunkId = extractId(metadata, CHUNK_ID_RE);
+    if (chunkId) {
+      citation.chunkId = chunkId;
+    }
+    const dataId = extractId(metadata, DATA_ID_RE);
+    if (dataId) {
+      citation.dataId = dataId;
+    }
+    const trimmedSnippet = unwrapQuotes(snippet);
+    if (trimmedSnippet) {
+      citation.snippet = trimmedSnippet;
+    }
+    citations.push(citation);
+  };
+
+  for (const line of block.split("\n")) {
+    if (/^-\s+/.test(line)) {
+      flush();
+    }
+    buffer.push(line);
+  }
+  flush();
+
+  return citations;
+}
+
+/** Pull a single id value out of the metadata parenthetical, if present. */
+function extractId(metadata: string | undefined, pattern: RegExp): string | undefined {
+  if (!metadata) {
+    return undefined;
+  }
+  const match = pattern.exec(metadata);
+  return match ? match[1].trim() : undefined;
+}
+
+/** Trim a snippet and remove a single pair of enclosing quotes, if any. */
+function unwrapQuotes(snippet: string | undefined): string {
+  const text = (snippet ?? "").trim();
+  if (text.length >= 2) {
+    const first = text[0];
+    const last = text[text.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return text.slice(1, -1).trim();
+    }
+  }
+  return text;
+}

--- a/integrations/vscode/src/core/git.test.ts
+++ b/integrations/vscode/src/core/git.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { parseOriginUrl } from "./git";
+
+const GIT_CONFIG = [
+  "[core]",
+  "\trepositoryformatversion = 0",
+  '[remote "origin"]',
+  "\turl = https://github.com/user/repo.git",
+  "\tfetch = +refs/heads/*:refs/remotes/origin/*",
+  '[branch "main"]',
+  "\tremote = origin",
+].join("\n");
+
+describe("parseOriginUrl", () => {
+  it("extracts the origin remote url", () => {
+    expect(parseOriginUrl(GIT_CONFIG)).toBe("https://github.com/user/repo.git");
+  });
+
+  it("returns null when there is no origin remote", () => {
+    expect(parseOriginUrl("[core]\n\tbare = false\n")).toBeNull();
+  });
+
+  it("does not pick up a non-origin remote's url", () => {
+    const config = ['[remote "upstream"]', "\turl = https://github.com/other/repo.git"].join("\n");
+    expect(parseOriginUrl(config)).toBeNull();
+  });
+});

--- a/integrations/vscode/src/core/git.ts
+++ b/integrations/vscode/src/core/git.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure helpers for reading a repository's identity from its git config text.
+ *
+ * The filesystem lookup (locating `.git/config`, handling worktrees) lives in
+ * the editor layer; this parsing is kept here so it is testable and reusable.
+ */
+
+/** Extract the `[remote "origin"] url = ...` value from a git config file's contents. */
+export function parseOriginUrl(gitConfig: string): string | null {
+  let inOrigin = false;
+  for (const line of gitConfig.split(/\r?\n/)) {
+    const section = /^\s*\[(.+?)\]\s*$/.exec(line);
+    if (section) {
+      inOrigin = /^remote\s+"origin"$/.test(section[1].trim());
+      continue;
+    }
+    if (inOrigin) {
+      const url = /^\s*url\s*=\s*(.+?)\s*$/.exec(line);
+      if (url) {
+        return url[1].trim();
+      }
+    }
+  }
+  return null;
+}

--- a/integrations/vscode/src/core/httpClient.test.ts
+++ b/integrations/vscode/src/core/httpClient.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import { CogneeApiError } from "./errors";
+import { HttpCogneeClient } from "./httpClient";
+
+interface Recorded {
+  url: string;
+  init: RequestInit;
+}
+
+/** Build a fetch stub that records calls and returns a canned response. */
+function stubFetch(response: () => Response): { fetch: typeof fetch; calls: Recorded[] } {
+  const calls: Recorded[] = [];
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    return response();
+  }) as unknown as typeof fetch;
+  return { fetch: fetchImpl, calls };
+}
+
+function headerValue(init: RequestInit, name: string): string | undefined {
+  const headers = init.headers as Record<string, string> | undefined;
+  return headers?.[name];
+}
+
+describe("HttpCogneeClient.recall", () => {
+  it("posts a snake_case body to /api/v1/recall with the API key header", async () => {
+    const { fetch, calls } = stubFetch(
+      () =>
+        new Response(
+          JSON.stringify([
+            { source: "graph", kind: "graph_completion", search_type: "GRAPH_COMPLETION", text: "hi" },
+          ]),
+          { status: 200 },
+        ),
+    );
+    const client = new HttpCogneeClient({ endpoint: "http://localhost:8011/", apiKey: "secret", fetch });
+
+    const results = await client.recall("q", {
+      datasets: ["vscode_abc"],
+      includeReferences: true,
+      topK: 5,
+      searchType: null,
+    });
+
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    expect(call.url).toBe("http://localhost:8011/api/v1/recall");
+    expect(call.init.method).toBe("POST");
+    expect(headerValue(call.init, "X-Api-Key")).toBe("secret");
+    expect(headerValue(call.init, "Content-Type")).toBe("application/json");
+
+    const body = JSON.parse(call.init.body as string);
+    expect(body).toMatchObject({
+      query: "q",
+      datasets: ["vscode_abc"],
+      include_references: true,
+      top_k: 5,
+      search_type: null,
+    });
+    expect(results).toHaveLength(1);
+  });
+
+  it("omits the API key header when no key is configured", async () => {
+    const { fetch, calls } = stubFetch(() => new Response("[]", { status: 200 }));
+    const client = new HttpCogneeClient({ endpoint: "http://localhost:8011", fetch });
+
+    await client.recall("q");
+
+    expect(headerValue(calls[0].init, "X-Api-Key")).toBeUndefined();
+  });
+
+  it("raises CogneeApiError on a non-2xx response", async () => {
+    const { fetch } = stubFetch(() => new Response(JSON.stringify({ error: "boom" }), { status: 409 }));
+    const client = new HttpCogneeClient({ endpoint: "http://localhost:8011", fetch });
+
+    await expect(client.recall("q")).rejects.toBeInstanceOf(CogneeApiError);
+  });
+});
+
+describe("HttpCogneeClient.remember", () => {
+  it("posts multipart form data with the dataset name to /api/v1/remember", async () => {
+    const { fetch, calls } = stubFetch(() => new Response(JSON.stringify({ status: "completed" }), { status: 200 }));
+    const client = new HttpCogneeClient({ endpoint: "http://localhost:8011", fetch });
+
+    const result = await client.remember("hello world", {
+      datasetName: "vscode_abc",
+      filename: "note.txt",
+    });
+
+    const call = calls[0];
+    expect(call.url).toBe("http://localhost:8011/api/v1/remember");
+    expect(call.init.method).toBe("POST");
+    const form = call.init.body as FormData;
+    expect(form).toBeInstanceOf(FormData);
+    expect(form.get("datasetName")).toBe("vscode_abc");
+    expect(result.status).toBe("completed");
+  });
+});
+
+describe("HttpCogneeClient.forget", () => {
+  it("posts the dataset and memory_only flag to /api/v1/forget", async () => {
+    const { fetch, calls } = stubFetch(() => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const client = new HttpCogneeClient({ endpoint: "http://localhost:8011", fetch });
+
+    await client.forget({ dataset: "vscode_abc", memoryOnly: true });
+
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body).toEqual({ dataset: "vscode_abc", memory_only: true });
+  });
+});

--- a/integrations/vscode/src/core/httpClient.ts
+++ b/integrations/vscode/src/core/httpClient.ts
@@ -1,0 +1,227 @@
+import type {
+  CogneeClient,
+  ForgetOptions,
+  ImproveOptions,
+  RecallOptions,
+  RememberOptions,
+} from "./client";
+import { CogneeApiError, CogneeNetworkError } from "./errors";
+import type { RecallResponseItem, RememberResult } from "./types";
+
+export interface HttpCogneeClientOptions {
+  /** Base URL of the backend (already normalized, no trailing slash). */
+  endpoint: string;
+  /** Optional API key, sent as `X-Api-Key`. */
+  apiKey?: string;
+  /** Default request timeout in milliseconds. */
+  timeoutMs?: number;
+  /**
+   * Injectable fetch implementation. Defaults to the global `fetch` (Node 18+ /
+   * VS Code extension host). Tests pass a mock to run without a live backend.
+   */
+  fetch?: typeof fetch;
+}
+
+const DEFAULT_TIMEOUT_MS = 300_000;
+
+/**
+ * HTTP implementation of {@link CogneeClient}.
+ *
+ * Endpoints and payload shapes match the Cognee server routers and the official
+ * Cloud client (`X-Api-Key` auth). Every request is bounded by a timeout and can
+ * be cancelled via an external `AbortSignal`.
+ */
+export class HttpCogneeClient implements CogneeClient {
+  private readonly endpoint: string;
+  private readonly apiKey: string | undefined;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: HttpCogneeClientOptions) {
+    this.endpoint = options.endpoint.replace(/\/+$/, "");
+    this.apiKey = options.apiKey?.trim() || undefined;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const fetchImpl = options.fetch ?? globalThis.fetch;
+    if (typeof fetchImpl !== "function") {
+      throw new Error("global fetch is unavailable; pass a fetch implementation.");
+    }
+    this.fetchImpl = fetchImpl;
+  }
+
+  async health(signal?: AbortSignal): Promise<boolean> {
+    try {
+      const response = await this.send("GET", "/health", undefined, signal);
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  async recall(query: string, options: RecallOptions = {}): Promise<RecallResponseItem[]> {
+    const body: Record<string, unknown> = { query };
+
+    // `search_type` is only sent when specified: `null` opts into auto-routing,
+    // a string forces a strategy, and omitting it uses the server default.
+    if (options.searchType !== undefined) {
+      body.search_type = options.searchType;
+    }
+    if (options.datasets && options.datasets.length > 0) {
+      body.datasets = options.datasets;
+    }
+    if (options.topK !== undefined) {
+      body.top_k = options.topK;
+    }
+    if (options.includeReferences !== undefined) {
+      body.include_references = options.includeReferences;
+    }
+    if (options.sessionId) {
+      body.session_id = options.sessionId;
+    }
+    if (options.scope !== undefined) {
+      body.scope = options.scope;
+    }
+    if (options.systemPrompt) {
+      body.system_prompt = options.systemPrompt;
+    }
+
+    const response = await this.send("POST", "/api/v1/recall", { json: body }, options.signal);
+    const data = await this.parse(response, "recall");
+    return Array.isArray(data) ? (data as RecallResponseItem[]) : [];
+  }
+
+  async remember(data: string, options: RememberOptions): Promise<RememberResult> {
+    const form = new FormData();
+    form.append("datasetName", options.datasetName);
+    if (options.sessionId) {
+      form.append("session_id", options.sessionId);
+    }
+    if (options.runInBackground) {
+      form.append("run_in_background", "true");
+    }
+    for (const tag of options.nodeSet ?? []) {
+      if (tag) {
+        form.append("node_set", tag);
+      }
+    }
+    const filename = options.filename?.trim() || "memory.txt";
+    form.append("data", new Blob([data], { type: "text/plain" }), filename);
+
+    const response = await this.send(
+      "POST",
+      "/api/v1/remember",
+      { form },
+      options.signal,
+    );
+    return (await this.parse(response, "remember")) as RememberResult;
+  }
+
+  async forget(options: ForgetOptions): Promise<Record<string, unknown>> {
+    const body: Record<string, unknown> = {};
+    if (options.everything) {
+      body.everything = true;
+    }
+    if (options.dataset) {
+      body.dataset = options.dataset;
+    }
+    if (options.datasetId) {
+      body.dataset_id = options.datasetId;
+    }
+    if (options.dataId) {
+      body.data_id = options.dataId;
+    }
+    if (options.memoryOnly !== undefined) {
+      body.memory_only = options.memoryOnly;
+    }
+
+    const response = await this.send("POST", "/api/v1/forget", { json: body }, options.signal);
+    return (await this.parse(response, "forget")) as Record<string, unknown>;
+  }
+
+  async improve(options: ImproveOptions = {}): Promise<Record<string, unknown>> {
+    const body: Record<string, unknown> = {};
+    if (options.datasetId) {
+      body.dataset_id = options.datasetId;
+    } else if (options.datasetName) {
+      body.dataset_name = options.datasetName;
+    }
+    if (options.runInBackground) {
+      body.run_in_background = true;
+    }
+
+    const response = await this.send("POST", "/api/v1/improve", { json: body }, options.signal);
+    return (await this.parse(response, "improve")) as Record<string, unknown>;
+  }
+
+  // --- internals -----------------------------------------------------------
+
+  private buildHeaders(extra?: Record<string, string>): Record<string, string> {
+    const headers: Record<string, string> = { Accept: "application/json", ...extra };
+    if (this.apiKey) {
+      headers["X-Api-Key"] = this.apiKey;
+    }
+    return headers;
+  }
+
+  private async send(
+    method: string,
+    path: string,
+    payload?: { json?: unknown; form?: FormData },
+    externalSignal?: AbortSignal,
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    if (externalSignal) {
+      if (externalSignal.aborted) {
+        controller.abort();
+      } else {
+        externalSignal.addEventListener("abort", () => controller.abort(), { once: true });
+      }
+    }
+
+    const init: RequestInit = { method, signal: controller.signal };
+    if (payload?.json !== undefined) {
+      init.body = JSON.stringify(payload.json);
+      init.headers = this.buildHeaders({ "Content-Type": "application/json" });
+    } else if (payload?.form) {
+      // Let fetch set the multipart boundary; do not set Content-Type manually.
+      init.body = payload.form;
+      init.headers = this.buildHeaders();
+    } else {
+      init.headers = this.buildHeaders();
+    }
+
+    try {
+      return await this.fetchImpl(`${this.endpoint}${path}`, init);
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new CogneeNetworkError(`Request to ${path} timed out or was cancelled.`, error);
+      }
+      throw new CogneeNetworkError(`Could not reach Cognee at ${this.endpoint}.`, error);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async parse(response: Response, operation: string): Promise<unknown> {
+    const rawBody = await response.text();
+    if (!response.ok) {
+      throw new CogneeApiError(
+        `${operation} failed (${response.status}).`,
+        response.status,
+        rawBody,
+      );
+    }
+    if (!rawBody) {
+      return null;
+    }
+    try {
+      return JSON.parse(rawBody);
+    } catch {
+      throw new CogneeApiError(
+        `${operation} returned a non-JSON response.`,
+        response.status,
+        rawBody,
+      );
+    }
+  }
+}

--- a/integrations/vscode/src/core/index.ts
+++ b/integrations/vscode/src/core/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Editor-agnostic core for the Cognee memory integration.
+ *
+ * Nothing in this folder imports `vscode`, so it can be unit-tested in plain
+ * Node against a mocked backend and reused by other editor front-ends.
+ */
+export * from "./types";
+export * from "./errors";
+export * from "./config";
+export * from "./scope";
+export * from "./git";
+export * from "./evidence";
+export * from "./client";
+export * from "./httpClient";

--- a/integrations/vscode/src/core/scope.test.ts
+++ b/integrations/vscode/src/core/scope.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveDatasetName, normalizeGitRemote, sanitizeDatasetName } from "./scope";
+
+describe("normalizeGitRemote", () => {
+  it("normalizes ssh, https, and scheme+userinfo forms to the same key", () => {
+    expect(normalizeGitRemote("git@github.com:user/repo.git")).toBe("github.com/user/repo");
+    expect(normalizeGitRemote("https://github.com/user/repo.git")).toBe("github.com/user/repo");
+    expect(normalizeGitRemote("ssh://git@github.com/user/repo/")).toBe("github.com/user/repo");
+    expect(normalizeGitRemote("HTTPS://GitHub.com/User/Repo")).toBe("github.com/user/repo");
+  });
+
+  it("returns null for empty or missing input", () => {
+    expect(normalizeGitRemote("")).toBeNull();
+    expect(normalizeGitRemote("   ")).toBeNull();
+    expect(normalizeGitRemote(null)).toBeNull();
+    expect(normalizeGitRemote(undefined)).toBeNull();
+  });
+});
+
+describe("sanitizeDatasetName", () => {
+  it("replaces disallowed characters and trims separators", () => {
+    expect(sanitizeDatasetName("My Project!")).toBe("My_Project");
+    expect(sanitizeDatasetName("  a//b  ")).toBe("a_b");
+    expect(sanitizeDatasetName("!!!")).toBe("workspace");
+  });
+});
+
+describe("deriveDatasetName", () => {
+  it("is deterministic and identical across equivalent remotes", () => {
+    const fromSsh = deriveDatasetName({ workspaceRoot: "/a", gitRemote: "git@github.com:user/repo.git" });
+    const fromHttps = deriveDatasetName({
+      workspaceRoot: "/b",
+      gitRemote: "https://github.com/user/repo.git",
+    });
+    expect(fromSsh).toBe(fromHttps);
+    expect(fromSsh).toMatch(/^vscode_[0-9a-f]{16}$/);
+  });
+
+  it("falls back to the workspace path (separator/trailing-slash insensitive)", () => {
+    const a = deriveDatasetName({ workspaceRoot: "/home/x/proj" });
+    const b = deriveDatasetName({ workspaceRoot: "/home/x/proj/" });
+    const c = deriveDatasetName({ workspaceRoot: "\\home\\x\\proj" });
+    expect(a).toBe(b);
+    expect(a).toBe(c);
+    expect(a).toMatch(/^vscode_[0-9a-f]{16}$/);
+  });
+
+  it("honors an explicit override", () => {
+    expect(deriveDatasetName({ workspaceRoot: "/a", override: "My Project!" })).toBe("My_Project");
+  });
+
+  it("respects a custom prefix", () => {
+    expect(deriveDatasetName({ workspaceRoot: "/a", prefix: "jetbrains" })).toMatch(
+      /^jetbrains_[0-9a-f]{16}$/,
+    );
+  });
+});

--- a/integrations/vscode/src/core/scope.ts
+++ b/integrations/vscode/src/core/scope.ts
@@ -1,0 +1,95 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Per-repository memory scoping.
+ *
+ * Each workspace maps to a single, stable Cognee dataset so that project memory
+ * is isolated per repository. The dataset name is derived deterministically from
+ * the git remote URL when available (stable across clones, renames, and machines)
+ * and falls back to the workspace path for repos without a remote.
+ *
+ * Passing an explicit dataset on every call is what keeps two workspaces open in
+ * the same editor from colliding — the server's per-client default is never relied on.
+ */
+
+export interface ScopeInput {
+  /** Absolute path of the workspace root. */
+  workspaceRoot: string;
+  /** The repository's `origin` remote URL, if any. */
+  gitRemote?: string | null;
+  /** An explicit dataset name that overrides the derived one. */
+  override?: string | null;
+  /** Dataset name prefix (default: "vscode"). */
+  prefix?: string;
+}
+
+const DEFAULT_PREFIX = "vscode";
+const HASH_LENGTH = 16;
+
+/**
+ * Normalize a git remote so that equivalent URLs (ssh vs https, with/without
+ * `.git`, trailing slashes, case) map to the same key.
+ *
+ * Examples (all normalize to `github.com/user/repo`):
+ *   - git@github.com:user/repo.git
+ *   - https://github.com/user/repo.git
+ *   - ssh://git@github.com/user/repo/
+ */
+export function normalizeGitRemote(remote: string | null | undefined): string | null {
+  if (!remote) {
+    return null;
+  }
+  let value = remote.trim();
+  if (!value) {
+    return null;
+  }
+
+  // Drop a URL scheme (https://, ssh://, git://, ...).
+  value = value.replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//, "");
+  // Drop userinfo (e.g. "git@").
+  value = value.replace(/^[^@/]+@/, "");
+  // Convert scp-like "host:path" to "host/path" (only when ':' precedes a
+  // non-digit, so an explicit ssh port like ":22/" is preserved).
+  value = value.replace(/:(?=\D)/, "/");
+  // Lowercase, then strip trailing slashes and a trailing ".git".
+  value = value
+    .toLowerCase()
+    .replace(/\/+$/, "")
+    .replace(/\.git$/, "")
+    .replace(/\/+$/, "");
+
+  return value || null;
+}
+
+/** Normalize a filesystem path so separators and trailing slashes don't affect the hash. */
+export function normalizeWorkspaceRoot(root: string): string {
+  return root.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+/** Coerce an arbitrary string into a Cognee-safe dataset name. */
+export function sanitizeDatasetName(name: string): string {
+  const cleaned = name
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return cleaned || "workspace";
+}
+
+/**
+ * Derive the dataset name for a workspace.
+ *
+ * Precedence: explicit `override` → git remote hash → workspace-path hash.
+ */
+export function deriveDatasetName(input: ScopeInput): string {
+  const prefix = sanitizeDatasetName(input.prefix ?? DEFAULT_PREFIX);
+
+  const override = input.override?.trim();
+  if (override) {
+    return sanitizeDatasetName(override);
+  }
+
+  const key = normalizeGitRemote(input.gitRemote) ?? normalizeWorkspaceRoot(input.workspaceRoot);
+  const hash = createHash("sha256").update(key, "utf8").digest("hex").slice(0, HASH_LENGTH);
+  return `${prefix}_${hash}`;
+}

--- a/integrations/vscode/src/core/types.ts
+++ b/integrations/vscode/src/core/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Wire types for the Cognee HTTP API.
+ *
+ * These mirror the server contracts exactly:
+ * - `POST /api/v1/recall`   → `RecallPayloadDTO` / `list[RecallResponse]`
+ * - `POST /api/v1/remember` → multipart form / `RememberResult.to_dict()`
+ * - `POST /api/v1/forget`   → `ForgetPayloadDTO`
+ * - `POST /api/v1/improve`  → `{ dataset_name | dataset_id, ... }`
+ *
+ * The recall endpoint accepts both camelCase and snake_case keys; this client
+ * sends snake_case to match the Python DTO field names precisely.
+ */
+
+/** Recall strategy. `null` asks the server to auto-route to the best strategy. */
+export type SearchType =
+  | "GRAPH_COMPLETION"
+  | "GRAPH_COMPLETION_COT"
+  | "RAG_COMPLETION"
+  | "CHUNKS"
+  | "SUMMARIES"
+  | (string & {});
+
+/**
+ * One normalized search hit (`SearchResultItem` on the server). `text` is
+ * always populated and renderable; for completion strategies with
+ * `include_references` enabled it carries the answer plus an `Evidence:` block.
+ */
+export interface SearchResultItem {
+  kind: string;
+  search_type: string;
+  text: string;
+  score?: number | null;
+  dataset_id?: string | null;
+  dataset_name?: string | null;
+  metadata?: Record<string, unknown>;
+  raw?: Record<string, unknown>;
+  structured?: unknown;
+}
+
+/**
+ * A single recall result. The server returns a discriminated union keyed by
+ * `source`; graph results carry a renderable `text`, while the context sources
+ * carry `content`.
+ */
+export type RecallResponseItem =
+  | ({ source: "graph" } & SearchResultItem)
+  | { source: "graph_context"; content: string }
+  | { source: "session_context"; content: string; context_profile: string }
+  | ({ source: "session"; question?: string; answer?: string; context?: string } & Record<
+      string,
+      unknown
+    >)
+  | ({ source: "trace" } & Record<string, unknown>);
+
+/** Result envelope returned by `POST /api/v1/remember`. */
+export interface RememberResult {
+  /** e.g. "completed", "running" (background), "errored". */
+  status?: string;
+  pipeline_run_id?: string;
+  dataset_id?: string;
+  [key: string]: unknown;
+}

--- a/integrations/vscode/src/extension/commands/forget.ts
+++ b/integrations/vscode/src/extension/commands/forget.ts
@@ -1,0 +1,43 @@
+import * as vscode from "vscode";
+
+import { describeError } from "../../core";
+import type { Runtime } from "../runtime";
+
+const CLEAR_MEMORY = "Clear memory (keep files)";
+const DELETE_ALL = "Delete everything";
+
+/**
+ * Forget the workspace's project memory. Offers a safe default (clear the graph
+ * and embeddings but keep raw files so it can be re-indexed) and a destructive
+ * option (delete the whole dataset). Both are confirmed via a modal.
+ */
+export async function forgetProject(runtime: Runtime): Promise<void> {
+  const choice = await vscode.window.showWarningMessage(
+    `Forget project memory for "${runtime.datasetName}"?`,
+    {
+      modal: true,
+      detail:
+        `"${CLEAR_MEMORY}" clears the knowledge graph and embeddings so you can re-index.\n` +
+        `"${DELETE_ALL}" permanently removes the dataset and its ingested data.`,
+    },
+    CLEAR_MEMORY,
+    DELETE_ALL,
+  );
+  if (choice !== CLEAR_MEMORY && choice !== DELETE_ALL) {
+    return;
+  }
+
+  const memoryOnly = choice === CLEAR_MEMORY;
+  try {
+    await runtime.client.forget({ dataset: runtime.datasetName, memoryOnly });
+    runtime.logger.info(`forget dataset=${runtime.datasetName} memoryOnly=${memoryOnly}`);
+    void vscode.window.showInformationMessage(
+      memoryOnly
+        ? `Cognee: cleared memory for ${runtime.datasetName} (files kept).`
+        : `Cognee: deleted dataset ${runtime.datasetName}.`,
+    );
+  } catch (error) {
+    runtime.logger.error("forget failed", error);
+    void vscode.window.showErrorMessage(`Cognee: ${describeError(error)}`);
+  }
+}

--- a/integrations/vscode/src/extension/commands/indexWorkspace.ts
+++ b/integrations/vscode/src/extension/commands/indexWorkspace.ts
@@ -1,0 +1,152 @@
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+
+import * as vscode from "vscode";
+
+import { buildIgnoreFilter } from "../ignore";
+import { basenameOf } from "../paths";
+import type { Runtime } from "../runtime";
+
+const INCLUDE_GLOB =
+  "**/*.{ts,tsx,js,jsx,mjs,cjs,py,go,rs,java,kt,rb,php,c,h,cc,cpp,hpp,cs,swift,scala," +
+  "md,mdx,txt,rst,json,yaml,yml,toml,ini,cfg,sh,bash,sql,graphql,html,css,scss,less,vue,svelte}";
+
+const EXCLUDE_GLOB =
+  "**/{node_modules,.git,dist,build,out,.next,.nuxt,.venv,venv,__pycache__,.mypy_cache," +
+  ".pytest_cache,coverage,.idea,.vscode-test,target,bin,obj}/**";
+
+const MAX_FILES = 400;
+
+/**
+ * Index the workspace into project memory: discover eligible files, show a
+ * preflight summary, and (on confirmation) remember each one with progress and
+ * cancellation. Opt-in by design — nothing is sent until the user confirms.
+ */
+export async function indexWorkspace(runtime: Runtime): Promise<void> {
+  // Dependency/build/VCS directories are never useful project memory, so they
+  // are always excluded — passing null here would disable VS Code's defaults too.
+  const found = await vscode.workspace.findFiles(INCLUDE_GLOB, EXCLUDE_GLOB, MAX_FILES);
+
+  // When enabled, honor the project's own ignore files so git-ignored (and
+  // .cogneeignore-listed) files — build output, secrets, envs — aren't uploaded.
+  const isIgnored = runtime.config.respectGitignore
+    ? await loadIgnoreFilter(runtime.workspaceRoot)
+    : undefined;
+
+  const maxBytes = runtime.config.maxFileSizeKb * 1024;
+  const eligible: { uri: vscode.Uri; size: number }[] = [];
+  let totalBytes = 0;
+  for (const uri of found) {
+    if (isIgnored?.(vscode.workspace.asRelativePath(uri, false))) {
+      continue;
+    }
+    try {
+      const stat = await vscode.workspace.fs.stat(uri);
+      if (stat.size > 0 && stat.size <= maxBytes) {
+        eligible.push({ uri, size: stat.size });
+        totalBytes += stat.size;
+      }
+    } catch {
+      // Unreadable entry — skip it.
+    }
+  }
+
+  if (eligible.length === 0) {
+    void vscode.window.showInformationMessage(
+      "Cognee: no eligible files to index (check size limit and ignore settings).",
+    );
+    return;
+  }
+
+  const capNote = found.length >= MAX_FILES ? ` (capped at ${MAX_FILES})` : "";
+  const proceed = await vscode.window.showWarningMessage(
+    `Index ${eligible.length} file(s), ${formatBytes(totalBytes)}${capNote} into "${runtime.datasetName}"? ` +
+      "This sends file contents to your configured Cognee backend.",
+    { modal: true },
+    "Index workspace",
+  );
+  if (proceed !== "Index workspace") {
+    return;
+  }
+
+  await runIndexing(runtime, eligible);
+}
+
+async function runIndexing(
+  runtime: Runtime,
+  files: { uri: vscode.Uri; size: number }[],
+): Promise<void> {
+  await vscode.window.withProgress(
+    { location: vscode.ProgressLocation.Notification, title: "Cognee: indexing workspace…", cancellable: true },
+    async (progress, token) => {
+      const controller = new AbortController();
+      token.onCancellationRequested(() => controller.abort());
+
+      let indexed = 0;
+      let failed = 0;
+      const increment = 100 / files.length;
+
+      for (const file of files) {
+        if (token.isCancellationRequested) {
+          break;
+        }
+        const label = vscode.workspace.asRelativePath(file.uri, false);
+        progress.report({ message: label, increment });
+        try {
+          const bytes = await vscode.workspace.fs.readFile(file.uri);
+          const text = Buffer.from(bytes).toString("utf8");
+          if (!text.trim()) {
+            continue;
+          }
+          await runtime.client.remember(`Source: ${label}\n\n${text}`, {
+            datasetName: runtime.datasetName,
+            filename: basenameOf(label),
+            runInBackground: true,
+            signal: controller.signal,
+          });
+          await runtime.pathIndex.record(label);
+          indexed += 1;
+        } catch (error) {
+          failed += 1;
+          runtime.logger.error(`index failed for ${label}`, error);
+        }
+      }
+
+      runtime.logger.info(`index complete: ${indexed} indexed, ${failed} failed.`);
+      if (failed > 0) {
+        void vscode.window.showWarningMessage(
+          `Cognee: indexed ${indexed} file(s); ${failed} failed. See the Cognee output for details.`,
+        );
+      } else {
+        void vscode.window.showInformationMessage(
+          `Cognee: queued ${indexed} file(s) into project memory (${runtime.datasetName}).`,
+        );
+      }
+    },
+  );
+}
+
+/** Read the workspace's `.gitignore` and `.cogneeignore` into a path matcher. */
+async function loadIgnoreFilter(
+  workspaceRoot: string,
+): Promise<((relativePath: string) => boolean) | undefined> {
+  const read = async (name: string): Promise<string | undefined> => {
+    try {
+      return await fs.readFile(path.join(workspaceRoot, name), "utf8");
+    } catch {
+      return undefined; // absent or unreadable — nothing to add
+    }
+  };
+  const [gitignore, cogneeignore] = await Promise.all([read(".gitignore"), read(".cogneeignore")]);
+  return buildIgnoreFilter(gitignore, cogneeignore);
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/integrations/vscode/src/extension/commands/recall.ts
+++ b/integrations/vscode/src/extension/commands/recall.ts
@@ -1,0 +1,105 @@
+import * as vscode from "vscode";
+
+import { describeError, resolveSearchType } from "../../core";
+import type { Runtime } from "../runtime";
+import { openCitation } from "../ui/citations";
+import { dedupeByFile, rankCitations, renderRecall, type RenderedRecall } from "../ui/render";
+
+/** Prompt for a query, recall project memory, and present the answer + sources. */
+export async function recallCommand(runtime: Runtime): Promise<void> {
+  const query = await vscode.window.showInputBox({
+    prompt: "Ask your project memory",
+    placeHolder: "e.g. How is authentication handled in this project?",
+  });
+  if (!query || !query.trim()) {
+    return;
+  }
+
+  const rendered = await runRecall(runtime, query.trim());
+  if (!rendered) {
+    return;
+  }
+  if (rendered.isEmpty) {
+    void vscode.window.showInformationMessage(
+      "Cognee: no answer yet — remember or index something first.",
+    );
+    return;
+  }
+
+  await presentResult(runtime, rendered);
+}
+
+/**
+ * Execute a recall against the workspace dataset with a progress notification.
+ * Shared by the command and the "Ask my project memory" panel. Returns undefined
+ * on error (already surfaced to the user).
+ */
+export async function runRecall(
+  runtime: Runtime,
+  query: string,
+): Promise<RenderedRecall | undefined> {
+  return vscode.window.withProgress(
+    { location: vscode.ProgressLocation.Notification, title: "Cognee: recalling…", cancellable: true },
+    async (_progress, token) => {
+      const controller = new AbortController();
+      token.onCancellationRequested(() => controller.abort());
+      try {
+        const items = await runtime.client.recall(query, {
+          datasets: [runtime.datasetName],
+          searchType: resolveSearchType(runtime.config.searchType),
+          topK: runtime.config.topK,
+          includeReferences: runtime.config.includeReferences,
+          signal: controller.signal,
+        });
+        const rendered = renderRecall(items);
+        // Present sources the professional way: rank by relevance to the query
+        // (Cognee returns the Evidence list unranked), then collapse repeated
+        // chunks of the same file so each cited file appears once. Only the
+        // source list is reordered/de-duplicated — never the answer.
+        const citations = dedupeByFile(rankCitations(rendered.citations, query));
+        return { ...rendered, citations };
+      } catch (error) {
+        runtime.logger.error("recall failed", error);
+        void vscode.window.showErrorMessage(`Cognee: ${describeError(error)}`);
+        return undefined;
+      }
+    },
+  );
+}
+
+async function presentResult(runtime: Runtime, rendered: RenderedRecall): Promise<void> {
+  const document = await vscode.workspace.openTextDocument({
+    language: "markdown",
+    content: toMarkdown(rendered),
+  });
+  await vscode.window.showTextDocument(document, { preview: true });
+
+  if (rendered.citations.length === 0) {
+    return;
+  }
+
+  const picked = await vscode.window.showQuickPick(
+    rendered.citations.map((citation) => ({
+      label: citation.documentName,
+      description: citation.chunkId ?? "",
+      detail: citation.snippet ?? "",
+      citation,
+    })),
+    { placeHolder: "Open a cited source" },
+  );
+  if (picked) {
+    await openCitation(picked.citation, runtime.pathIndex);
+  }
+}
+
+function toMarkdown(rendered: RenderedRecall): string {
+  const lines = ["# Cognee — project memory", "", rendered.answer.trim() || "_No answer._"];
+  if (rendered.citations.length > 0) {
+    lines.push("", "## Sources");
+    for (const citation of rendered.citations) {
+      const snippet = citation.snippet ? ` — ${citation.snippet}` : "";
+      lines.push(`- \`${citation.documentName}\`${snippet}`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/integrations/vscode/src/extension/commands/remember.ts
+++ b/integrations/vscode/src/extension/commands/remember.ts
@@ -1,0 +1,132 @@
+import * as vscode from "vscode";
+
+import { describeError } from "../../core";
+import { basenameOf } from "../paths";
+import type { Runtime } from "../runtime";
+
+/** Remember the current selection (or the whole file when nothing is selected). */
+export async function rememberSelection(runtime: Runtime): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    void vscode.window.showWarningMessage("Cognee: open a file and select text to remember.");
+    return;
+  }
+
+  const { selection, document } = editor;
+  const text = selection.isEmpty ? document.getText() : document.getText(selection);
+  if (!text.trim()) {
+    void vscode.window.showWarningMessage("Cognee: nothing to remember (the selection is empty).");
+    return;
+  }
+
+  const relativePath = vscode.workspace.asRelativePath(document.uri, false);
+  // A full-line selection ends at column 0 of the following line; that trailing
+  // line holds no selected text, so exclude it from the recorded range.
+  const lastLine =
+    selection.end.character === 0 && selection.end.line > selection.start.line
+      ? selection.end.line
+      : selection.end.line + 1;
+  const lineRange = selection.isEmpty
+    ? undefined
+    : `lines ${selection.start.line + 1}-${lastLine}`;
+
+  await ingest(
+    runtime,
+    decorate(text, relativePath, lineRange),
+    basenameOf(relativePath),
+    `Remembering from ${relativePath}…`,
+    relativePath,
+  );
+}
+
+/** Remember an entire file, invoked from the explorer context menu or palette. */
+export async function rememberFile(runtime: Runtime, resource?: vscode.Uri): Promise<void> {
+  const uri = resource ?? vscode.window.activeTextEditor?.document.uri;
+  if (!uri) {
+    void vscode.window.showWarningMessage("Cognee: no file to remember.");
+    return;
+  }
+
+  let bytes: Uint8Array;
+  try {
+    bytes = await vscode.workspace.fs.readFile(uri);
+  } catch (error) {
+    runtime.logger.error("rememberFile read failed", error);
+    void vscode.window.showErrorMessage("Cognee: couldn't read that file.");
+    return;
+  }
+
+  const text = Buffer.from(bytes).toString("utf8");
+  if (!text.trim()) {
+    void vscode.window.showWarningMessage("Cognee: that file is empty.");
+    return;
+  }
+
+  const relativePath = vscode.workspace.asRelativePath(uri, false);
+  await ingest(
+    runtime,
+    decorate(text, relativePath),
+    basenameOf(relativePath),
+    `Remembering ${relativePath}…`,
+    relativePath,
+  );
+}
+
+/** Remember a free-form note typed by the user (no file backing). */
+export async function rememberNote(runtime: Runtime): Promise<void> {
+  const note = await vscode.window.showInputBox({
+    prompt: "Remember a note in project memory",
+    placeHolder: "e.g. API fields use snake_case; auth tokens live in the session cache.",
+    ignoreFocusOut: true,
+  });
+  // `undefined` = dismissed; an empty/whitespace note is nothing to store.
+  if (note === undefined || !note.trim()) {
+    return;
+  }
+
+  await ingest(runtime, note.trim(), "note.md", "Remembering note…");
+}
+
+/**
+ * Ingest text into project memory. When the content comes from a file, pass its
+ * workspace-relative path so the source is recorded and future citations resolve
+ * straight to the exact file; free-form notes omit it.
+ */
+async function ingest(
+  runtime: Runtime,
+  data: string,
+  filename: string,
+  title: string,
+  relativePath?: string,
+): Promise<void> {
+  await vscode.window.withProgress(
+    { location: vscode.ProgressLocation.Notification, title, cancellable: true },
+    async (_progress, token) => {
+      const controller = new AbortController();
+      token.onCancellationRequested(() => controller.abort());
+      try {
+        const result = await runtime.client.remember(data, {
+          datasetName: runtime.datasetName,
+          filename,
+          signal: controller.signal,
+        });
+        if (relativePath) {
+          await runtime.pathIndex.record(relativePath);
+        }
+        runtime.logger.info(`remember → status=${result.status ?? "ok"} dataset=${runtime.datasetName}`);
+        void vscode.window.showInformationMessage(
+          `Cognee: remembered into project memory (${runtime.datasetName}).`,
+        );
+      } catch (error) {
+        runtime.logger.error("remember failed", error);
+        void vscode.window.showErrorMessage(`Cognee: ${describeError(error)}`);
+      }
+    },
+  );
+}
+
+/** Prepend a provenance header so the source is preserved in memory. */
+function decorate(text: string, relativePath: string, lineRange?: string): string {
+  const source = lineRange ? `${relativePath} (${lineRange})` : relativePath;
+  return `Source: ${source}\n\n${text}`;
+}

--- a/integrations/vscode/src/extension/commands/setup.ts
+++ b/integrations/vscode/src/extension/commands/setup.ts
@@ -1,0 +1,78 @@
+import * as vscode from "vscode";
+
+import { HttpCogneeClient, validateConfig } from "../../core";
+import type { Logger } from "../logger";
+import { SECRET_API_KEY } from "../runtime";
+import { readConfig } from "../settings";
+import { getWorkspaceRoot } from "../workspace";
+
+/**
+ * Guided onboarding: capture the endpoint and (optionally) an API key, store the
+ * key in the OS keychain via secret storage, then run a health check so the user
+ * knows their connection works.
+ *
+ * The health check does not require an open folder — only Remember/Ask do — so
+ * Set Up is useful even on an empty window.
+ */
+export async function setup(context: vscode.ExtensionContext, logger: Logger): Promise<void> {
+  const current = readConfig();
+
+  const endpoint = await vscode.window.showInputBox({
+    prompt: "Cognee endpoint",
+    value: current.endpoint,
+    placeHolder: "http://localhost:8011 or https://<tenant>.cognee.ai",
+    validateInput: (value) =>
+      /^https?:\/\//i.test(value.trim()) ? undefined : "Must start with http:// or https://",
+  });
+  if (endpoint === undefined) {
+    return;
+  }
+  await vscode.workspace
+    .getConfiguration("cognee")
+    .update("endpoint", endpoint.trim(), vscode.ConfigurationTarget.Global);
+
+  const apiKey = await vscode.window.showInputBox({
+    prompt: "Cognee API key (leave empty for a local server)",
+    password: true,
+    placeHolder: "Stored securely in the OS keychain — not in settings",
+  });
+  if (apiKey !== undefined) {
+    if (apiKey.trim()) {
+      await context.secrets.store(SECRET_API_KEY, apiKey.trim());
+    } else {
+      await context.secrets.delete(SECRET_API_KEY);
+    }
+  }
+
+  const saved = readConfig();
+  const validation = validateConfig(saved);
+  if (!validation.ok) {
+    void vscode.window.showErrorMessage(`Cognee: ${validation.errors.join(" ")}`);
+    return;
+  }
+
+  const storedKey = (await context.secrets.get(SECRET_API_KEY))?.trim();
+  const client = new HttpCogneeClient({
+    endpoint: saved.endpoint,
+    apiKey: storedKey || saved.apiKey,
+    timeoutMs: saved.requestTimeoutMs,
+  });
+
+  const reachable = await client.health();
+  logger.info(`setup: health check ${reachable ? "ok" : "unreachable"} for ${saved.endpoint}`);
+
+  if (!reachable) {
+    void vscode.window.showWarningMessage(
+      `Cognee: settings saved, but ${saved.endpoint} isn't reachable yet. ` +
+        "Start the Cognee server or re-check the endpoint/key.",
+    );
+    return;
+  }
+
+  const hasFolder = getWorkspaceRoot() !== undefined;
+  void vscode.window.showInformationMessage(
+    hasFolder
+      ? `Cognee: connected to ${saved.endpoint}. Ready — try "Cognee: Ask My Project Memory".`
+      : `Cognee: connected to ${saved.endpoint}. Open a folder to start capturing project memory.`,
+  );
+}

--- a/integrations/vscode/src/extension/extension.ts
+++ b/integrations/vscode/src/extension/extension.ts
@@ -1,0 +1,64 @@
+import * as vscode from "vscode";
+
+import { forgetProject } from "./commands/forget";
+import { indexWorkspace } from "./commands/indexWorkspace";
+import { recallCommand } from "./commands/recall";
+import { rememberFile, rememberNote, rememberSelection } from "./commands/remember";
+import { setup } from "./commands/setup";
+import { Logger } from "./logger";
+import { resolveRuntime } from "./runtime";
+import { AskPanel } from "./ui/askPanel";
+
+export function activate(context: vscode.ExtensionContext): void {
+  const logger = new Logger();
+  context.subscriptions.push(logger);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("cognee.rememberSelection", async () => {
+      const runtime = await resolveRuntime(context, logger);
+      if (runtime) {
+        await rememberSelection(runtime);
+      }
+    }),
+    vscode.commands.registerCommand("cognee.rememberFile", async (resource?: vscode.Uri) => {
+      const runtime = await resolveRuntime(context, logger);
+      if (runtime) {
+        await rememberFile(runtime, resource);
+      }
+    }),
+    vscode.commands.registerCommand("cognee.rememberNote", async () => {
+      const runtime = await resolveRuntime(context, logger);
+      if (runtime) {
+        await rememberNote(runtime);
+      }
+    }),
+    vscode.commands.registerCommand("cognee.recall", async () => {
+      const runtime = await resolveRuntime(context, logger);
+      if (runtime) {
+        await recallCommand(runtime);
+      }
+    }),
+    vscode.commands.registerCommand("cognee.indexWorkspace", async () => {
+      const runtime = await resolveRuntime(context, logger);
+      if (runtime) {
+        await indexWorkspace(runtime);
+      }
+    }),
+    vscode.commands.registerCommand("cognee.forgetProject", async () => {
+      const runtime = await resolveRuntime(context, logger);
+      if (runtime) {
+        await forgetProject(runtime);
+      }
+    }),
+    vscode.commands.registerCommand("cognee.askProjectMemory", () => {
+      AskPanel.show(() => resolveRuntime(context, logger));
+    }),
+    vscode.commands.registerCommand("cognee.setup", () => setup(context, logger)),
+  );
+
+  logger.info("Cognee extension activated.");
+}
+
+export function deactivate(): void {
+  // Nothing to clean up beyond context.subscriptions.
+}

--- a/integrations/vscode/src/extension/ignore.test.ts
+++ b/integrations/vscode/src/extension/ignore.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { buildIgnoreFilter } from "./ignore";
+
+describe("buildIgnoreFilter", () => {
+  it("returns undefined when there are no rules", () => {
+    expect(buildIgnoreFilter(undefined, "")).toBeUndefined();
+    expect(buildIgnoreFilter("   \n\n")).toBeUndefined();
+  });
+
+  it("ignores paths matched by .gitignore patterns", () => {
+    const isIgnored = buildIgnoreFilter("*.log\ndist/\n")!;
+    expect(isIgnored("app.log")).toBe(true);
+    expect(isIgnored("dist/bundle.js")).toBe(true);
+    expect(isIgnored("src/index.ts")).toBe(false);
+  });
+
+  it("combines .gitignore and .cogneeignore rules", () => {
+    const isIgnored = buildIgnoreFilter("*.log", "secrets/\n")!;
+    expect(isIgnored("a.log")).toBe(true);
+    expect(isIgnored("secrets/key.txt")).toBe(true);
+    expect(isIgnored("README.md")).toBe(false);
+  });
+
+  it("honors git negation (re-include) rules", () => {
+    const isIgnored = buildIgnoreFilter("*.log\n!keep.log")!;
+    expect(isIgnored("debug.log")).toBe(true);
+    expect(isIgnored("keep.log")).toBe(false);
+  });
+
+  it("normalizes backslashes and never ignores a blank path", () => {
+    const isIgnored = buildIgnoreFilter("dist/")!;
+    expect(isIgnored("dist\\bundle.js")).toBe(true);
+    expect(isIgnored("")).toBe(false);
+  });
+});

--- a/integrations/vscode/src/extension/ignore.ts
+++ b/integrations/vscode/src/extension/ignore.ts
@@ -1,0 +1,33 @@
+import ignore from "ignore";
+
+/**
+ * Build a predicate that reports whether a workspace-relative path is excluded
+ * by the given ignore-file contents. Inputs use `.gitignore` / `.cogneeignore`
+ * syntax — globs, `!` negation, `/` anchoring, and trailing `/` for directories —
+ * matched by the `ignore` library so the semantics are exactly git's.
+ *
+ * Returns undefined when none of the inputs contain any rules, so the caller can
+ * skip filtering entirely. Kept `vscode`-free so it is unit-tested in plain Node
+ * and reusable by the planned JetBrains sidecar.
+ */
+export function buildIgnoreFilter(
+  ...contents: (string | undefined)[]
+): ((relativePath: string) => boolean) | undefined {
+  const matcher = ignore();
+  let hasRules = false;
+  for (const content of contents) {
+    if (content && content.trim()) {
+      matcher.add(content);
+      hasRules = true;
+    }
+  }
+  if (!hasRules) {
+    return undefined;
+  }
+  return (relativePath) => {
+    // `ignore` expects a relative, forward-slashed path and throws on empty or
+    // absolute input; a blank path is never considered ignored.
+    const normalized = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
+    return normalized.length > 0 && matcher.ignores(normalized);
+  };
+}

--- a/integrations/vscode/src/extension/logger.ts
+++ b/integrations/vscode/src/extension/logger.ts
@@ -1,0 +1,31 @@
+import * as vscode from "vscode";
+
+/** Thin wrapper over a VS Code output channel with timestamped, levelled lines. */
+export class Logger implements vscode.Disposable {
+  private readonly channel: vscode.OutputChannel;
+
+  constructor() {
+    this.channel = vscode.window.createOutputChannel("Cognee");
+  }
+
+  info(message: string): void {
+    this.write("info", message);
+  }
+
+  error(message: string, error?: unknown): void {
+    const detail = error instanceof Error ? `${error.name}: ${error.message}` : error ? String(error) : "";
+    this.write("error", detail ? `${message} — ${detail}` : message);
+  }
+
+  show(): void {
+    this.channel.show(true);
+  }
+
+  dispose(): void {
+    this.channel.dispose();
+  }
+
+  private write(level: "info" | "error", message: string): void {
+    this.channel.appendLine(`[${new Date().toISOString()}] [${level}] ${message}`);
+  }
+}

--- a/integrations/vscode/src/extension/pathIndex.test.ts
+++ b/integrations/vscode/src/extension/pathIndex.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { PathIndex, type KeyValueStore } from "./pathIndex";
+
+function fakeStore(): KeyValueStore {
+  const data = new Map<string, unknown>();
+  return {
+    get<T>(key: string): T | undefined {
+      return data.get(key) as T | undefined;
+    },
+    update(key: string, value: unknown): Thenable<void> {
+      data.set(key, value);
+      return Promise.resolve();
+    },
+  };
+}
+
+describe("PathIndex", () => {
+  it("records and resolves an exact path by basename", async () => {
+    const index = new PathIndex(fakeStore());
+    await index.record("themes/_welcome/composer.json");
+    expect(index.pathsFor("composer.json")).toEqual(["themes/_welcome/composer.json"]);
+  });
+
+  it("keeps distinct paths for the same basename, sorted and de-duplicated", async () => {
+    const index = new PathIndex(fakeStore());
+    await index.record("themes/_welcome/composer.json");
+    await index.record("themes/attract/composer.json");
+    await index.record("themes/_welcome/composer.json"); // duplicate ignored
+    expect(index.pathsFor("composer.json")).toEqual([
+      "themes/_welcome/composer.json",
+      "themes/attract/composer.json",
+    ]);
+  });
+
+  it("normalizes separators and leading ./ when recording", async () => {
+    const index = new PathIndex(fakeStore());
+    await index.record(".\\src\\app\\main.ts");
+    expect(index.pathsFor("main.ts")).toEqual(["src/app/main.ts"]);
+  });
+
+  it("falls back to the stem when the cited name has no extension", async () => {
+    const index = new PathIndex(fakeStore());
+    await index.record("src/app/main.ts");
+    expect(index.pathsFor("main")).toEqual(["src/app/main.ts"]);
+  });
+
+  it("returns an empty list for unknown or empty names", async () => {
+    const index = new PathIndex(fakeStore());
+    await index.record("   ");
+    expect(index.pathsFor("nope.txt")).toEqual([]);
+    expect(index.pathsFor("")).toEqual([]);
+  });
+});

--- a/integrations/vscode/src/extension/pathIndex.ts
+++ b/integrations/vscode/src/extension/pathIndex.ts
@@ -1,0 +1,78 @@
+import { basenameOf, normalizeRelativePath, stemOf } from "./paths";
+
+/**
+ * Minimal persistence contract. Structurally satisfied by `vscode.Memento`
+ * (workspace state), and by a plain object in tests — so this module needs no
+ * `vscode` import and is fully unit-testable.
+ */
+export interface KeyValueStore {
+  get<T>(key: string): T | undefined;
+  update(key: string, value: unknown): Thenable<void>;
+}
+
+type IndexShape = Record<string, string[]>;
+
+/**
+ * Maps a document basename to the workspace-relative path(s) that were ingested
+ * for it, persisted per workspace.
+ *
+ * Cognee's recall citations carry only a document *basename* (its metadata
+ * reduces the source to a display name and does not surface the directory
+ * path). This index lets a citation resolve directly to the exact file the user
+ * actually remembered — no snippet guessing, no picker — even when the workspace
+ * has several files of that name.
+ */
+export class PathIndex {
+  private static readonly STORAGE_KEY = "cognee.pathIndex";
+
+  constructor(private readonly store: KeyValueStore) {}
+
+  /** Record that a workspace-relative path was ingested. Idempotent. */
+  async record(relativePath: string): Promise<void> {
+    const normalized = normalizeRelativePath(relativePath);
+    if (!normalized) {
+      return;
+    }
+    const key = basenameOf(normalized);
+    const index = this.read();
+    const paths = new Set(index[key] ?? []);
+    paths.add(normalized);
+    index[key] = [...paths].sort();
+    await this.store.update(PathIndex.STORAGE_KEY, index);
+  }
+
+  /**
+   * Workspace-relative paths previously ingested for a cited document name.
+   * Falls back to matching on the extension-less stem, in case the backend
+   * dropped the extension from the document name.
+   */
+  pathsFor(documentName: string): string[] {
+    const index = this.read();
+    const key = basenameOf(documentName);
+
+    const direct = index[key];
+    if (direct && direct.length > 0) {
+      return direct;
+    }
+
+    const stem = stemOf(key);
+    if (!stem) {
+      return [];
+    }
+    const matches = new Set<string>();
+    for (const [indexedName, paths] of Object.entries(index)) {
+      if (stemOf(indexedName) === stem) {
+        for (const path of paths) {
+          matches.add(path);
+        }
+      }
+    }
+    return [...matches].sort();
+  }
+
+  private read(): IndexShape {
+    const stored = this.store.get<IndexShape>(PathIndex.STORAGE_KEY);
+    // Return a shallow clone so callers never mutate the persisted object in place.
+    return stored ? { ...stored } : {};
+  }
+}

--- a/integrations/vscode/src/extension/paths.test.ts
+++ b/integrations/vscode/src/extension/paths.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { basenameOf, knownPathMatches, normalizeRelativePath, stemOf } from "./paths";
+
+describe("normalizeRelativePath", () => {
+  it("uses forward slashes and strips ./ and leading/trailing slashes", () => {
+    expect(normalizeRelativePath("./themes\\_welcome\\composer.json")).toBe(
+      "themes/_welcome/composer.json",
+    );
+    expect(normalizeRelativePath("/a/b/")).toBe("a/b");
+    expect(normalizeRelativePath("  x  ")).toBe("x");
+  });
+
+  it("drops .. and . segments so a Source path cannot escape the workspace", () => {
+    expect(normalizeRelativePath("../../etc/passwd")).toBe("etc/passwd");
+    expect(normalizeRelativePath("a/../b/./c")).toBe("a/b/c");
+    expect(normalizeRelativePath("/../secret.txt")).toBe("secret.txt");
+  });
+});
+
+describe("basenameOf", () => {
+  it("returns the final segment for posix and windows separators", () => {
+    expect(basenameOf("themes/_welcome/composer.json")).toBe("composer.json");
+    expect(basenameOf("a\\b\\c.ts")).toBe("c.ts");
+    expect(basenameOf("composer.json")).toBe("composer.json");
+  });
+});
+
+describe("stemOf", () => {
+  it("drops only the final extension", () => {
+    expect(stemOf("composer.json")).toBe("composer");
+    expect(stemOf("themes/x/README.md")).toBe("README");
+    expect(stemOf("archive.tar.gz")).toBe("archive.tar");
+    expect(stemOf("Makefile")).toBe("Makefile");
+  });
+});
+
+describe("knownPathMatches", () => {
+  const candidates = ["app/README.md", "themes/_welcome/README.md", "README.md"];
+
+  it("returns indices of candidates present in knownPaths (normalization-insensitive)", () => {
+    expect(knownPathMatches(candidates, ["themes/_welcome/README.md"])).toEqual([1]);
+    expect(knownPathMatches(candidates, ["./themes/_welcome/README.md"])).toEqual([1]);
+    expect(knownPathMatches(candidates, ["app/README.md", "README.md"])).toEqual([0, 2]);
+  });
+
+  it("returns an empty list when nothing matches", () => {
+    expect(knownPathMatches(candidates, [])).toEqual([]);
+    expect(knownPathMatches(candidates, ["other/README.md"])).toEqual([]);
+  });
+});

--- a/integrations/vscode/src/extension/paths.ts
+++ b/integrations/vscode/src/extension/paths.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure path helpers shared by the citation resolver and the path index.
+ *
+ * No `vscode` import, so these are unit-tested in plain Node and reusable by the
+ * planned JetBrains sidecar.
+ */
+
+/**
+ * Normalize a workspace-relative path to forward slashes with no empty, `.`, or
+ * `..` segments. Dropping `..` keeps a citation's server-provided `Source:` path
+ * from traversing outside the workspace (e.g. `../../etc/passwd` → `etc/passwd`),
+ * since the resolver joins the result onto a workspace folder and opens it.
+ */
+export function normalizeRelativePath(path: string): string {
+  return path
+    .trim()
+    .replace(/\\/g, "/")
+    .split("/")
+    .filter((segment) => segment && segment !== "." && segment !== "..")
+    .join("/");
+}
+
+/** The final path segment (basename) of a path or document name. */
+export function basenameOf(path: string): string {
+  const segments = path.split(/[\\/]/);
+  return (segments[segments.length - 1] ?? path).trim();
+}
+
+/** A basename with its final extension removed (e.g. `composer.json` → `composer`). */
+export function stemOf(name: string): string {
+  return basenameOf(name).replace(/\.[^.]+$/, "");
+}
+
+/**
+ * Indices of `candidateRelativePaths` that also appear in `knownPaths` (both
+ * normalized), preserving candidate order. Used to prefer files the user
+ * actually ingested when several share a basename.
+ */
+export function knownPathMatches(candidateRelativePaths: string[], knownPaths: string[]): number[] {
+  const known = new Set(knownPaths.map(normalizeRelativePath).filter((path) => path.length > 0));
+  const matches: number[] = [];
+  candidateRelativePaths.forEach((path, index) => {
+    if (known.has(normalizeRelativePath(path))) {
+      matches.push(index);
+    }
+  });
+  return matches;
+}

--- a/integrations/vscode/src/extension/runtime.ts
+++ b/integrations/vscode/src/extension/runtime.ts
@@ -1,0 +1,75 @@
+import * as vscode from "vscode";
+
+import {
+  deriveDatasetName,
+  HttpCogneeClient,
+  validateConfig,
+  type CogneeClient,
+  type CogneeConfig,
+} from "../core";
+import type { Logger } from "./logger";
+import { PathIndex } from "./pathIndex";
+import { readConfig } from "./settings";
+import { getGitRemote, getWorkspaceRoot } from "./workspace";
+
+/** Secret-storage key for the Cognee API key (preferred over synced settings). */
+export const SECRET_API_KEY = "cognee.apiKey";
+
+/** Everything a command needs to talk to Cognee for the active workspace. */
+export interface Runtime {
+  config: CogneeConfig;
+  client: CogneeClient;
+  datasetName: string;
+  workspaceRoot: string;
+  /** Per-workspace map of ingested basenames → relative paths, for direct citation redirect. */
+  pathIndex: PathIndex;
+  logger: Logger;
+}
+
+/**
+ * Build a {@link Runtime} for the active workspace, or surface a clear message
+ * and return undefined when preconditions aren't met (no folder, invalid config).
+ * Resolved fresh per command so settings changes take effect immediately.
+ */
+export async function resolveRuntime(
+  context: vscode.ExtensionContext,
+  logger: Logger,
+): Promise<Runtime | undefined> {
+  const workspaceRoot = getWorkspaceRoot();
+  if (!workspaceRoot) {
+    void vscode.window.showWarningMessage(
+      "Cognee: open a folder or workspace to use project memory.",
+    );
+    return undefined;
+  }
+
+  const config = readConfig();
+  const validation = validateConfig(config);
+  if (!validation.ok) {
+    void vscode.window.showErrorMessage(
+      `Cognee configuration problem: ${validation.errors.join(" ")}`,
+    );
+    return undefined;
+  }
+
+  const storedKey = (await context.secrets.get(SECRET_API_KEY))?.trim();
+  const apiKey = storedKey || config.apiKey;
+
+  const gitRemote = await getGitRemote(workspaceRoot);
+  const datasetName = deriveDatasetName({
+    workspaceRoot,
+    gitRemote,
+    override: config.datasetOverride,
+  });
+
+  const client = new HttpCogneeClient({
+    endpoint: config.endpoint,
+    apiKey,
+    timeoutMs: config.requestTimeoutMs,
+  });
+
+  const pathIndex = new PathIndex(context.workspaceState);
+
+  logger.info(`Resolved dataset "${datasetName}" for endpoint ${config.endpoint}.`);
+  return { config, client, datasetName, workspaceRoot, pathIndex, logger };
+}

--- a/integrations/vscode/src/extension/settings.ts
+++ b/integrations/vscode/src/extension/settings.ts
@@ -1,0 +1,20 @@
+import * as vscode from "vscode";
+
+import { normalizeEndpoint, type CogneeConfig } from "../core";
+
+/** Read the extension's configuration from VS Code settings into a plain core config. */
+export function readConfig(scope?: vscode.ConfigurationScope): CogneeConfig {
+  const settings = vscode.workspace.getConfiguration("cognee", scope);
+
+  return {
+    endpoint: normalizeEndpoint(settings.get<string>("endpoint", "http://localhost:8011")),
+    apiKey: settings.get<string>("apiKey", "").trim() || undefined,
+    datasetOverride: settings.get<string>("datasetOverride", "").trim() || undefined,
+    searchType: settings.get<string>("searchType", "auto"),
+    topK: settings.get<number>("topK", 15),
+    includeReferences: settings.get<boolean>("includeReferences", true),
+    respectGitignore: settings.get<boolean>("ingestion.respectGitignore", true),
+    maxFileSizeKb: settings.get<number>("ingestion.maxFileSizeKb", 512),
+    requestTimeoutMs: settings.get<number>("requestTimeoutMs", 300000),
+  };
+}

--- a/integrations/vscode/src/extension/ui/askPanel.ts
+++ b/integrations/vscode/src/extension/ui/askPanel.ts
@@ -1,0 +1,236 @@
+import { randomBytes } from "node:crypto";
+
+import * as vscode from "vscode";
+
+import type { Citation } from "../../core";
+import { runRecall } from "../commands/recall";
+import type { PathIndex } from "../pathIndex";
+import type { Runtime } from "../runtime";
+import { openCitation } from "./citations";
+
+/** Lazily resolves a fresh runtime so settings changes apply on every question. */
+export type RuntimeResolver = () => Promise<Runtime | undefined>;
+
+interface AskMessage {
+  type: "ask";
+  query: string;
+}
+interface OpenCitationMessage {
+  type: "openCitation";
+  index: number;
+}
+type InboundMessage = AskMessage | OpenCitationMessage;
+
+/**
+ * The "Ask my project memory" panel: a single webview that queries the
+ * workspace's Cognee dataset and renders answers with clickable citations.
+ */
+export class AskPanel {
+  private static current: AskPanel | undefined;
+
+  private readonly disposables: vscode.Disposable[] = [];
+  private citations: Citation[] = [];
+  private pathIndex: PathIndex | undefined;
+
+  static show(resolveRuntime: RuntimeResolver): void {
+    const column = vscode.window.activeTextEditor?.viewColumn ?? vscode.ViewColumn.One;
+    if (AskPanel.current) {
+      AskPanel.current.panel.reveal(column);
+      return;
+    }
+    const panel = vscode.window.createWebviewPanel(
+      "cognee.askPanel",
+      "Ask My Project Memory",
+      column,
+      { enableScripts: true, retainContextWhenHidden: true },
+    );
+    AskPanel.current = new AskPanel(panel, resolveRuntime);
+  }
+
+  private constructor(
+    private readonly panel: vscode.WebviewPanel,
+    private readonly resolveRuntime: RuntimeResolver,
+  ) {
+    this.panel.webview.html = this.render(this.panel.webview);
+    this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+    this.panel.webview.onDidReceiveMessage(
+      (message: InboundMessage) => void this.handleMessage(message),
+      null,
+      this.disposables,
+    );
+  }
+
+  private async handleMessage(message: InboundMessage): Promise<void> {
+    if (message.type === "ask") {
+      await this.handleAsk(message.query);
+    } else if (message.type === "openCitation") {
+      const citation = this.citations[message.index];
+      if (citation) {
+        await openCitation(citation, this.pathIndex);
+      }
+    }
+  }
+
+  private async handleAsk(rawQuery: string): Promise<void> {
+    const query = rawQuery.trim();
+    if (!query) {
+      return;
+    }
+    this.post({ type: "status", state: "loading" });
+
+    const runtime = await this.resolveRuntime();
+    if (!runtime) {
+      this.post({ type: "status", state: "error", message: "Configure Cognee first (Cognee: Set Up)." });
+      return;
+    }
+    this.pathIndex = runtime.pathIndex;
+
+    const rendered = await runRecall(runtime, query);
+    if (!rendered) {
+      this.post({ type: "status", state: "error", message: "Recall failed — see the Cognee output channel." });
+      return;
+    }
+
+    this.citations = rendered.citations;
+    this.post({
+      type: "answer",
+      answer: rendered.isEmpty ? "" : rendered.answer,
+      citations: rendered.citations.map((citation, index) => ({
+        index,
+        documentName: citation.documentName,
+        snippet: citation.snippet ?? "",
+      })),
+    });
+  }
+
+  private post(message: unknown): void {
+    void this.panel.webview.postMessage(message);
+  }
+
+  private dispose(): void {
+    AskPanel.current = undefined;
+    this.panel.dispose();
+    while (this.disposables.length) {
+      this.disposables.pop()?.dispose();
+    }
+  }
+
+  private render(webview: vscode.Webview): string {
+    const nonce = getNonce();
+    const csp = [
+      "default-src 'none'",
+      `style-src ${webview.cspSource} 'unsafe-inline'`,
+      `script-src 'nonce-${nonce}'`,
+    ].join("; ");
+
+    return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="${csp}" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ask My Project Memory</title>
+  <style>
+    body { font-family: var(--vscode-font-family); color: var(--vscode-foreground);
+           padding: 12px 16px; font-size: var(--vscode-font-size); }
+    h1 { font-size: 1.1em; margin: 0 0 12px; }
+    .row { display: flex; gap: 8px; }
+    textarea { flex: 1; resize: vertical; min-height: 44px; padding: 6px 8px;
+      color: var(--vscode-input-foreground); background: var(--vscode-input-background);
+      border: 1px solid var(--vscode-input-border, transparent); border-radius: 4px;
+      font-family: inherit; font-size: inherit; }
+    button { color: var(--vscode-button-foreground); background: var(--vscode-button-background);
+      border: none; padding: 6px 14px; border-radius: 4px; cursor: pointer; }
+    button:hover { background: var(--vscode-button-hoverBackground); }
+    #status { min-height: 18px; margin: 10px 0; color: var(--vscode-descriptionForeground); }
+    #status.error { color: var(--vscode-errorForeground); }
+    #answer { white-space: pre-wrap; line-height: 1.5; margin-top: 4px; }
+    h2 { font-size: 0.95em; margin: 18px 0 6px; color: var(--vscode-descriptionForeground); }
+    .cite { display: block; width: 100%; text-align: left; margin: 4px 0; padding: 6px 8px;
+      background: var(--vscode-editor-inactiveSelectionBackground); color: var(--vscode-foreground);
+      border: none; border-radius: 4px; cursor: pointer; }
+    .cite:hover { background: var(--vscode-list-hoverBackground); }
+    .cite .name { font-weight: 600; }
+    .cite .snippet { display: block; color: var(--vscode-descriptionForeground);
+      font-size: 0.9em; margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  </style>
+</head>
+<body>
+  <h1>Ask my project memory</h1>
+  <div class="row">
+    <textarea id="query" placeholder="e.g. How is authentication handled in this project?"></textarea>
+    <button id="ask">Ask</button>
+  </div>
+  <div id="status"></div>
+  <div id="answer"></div>
+  <div id="sources"></div>
+
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    const queryEl = document.getElementById('query');
+    const statusEl = document.getElementById('status');
+    const answerEl = document.getElementById('answer');
+    const sourcesEl = document.getElementById('sources');
+
+    function ask() {
+      const query = queryEl.value.trim();
+      if (!query) { return; }
+      vscode.postMessage({ type: 'ask', query });
+    }
+
+    document.getElementById('ask').addEventListener('click', ask);
+    queryEl.addEventListener('keydown', (event) => {
+      if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') { ask(); }
+    });
+
+    window.addEventListener('message', (event) => {
+      const message = event.data;
+      if (message.type === 'status') {
+        statusEl.className = message.state === 'error' ? 'error' : '';
+        statusEl.textContent = message.state === 'loading'
+          ? 'Recalling…'
+          : (message.message || '');
+        if (message.state !== 'answer') { /* keep answer until replaced */ }
+      } else if (message.type === 'answer') {
+        statusEl.className = '';
+        statusEl.textContent = '';
+        answerEl.textContent = message.answer || 'No answer yet — remember or index something first.';
+        renderSources(message.citations || []);
+      }
+    });
+
+    function renderSources(citations) {
+      sourcesEl.innerHTML = '';
+      if (!citations.length) { return; }
+      const heading = document.createElement('h2');
+      heading.textContent = 'Sources';
+      sourcesEl.appendChild(heading);
+      for (const citation of citations) {
+        const button = document.createElement('button');
+        button.className = 'cite';
+        const name = document.createElement('span');
+        name.className = 'name';
+        name.textContent = citation.documentName;
+        button.appendChild(name);
+        if (citation.snippet) {
+          const snippet = document.createElement('span');
+          snippet.className = 'snippet';
+          snippet.textContent = citation.snippet;
+          button.appendChild(snippet);
+        }
+        button.addEventListener('click', () => {
+          vscode.postMessage({ type: 'openCitation', index: citation.index });
+        });
+        sourcesEl.appendChild(button);
+      }
+    }
+  </script>
+</body>
+</html>`;
+  }
+}
+
+/** A per-render, CSP-grade nonce authorizing the panel's single inline script. */
+function getNonce(): string {
+  return randomBytes(16).toString("base64");
+}

--- a/integrations/vscode/src/extension/ui/citations.ts
+++ b/integrations/vscode/src/extension/ui/citations.ts
@@ -1,0 +1,161 @@
+import * as vscode from "vscode";
+
+import type { Citation } from "../../core";
+import { basenameOf, knownPathMatches, normalizeRelativePath } from "../paths";
+import type { PathIndex } from "../pathIndex";
+import {
+  contentMatchesSnippet,
+  extractSourcePath,
+  findSnippetRange,
+  stripProvenanceHeader,
+} from "./resolve";
+
+const MAX_CANDIDATES = 50;
+
+/**
+ * Resolve a citation to a workspace file and reveal the cited region.
+ *
+ * Resolution order, most reliable first:
+ * 0. the exact `Source: <path>` the extension recorded at ingest (deterministic);
+ * 1. the file(s) we actually ingested for this document name (path index);
+ * 2. the file whose content contains the cited snippet;
+ * 3. a user pick (only when still genuinely ambiguous).
+ *
+ * When the source can't be found or has changed, the user is told rather than
+ * silently sent to the wrong file.
+ */
+export async function openCitation(citation: Citation, pathIndex?: PathIndex): Promise<void> {
+  // The reveal text is the snippet without our ingest-time `Source: …` header,
+  // so needles match the file's real content.
+  const revealText = stripProvenanceHeader(citation.snippet);
+
+  // 0. Deterministic: our own provenance header names the exact file.
+  const sourcePath = extractSourcePath(citation.snippet);
+  if (sourcePath) {
+    const exact = await findWorkspaceFile(sourcePath);
+    if (exact) {
+      await openAndReveal(exact, revealText);
+      return;
+    }
+  }
+
+  const basename = basenameOf(citation.documentName);
+  if (!basename) {
+    return;
+  }
+
+  const candidates = await findCandidates(basename);
+  if (candidates.length === 0) {
+    void vscode.window.showWarningMessage(
+      `Cognee: couldn't locate "${citation.documentName}" in this workspace (source may have moved).`,
+    );
+    return;
+  }
+
+  const knownPaths = pathIndex?.pathsFor(citation.documentName) ?? [];
+  const uri = await selectCitationTarget(candidates, basename, knownPaths, revealText);
+  if (!uri) {
+    return; // user dismissed the disambiguation picker
+  }
+
+  await openAndReveal(uri, revealText);
+}
+
+/** Open a document and reveal the cited region when a snippet is available. */
+async function openAndReveal(uri: vscode.Uri, revealText: string): Promise<void> {
+  const document = await vscode.workspace.openTextDocument(uri);
+  const editor = await vscode.window.showTextDocument(document);
+  if (revealText) {
+    revealSnippet(editor, revealText);
+  }
+}
+
+/** Resolve a workspace-relative path to an existing file, across all folders. */
+async function findWorkspaceFile(relativePath: string): Promise<vscode.Uri | undefined> {
+  const normalized = normalizeRelativePath(relativePath);
+  if (!normalized) {
+    return undefined;
+  }
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    const uri = vscode.Uri.joinPath(folder.uri, normalized);
+    try {
+      const stat = await vscode.workspace.fs.stat(uri);
+      if ((stat.type & vscode.FileType.File) !== 0) {
+        return uri;
+      }
+    } catch {
+      // Not under this folder — try the next.
+    }
+  }
+  return undefined;
+}
+
+/** Find files matching the cited basename, with a stem fallback if it had no extension. */
+async function findCandidates(basename: string): Promise<vscode.Uri[]> {
+  const direct = await vscode.workspace.findFiles(
+    `**/${escapeGlob(basename)}`,
+    "**/node_modules/**",
+    MAX_CANDIDATES,
+  );
+  if (direct.length > 0 || basename.includes(".")) {
+    return direct;
+  }
+  // The backend may drop the extension from the document name; try `<name>.*`.
+  return vscode.workspace.findFiles(`**/${escapeGlob(basename)}.*`, "**/node_modules/**", MAX_CANDIDATES);
+}
+
+async function selectCitationTarget(
+  candidates: vscode.Uri[],
+  basename: string,
+  knownPaths: string[],
+  revealText: string,
+): Promise<vscode.Uri | undefined> {
+  // 1. Prefer files we actually ingested for this document name.
+  const relativePaths = candidates.map((uri) => vscode.workspace.asRelativePath(uri, false));
+  const knownIndexes = knownPathMatches(relativePaths, knownPaths);
+  const pool = knownIndexes.length > 0 ? knownIndexes.map((index) => candidates[index]) : candidates;
+
+  if (pool.length === 1) {
+    return pool[0];
+  }
+
+  // 2. Prefer the file whose content contains the cited snippet.
+  if (revealText) {
+    for (const uri of pool) {
+      try {
+        const bytes = await vscode.workspace.fs.readFile(uri);
+        if (contentMatchesSnippet(Buffer.from(bytes).toString("utf8"), revealText)) {
+          return uri;
+        }
+      } catch {
+        // Unreadable candidate — skip it.
+      }
+    }
+  }
+
+  // 3. Ask the user, shallowest path first.
+  const items = pool
+    .map((uri) => ({ label: vscode.workspace.asRelativePath(uri, false), uri }))
+    .sort((a, b) => a.label.length - b.label.length);
+  const picked = await vscode.window.showQuickPick(items, {
+    placeHolder: `Multiple files named "${basename}" — choose the cited source`,
+  });
+  return picked?.uri;
+}
+
+function revealSnippet(editor: vscode.TextEditor, snippet: string): void {
+  const match = findSnippetRange(editor.document.getText(), snippet);
+  if (!match) {
+    return;
+  }
+  const range = new vscode.Range(
+    editor.document.positionAt(match[0]),
+    editor.document.positionAt(match[1]),
+  );
+  editor.selection = new vscode.Selection(range.start, range.end);
+  editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+}
+
+function escapeGlob(name: string): string {
+  return name.replace(/[*?{}[\]]/g, "");
+}

--- a/integrations/vscode/src/extension/ui/render.test.ts
+++ b/integrations/vscode/src/extension/ui/render.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import type { Citation, RecallResponseItem } from "../../core";
+import { dedupeByFile, rankCitations, renderRecall } from "./render";
+
+function citation(documentName: string, snippet: string): Citation {
+  return { chunkLabel: "1", documentName, snippet, raw: `${documentName}: ${snippet}` };
+}
+
+describe("rankCitations", () => {
+  const rootReadme = citation(
+    "README",
+    "Source: README.md (lines 1-409) Mautic Open Source Marketing Automation",
+  );
+  const auroraReadme = citation(
+    "README",
+    "Source: themes/aurora/README.md (lines 1-5) # Aurora theme for Mautic. This theme is managed centrally.",
+  );
+
+  it("ranks the query-relevant source above an incidental one", () => {
+    const ranked = rankCitations([rootReadme, auroraReadme], "how to manage aurora theme");
+    expect(ranked[0]).toBe(auroraReadme);
+    expect(ranked[1]).toBe(rootReadme);
+  });
+
+  it("keeps Cognee's original order when scores tie (stable)", () => {
+    const ranked = rankCitations([rootReadme, auroraReadme], "unrelated zzz query");
+    expect(ranked[0]).toBe(rootReadme);
+    expect(ranked[1]).toBe(auroraReadme);
+  });
+
+  it("is a no-op for a single citation", () => {
+    expect(rankCitations([auroraReadme], "aurora")).toEqual([auroraReadme]);
+  });
+});
+
+describe("dedupeByFile", () => {
+  it("collapses multiple chunks of the same file into one entry, keeping the first", () => {
+    const rootChunk1 = citation("README", "Source: README.md (lines 1-409) logo and intro");
+    const rootChunk2 = citation("README", "Source: README.md (lines 1-409) contributors list");
+    const aurora = citation("README", "Source: themes/aurora/README.md (lines 1-5) # Aurora theme");
+
+    const unique = dedupeByFile([rootChunk1, rootChunk2, aurora]);
+    expect(unique).toEqual([rootChunk1, aurora]);
+  });
+
+  it("falls back to the document name when there is no Source header", () => {
+    const a = citation("a.ts", "some code");
+    const aAgain = citation("a.ts", "more code from the same file");
+    const b = citation("b.ts", "other code");
+    expect(dedupeByFile([a, aAgain, b])).toEqual([a, b]);
+  });
+
+  it("collapses a headerless later chunk into the header chunk of the same file", () => {
+    const chunk1 = citation("foo.ts", "Source: src/utils/foo.ts (lines 1-40) export const foo = 1;");
+    const chunk2 = citation("foo.ts", "more of the same file, no header on this chunk");
+    expect(dedupeByFile([chunk1, chunk2])).toEqual([chunk1]);
+  });
+
+  it("keeps distinct same-named files that each carry a Source header", () => {
+    const a = citation("README.md", "Source: a/README.md (lines 1-5) alpha");
+    const b = citation("README.md", "Source: b/README.md (lines 1-5) beta");
+    expect(dedupeByFile([a, b])).toEqual([a, b]);
+  });
+});
+
+describe("renderRecall", () => {
+  it("extracts the graph answer and parses its citations", () => {
+    const items: RecallResponseItem[] = [
+      {
+        source: "graph",
+        kind: "graph_completion",
+        search_type: "GRAPH_COMPLETION",
+        text: "The answer.\n\nEvidence:\n- chunk 1 of document a.ts (chunk_id: c1): snippet text",
+      },
+    ];
+
+    const rendered = renderRecall(items);
+    expect(rendered.isEmpty).toBe(false);
+    expect(rendered.answer).toBe("The answer.");
+    expect(rendered.citations).toHaveLength(1);
+    expect(rendered.citations[0].documentName).toBe("a.ts");
+  });
+
+  it("uses `content` for context-source items", () => {
+    const items: RecallResponseItem[] = [{ source: "graph_context", content: "context summary" }];
+    expect(renderRecall(items).answer).toBe("context summary");
+  });
+
+  it("de-duplicates identical citations across items", () => {
+    const evidence = "A.\n\nEvidence:\n- chunk 1 of document a.ts (chunk_id: c1): s";
+    const items: RecallResponseItem[] = [
+      { source: "graph", kind: "graph_completion", search_type: "GRAPH_COMPLETION", text: evidence },
+      { source: "graph", kind: "graph_completion", search_type: "GRAPH_COMPLETION", text: evidence },
+    ];
+    expect(renderRecall(items).citations).toHaveLength(1);
+  });
+
+  it("reports empty when nothing is renderable", () => {
+    expect(renderRecall([]).isEmpty).toBe(true);
+  });
+});

--- a/integrations/vscode/src/extension/ui/render.ts
+++ b/integrations/vscode/src/extension/ui/render.ts
@@ -1,0 +1,155 @@
+import { parseAnswer, type Citation, type RecallResponseItem } from "../../core";
+import { basenameOf } from "../paths";
+import { extractSourcePath } from "./resolve";
+
+export interface RenderedRecall {
+  /** The combined prose answer, with Evidence blocks stripped. */
+  answer: string;
+  /** De-duplicated citations gathered from all result items. */
+  citations: Citation[];
+  /** True when no renderable answer was produced. */
+  isEmpty: boolean;
+}
+
+/**
+ * Collapse the recall response (a union of graph/context/session items) into a
+ * single answer plus a flat, de-duplicated citation list for display.
+ */
+export function renderRecall(items: RecallResponseItem[]): RenderedRecall {
+  const answers: string[] = [];
+  const citations: Citation[] = [];
+
+  for (const item of items) {
+    const text = extractText(item);
+    if (!text) {
+      continue;
+    }
+    const parsed = parseAnswer(text);
+    const trimmed = parsed.answer.trim();
+    if (trimmed) {
+      answers.push(trimmed);
+    }
+    citations.push(...parsed.citations);
+  }
+
+  return {
+    answer: answers.join("\n\n"),
+    citations: dedupeCitations(citations),
+    isEmpty: answers.length === 0,
+  };
+}
+
+/**
+ * Collapse citations that point at the same source file into one entry, keeping
+ * the first occurrence (so, applied after ranking, the best-matching chunk wins).
+ *
+ * Cognee emits one Evidence line per chunk, so a single file can appear several
+ * times (e.g. three chunks of the same README). Showing every unique *file* once
+ * is the useful, honest unit for provenance — all sources, no repeats. Files are
+ * keyed by their `Source: <path>` header when present, else the document name.
+ *
+ * Only the first chunk of an ingested file carries the `Source:` header, so a
+ * later chunk of that same file would key by its bare document name and slip
+ * through as a duplicate. To avoid that, a headerless chunk whose document name
+ * matches the basename of an already-kept `Source:` path is treated as the same
+ * file — without merging genuinely distinct files that share a basename, since
+ * those each carry their own distinct `Source:` path.
+ */
+export function dedupeByFile(citations: Citation[]): Citation[] {
+  const seenKeys = new Set<string>();
+  const seenSourceBasenames = new Set<string>();
+  const unique: Citation[] = [];
+  for (const citation of citations) {
+    const sourcePath = extractSourcePath(citation.snippet);
+    const key = (sourcePath ?? citation.documentName).toLowerCase();
+    if (seenKeys.has(key)) {
+      continue;
+    }
+    if (!sourcePath && seenSourceBasenames.has(citation.documentName.toLowerCase())) {
+      continue;
+    }
+    seenKeys.add(key);
+    if (sourcePath) {
+      seenSourceBasenames.add(basenameOf(sourcePath).toLowerCase());
+    }
+    unique.push(citation);
+  }
+  return unique;
+}
+
+/**
+ * Order citations by lexical relevance to the query, most relevant first.
+ *
+ * Cognee lists Evidence chunks in retrieval order and does not populate a
+ * per-citation `score`, so a large, incidental document can appear above the one
+ * the query is actually about. We rank client-side by how many distinct query
+ * terms appear in each citation's document name and snippet (the snippet includes
+ * our `Source: <path>` header, so a path like `themes/aurora/…` counts too). The
+ * sort is stable: equal scores keep Cognee's original order, and this only
+ * reorders the source list — never the answer.
+ */
+export function rankCitations(citations: Citation[], query: string): Citation[] {
+  const terms = queryTerms(query);
+  if (terms.length === 0 || citations.length < 2) {
+    return citations;
+  }
+  return citations
+    .map((citation, index) => ({ citation, index, score: relevanceScore(citation, terms) }))
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((entry) => entry.citation);
+}
+
+const STOP_WORDS = new Set([
+  "how", "to", "the", "a", "an", "is", "are", "in", "of", "and", "or", "for", "on",
+  "what", "why", "do", "does", "did", "i", "my", "me", "we", "it", "this", "that",
+  "about", "with", "can", "should", "would", "please", "tell",
+]);
+
+/** Distinct, meaningful lower-cased query terms (stop words and stubs dropped). */
+function queryTerms(query: string): string[] {
+  const seen = new Set<string>();
+  for (const token of query.toLowerCase().split(/[^a-z0-9]+/)) {
+    if (token.length >= 3 && !STOP_WORDS.has(token)) {
+      seen.add(token);
+    }
+  }
+  return [...seen];
+}
+
+/** Count how many distinct query terms appear in the citation's name + snippet. */
+function relevanceScore(citation: Citation, terms: string[]): number {
+  const haystack = `${citation.documentName} ${citation.snippet ?? ""}`.toLowerCase();
+  let score = 0;
+  for (const term of terms) {
+    if (haystack.includes(term)) {
+      score += 1;
+    }
+  }
+  return score;
+}
+
+function extractText(item: RecallResponseItem): string {
+  if ("text" in item && typeof item.text === "string") {
+    return item.text;
+  }
+  if ("content" in item && typeof item.content === "string") {
+    return item.content;
+  }
+  if (item.source === "session" && typeof item.answer === "string") {
+    return item.answer;
+  }
+  return "";
+}
+
+function dedupeCitations(citations: Citation[]): Citation[] {
+  const seen = new Set<string>();
+  const unique: Citation[] = [];
+  for (const citation of citations) {
+    if (seen.has(citation.raw)) {
+      continue;
+    }
+    seen.add(citation.raw);
+    unique.push(citation);
+  }
+  return unique;
+}

--- a/integrations/vscode/src/extension/ui/resolve.test.ts
+++ b/integrations/vscode/src/extension/ui/resolve.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  contentMatchesSnippet,
+  extractSourcePath,
+  findSnippetRange,
+  normalizeWhitespace,
+  stripProvenanceHeader,
+} from "./resolve";
+
+describe("extractSourcePath", () => {
+  it("reads the path from a multi-line provenance header with a line range", () => {
+    const snippet = "Source: themes/aurora/README.md (lines 1-5)\n\n# Aurora theme for Mautic";
+    expect(extractSourcePath(snippet)).toBe("themes/aurora/README.md");
+  });
+
+  it("reads the path when the header is collapsed onto one line", () => {
+    const snippet = "Source: themes/_welcome/README.md (lines 1-5) # Welcome theme for Mautic";
+    expect(extractSourcePath(snippet)).toBe("themes/_welcome/README.md");
+  });
+
+  it("reads a whole-file header without a line range", () => {
+    expect(extractSourcePath("Source: README.md\n\n# Root")).toBe("README.md");
+  });
+
+  it("returns undefined when there is no provenance header", () => {
+    expect(extractSourcePath("# Aurora theme for Mautic")).toBeUndefined();
+    expect(extractSourcePath(undefined)).toBeUndefined();
+  });
+});
+
+describe("stripProvenanceHeader", () => {
+  it("removes a multi-line header, leaving the file's real text", () => {
+    const snippet = "Source: themes/aurora/README.md (lines 1-5)\n\n# Aurora theme for Mautic";
+    expect(stripProvenanceHeader(snippet)).toBe("# Aurora theme for Mautic");
+  });
+
+  it("removes a collapsed single-line header", () => {
+    const snippet = "Source: themes/aurora/README.md (lines 1-5) # Aurora theme for Mautic";
+    expect(stripProvenanceHeader(snippet)).toBe("# Aurora theme for Mautic");
+  });
+
+  it("leaves a snippet without a header untouched", () => {
+    expect(stripProvenanceHeader("Project note: rotate weekly.")).toBe("Project note: rotate weekly.");
+  });
+});
+
+describe("normalizeWhitespace", () => {
+  it("collapses runs of whitespace and trims", () => {
+    expect(normalizeWhitespace("  a\n\t b   c  ")).toBe("a b c");
+  });
+});
+
+describe("contentMatchesSnippet", () => {
+  const fileA = "# Root README\n\nThis is the main project readme with setup steps.";
+  const fileB = "# App mirror\n\nRead-only mirror of the app folder. Do not edit.";
+
+  it("matches the file that contains the snippet", () => {
+    const snippet = "the main project readme with setup steps";
+    expect(contentMatchesSnippet(fileA, snippet)).toBe(true);
+    expect(contentMatchesSnippet(fileB, snippet)).toBe(false);
+  });
+
+  it("tolerates whitespace differences between snippet and file", () => {
+    expect(contentMatchesSnippet("alpha   beta\n\ngamma", "alpha beta gamma")).toBe(true);
+  });
+
+  it("ignores snippets that are too short to be distinctive", () => {
+    expect(contentMatchesSnippet(fileA, "the")).toBe(false);
+  });
+});
+
+describe("findSnippetRange", () => {
+  it("locates a whitespace-collapsed snippet inside real (multi-line, indented) source", () => {
+    const doc = "export function foo() {\n  return bar;\n}\n";
+    // The server emits the snippet with whitespace collapsed to single spaces.
+    const range = findSnippetRange(doc, "export function foo() { return bar; }");
+    expect(range).toBeDefined();
+    expect(doc.slice(range![0], range![1])).toBe("export function foo() {\n  return bar;\n}");
+  });
+
+  it("tolerates differing whitespace/indentation between snippet and file", () => {
+    const doc = "line one\n\n    indented    block\tend";
+    const range = findSnippetRange(doc, "indented block end")!;
+    expect(doc.slice(range[0], range[1])).toBe("indented    block\tend");
+  });
+
+  it("ignores the trailing ellipsis the server adds to truncated snippets", () => {
+    const doc = "Project note: the deployment canary token for the checkout service is SMOKE-1.";
+    const range = findSnippetRange(doc, "Project note: the deployment cana…")!;
+    expect(doc.slice(range[0], range[1])).toBe("Project note: the deployment cana");
+  });
+
+  it("returns undefined when the snippet is absent or too short to match", () => {
+    expect(findSnippetRange("some document text here", "nope not present anywhere")).toBeUndefined();
+    expect(findSnippetRange("whatever", "hi")).toBeUndefined();
+  });
+});

--- a/integrations/vscode/src/extension/ui/resolve.ts
+++ b/integrations/vscode/src/extension/ui/resolve.ts
@@ -1,0 +1,109 @@
+/**
+ * Pure helpers for resolving a chunk/document-level citation to the right file.
+ *
+ * Citations carry only a document *basename* (Cognee's `document_name`), so when
+ * a workspace has several files with that name (e.g. multiple `README.md`), we
+ * disambiguate three ways, most reliable first:
+ *   1. the `Source: <path>` provenance header the extension prepends at ingest,
+ *      which names the exact file (see `extractSourcePath`);
+ *   2. the file the user actually remembered (path index);
+ *   3. the file whose content contains the cited snippet.
+ * The matching is whitespace-tolerant because chunking can normalize whitespace.
+ *
+ * These functions are `vscode`-free so they can be unit-tested and reused by the
+ * planned JetBrains sidecar.
+ */
+
+/**
+ * The extension prepends a `Source: <relative/path>` header (optionally with a
+ * `(lines a-b)` suffix) to everything it ingests. Matches that header at the
+ * start of a snippet so callers can recover the exact source path and the file's
+ * real leading text.
+ */
+const PROVENANCE_RE = /^\s*Source:\s*(\S+)(?:\s+\(lines\s+[^)]*\))?\s*/i;
+
+/**
+ * The exact source path recorded in the snippet's provenance header, if present.
+ * Deterministic — no guessing among same-named files.
+ */
+export function extractSourcePath(snippet: string | undefined): string | undefined {
+  const match = PROVENANCE_RE.exec(snippet ?? "");
+  const path = match?.[1]?.trim();
+  return path ? path : undefined;
+}
+
+/**
+ * The snippet with the `Source: …` provenance header removed, so content matching
+ * and in-file reveal run against the document's real text rather than the header.
+ */
+export function stripProvenanceHeader(snippet: string | undefined): string {
+  return (snippet ?? "").replace(PROVENANCE_RE, "").trim();
+}
+
+/** Collapse runs of whitespace to single spaces and trim. */
+export function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/** The minimum snippet length worth matching on (avoids false positives). */
+const MIN_MATCH_LENGTH = 8;
+
+/** Longest prefix of the snippet used as a match needle. */
+const MAX_NEEDLE_LENGTH = 200;
+
+/**
+ * True when `content` contains the cited `snippet`, comparing with normalized
+ * whitespace so minor reformatting between ingest and now doesn't defeat it.
+ */
+export function contentMatchesSnippet(content: string, snippet: string): boolean {
+  const needle = normalizeWhitespace(snippet).slice(0, MAX_NEEDLE_LENGTH);
+  if (needle.length < MIN_MATCH_LENGTH) {
+    return false;
+  }
+  return normalizeWhitespace(content).includes(needle);
+}
+
+/**
+ * Locate the cited snippet inside a document and return the `[start, end)`
+ * character offsets of the match, or undefined when it can't be found.
+ *
+ * The server collapses each snippet's whitespace to single spaces and truncates
+ * it with a trailing "…" (references.py), so a literal search against the file's
+ * real text — with its newlines and indentation — would never match source code.
+ * We search a whitespace-normalized copy of the document and project the match
+ * back onto the raw text via an index map.
+ */
+export function findSnippetRange(text: string, snippet: string): [number, number] | undefined {
+  const needle = normalizeWhitespace(snippet)
+    .replace(/…+$/, "")
+    .trim()
+    .slice(0, MAX_NEEDLE_LENGTH);
+  if (needle.length < MIN_MATCH_LENGTH) {
+    return undefined;
+  }
+
+  // Normalized document text plus, for each normalized character, the raw offset
+  // it came from — so a match in `normalized` maps back to a range in `text`.
+  let normalized = "";
+  const offsets: number[] = [];
+  let pendingSpace = false;
+  for (let i = 0; i < text.length; i += 1) {
+    if (/\s/.test(text[i])) {
+      pendingSpace = normalized.length > 0; // collapse runs; drop leading whitespace
+      continue;
+    }
+    if (pendingSpace) {
+      normalized += " ";
+      offsets.push(i);
+      pendingSpace = false;
+    }
+    normalized += text[i];
+    offsets.push(i);
+  }
+
+  const start = normalized.indexOf(needle);
+  if (start === -1) {
+    return undefined;
+  }
+  return [offsets[start], offsets[start + needle.length - 1] + 1];
+}

--- a/integrations/vscode/src/extension/workspace.ts
+++ b/integrations/vscode/src/extension/workspace.ts
@@ -1,0 +1,59 @@
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+
+import * as vscode from "vscode";
+
+import { parseOriginUrl } from "../core";
+
+/** Absolute path of the first workspace folder, or undefined when none is open. */
+export function getWorkspaceRoot(): string | undefined {
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders || folders.length === 0) {
+    return undefined;
+  }
+  return folders[0].uri.fsPath;
+}
+
+/**
+ * Best-effort resolution of the `origin` remote URL by reading the repository's
+ * git config directly. Dependency-free and good enough for stable dataset
+ * scoping; returns null for non-git folders (the caller falls back to the path).
+ */
+export async function getGitRemote(workspaceRoot: string): Promise<string | null> {
+  try {
+    const configPath = await resolveGitConfigPath(workspaceRoot);
+    if (!configPath) {
+      return null;
+    }
+    const content = await fs.readFile(configPath, "utf8");
+    return parseOriginUrl(content);
+  } catch {
+    return null;
+  }
+}
+
+async function resolveGitConfigPath(workspaceRoot: string): Promise<string | null> {
+  const dotGit = path.join(workspaceRoot, ".git");
+  try {
+    const stat = await fs.stat(dotGit);
+    if (stat.isDirectory()) {
+      return path.join(dotGit, "config");
+    }
+    if (stat.isFile()) {
+      // Worktrees and submodules use a ".git" file: "gitdir: <path>".
+      const pointer = await fs.readFile(dotGit, "utf8");
+      const match = /gitdir:\s*(.+)/.exec(pointer);
+      if (!match) {
+        return null;
+      }
+      let gitDir = match[1].trim();
+      if (!path.isAbsolute(gitDir)) {
+        gitDir = path.resolve(workspaceRoot, gitDir);
+      }
+      return path.join(gitDir, "config");
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}

--- a/integrations/vscode/tsconfig.json
+++ b/integrations/vscode/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": ".",
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/integrations/vscode/vitest.config.ts
+++ b/integrations/vscode/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Core unit tests run in a plain Node environment against a mocked Cognee
+ * backend. The `src/core` layer never imports `vscode`, so no editor host is
+ * required — this keeps the suite fast and CI-friendly (no live keys, no LLM).
+ */
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+    globals: false,
+  },
+});


### PR DESCRIPTION
Adds `integrations/vscode` — a TypeScript VS Code extension that gives the editor a persistent, citable memory of the project. Remember selections/files/notes, recall, "ask my project memory" with answers linked back to source files, and index-workspace (respecting `.gitignore`/`.cogneeignore`). Each repo is isolated by a dataset derived from the git remote (`vscode_<hash>`).

Talks to a running cognee server over HTTP (`/api/v1/recall|remember|forget|improve`, `X-Api-Key` auth) — no cognee dependency. The editor-agnostic `src/core/` sits behind a `CogneeClient` interface. The source's bespoke per-extension CI workflow is dropped — cognee-integrations CI type-checks TypeScript centrally (`tsc --noEmit`).

**Verification:** 68 vitest unit tests + `tsc --noEmit` + esbuild build clean; verified live (remember → recall round-trip with Evidence block against a real cognee server).

Part of the "Chat bots & editor" category. Migrated from topoteretes/cognee#4067 (SDK-173); original author credited.