### PR TITLE
fix(crewai): bound cognee dependency and add smoke test

### DIFF
--- a/integrations/crewai/pyproject.toml
+++ b/integrations/crewai/pyproject.toml
@@ -9,7 +9,7 @@ description = "CrewAI integration for Cognee - enables AI agents to store and re
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "cognee>=0.4.0",
+    "cognee>=0.4.0,<0.5.4",
     "crewai>=1.5.0",
     "crewai-tools>=1.5.0",
     "pydantic>=2.12.4",
@@ -23,5 +23,6 @@ exclude = ["examples*"]
 
 [dependency-groups]
 dev = [
+    "pytest>=8.0",
     "ruff>=0.14.5",
 ]

--- a/integrations/crewai/tests/test_smoke.py
+++ b/integrations/crewai/tests/test_smoke.py
@@ -1,0 +1,6 @@
+def test_imports():
+    from cognee_integration_crewai import add_tool, get_sessionized_cognee_tools, search_tool
+
+    assert add_tool is not None
+    assert search_tool is not None
+    assert get_sessionized_cognee_tools is not None

--- a/integrations/crewai/uv.lock
+++ b/integrations/crewai/uv.lock
@@ -708,12 +708,13 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "cognee", specifier = ">=0.4.0" },
+    { name = "cognee", specifier = ">=0.4.0,<0.5.4" },
     { name = "crewai", specifier = ">=1.5.0" },
     { name = "crewai-tools", specifier = ">=1.5.0" },
     { name = "pydantic", specifier = ">=2.12.4" },
@@ -721,7 +722,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.14.5" }]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "ruff", specifier = ">=0.14.5" },
+]
 
 [[package]]
 name = "colorama"
@@ -1002,7 +1006,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1656,6 +1660,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461, upload-time = "2025-01-03T18:51:54.306Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -3179,6 +3192,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "portalocker"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3937,6 +3959,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`crewai` declares an **unbounded** `cognee>=0.4.0`, violating the repo's version-pinning policy. Because `scripts/check_version_pins.py` scans **every** integration, this pre-existing debt fails the `check-pins` job on any PR that touches an `integrations/*/pyproject.toml` — currently blocking **#250** (the Slack bot), whose own dependencies are compliant (Slack talks to cognee over HTTP and declares no cognee dep).

`crewai` has also had a failing `test-python (crewai)` job since its migration (#77): it has no `tests/` dir and `pytest` isn't installed, so `uv run pytest tests/ -v` errors (`Failed to spawn: pytest`). Merely bounding the pin would surface that job via `detect-changes`, so this fixes both.

## Changes

- **Bound the pin:** `cognee>=0.4.0` → `cognee>=0.4.0,<0.5.4` — matches `google-adk`, which shares the same `>=0.4.0` lower bound. `uv lock` keeps the resolved cognee at **0.4.0** (no upgrade; still satisfies the range).
- **Add `pytest>=8.0`** to dev dependencies and a **keyless** `tests/test_smoke.py` (import smoke test, mirrors `google-adk`/`strands`), so `test-python (crewai)` passes.
- **Regenerate `uv.lock`** (adds the pytest tree + updates the cognee specifier; cognee stays 0.4.0).

## Verification (local, Python 3.13)

```
python scripts/check_version_pins.py     # exit 0 — all 8 integrations bounded
uv sync --locked --dev                    # OK — lockfile consistent
uv run pytest tests/ -v                   # 1 passed
ruff format --check integrations/crewai/  # clean
ruff check integrations/crewai/           # clean
```

Once merged, #250's `check-pins` passes after updating it from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)