### PR TITLE
fix(claude-code): preserve custom status lines

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -197,7 +197,7 @@ cognee: my-project · cloud
 
 `<dataset>` is the active Cognee dataset. `<mode>` is `local` when no `COGNEE_BASE_URL` is set or when it points to localhost, and `cloud` when it points to a remote host.
 
-It is configured automatically on first launch — no manual steps needed. SessionStart writes the correct path into `~/.claude/settings.json` and Claude Code hot-reloads it, so the status line appears from your first interaction onward.
+It is configured automatically on first launch when no custom status line is already configured. SessionStart writes the correct path into `~/.claude/settings.json` and Claude Code hot-reloads it, so the status line appears from your first interaction onward. Existing non-Cognee `statusLine` settings are preserved; set `COGNEE_STATUSLINE=false` before launching Claude Code to opt out entirely.
 
 The status line reads only local state — no network calls on every refresh:
 1. Dataset: `COGNEE_PLUGIN_DATASET` env var, otherwise `agent_sessions`

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -1114,11 +1114,15 @@ def _session_start_guidance(mode: str, dataset: str, session_id: str, ready: boo
 
 
 def _ensure_statusline_configured() -> None:
-    """Write the statusLine entry to ~/.claude/settings.json if not already set.
+    """Write the statusLine entry to ~/.claude/settings.json when safe.
 
     Claude Code hot-reloads settings.json, so the status line becomes active on
     the next status refresh without requiring a restart.
     """
+    if os.environ.get("COGNEE_STATUSLINE", "").lower() in {"0", "false", "no", "off"}:
+        hook_log("statusline_setup_skipped", {"reason": "disabled_by_env"})
+        return
+
     plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", "")
     if plugin_root:
         statusline_sh = Path(plugin_root) / "scripts" / "cognee-statusline.sh"
@@ -1149,6 +1153,11 @@ def _ensure_statusline_configured() -> None:
                 settings = json.loads(text)
 
         if settings.get("statusLine") == desired:
+            return
+
+        current_statusline = settings.get("statusLine")
+        if current_statusline and "cognee-statusline" not in json.dumps(current_statusline):
+            hook_log("statusline_setup_skipped", {"reason": "user_statusline_exists"})
             return
 
         settings["statusLine"] = desired

--- a/integrations/claude-code/tests/test_statusline_config.py
+++ b/integrations/claude-code/tests/test_statusline_config.py
@@ -1,0 +1,137 @@
+"""Tests for Claude Code statusLine setup behavior.
+
+Run: python integrations/claude-code/tests/test_statusline_config.py
+"""
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "session_start_mod", _SCRIPTS / "session-start.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod.hook_log = lambda *_args, **_kwargs: None
+    return mod
+
+
+try:
+    ss = _load()
+except Exception:  # pragma: no cover - hook deps not importable in this environment
+    ss = None
+
+
+def _with_temp_home(fn):
+    old_home = os.environ.get("HOME")
+    old_statusline = os.environ.get("COGNEE_STATUSLINE")
+    old_plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            os.environ["HOME"] = tmp
+            os.environ.pop("COGNEE_STATUSLINE", None)
+            os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+            return fn(pathlib.Path(tmp))
+        finally:
+            if old_home is None:
+                os.environ.pop("HOME", None)
+            else:
+                os.environ["HOME"] = old_home
+            if old_statusline is None:
+                os.environ.pop("COGNEE_STATUSLINE", None)
+            else:
+                os.environ["COGNEE_STATUSLINE"] = old_statusline
+            if old_plugin_root is None:
+                os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+            else:
+                os.environ["CLAUDE_PLUGIN_ROOT"] = old_plugin_root
+
+
+def _settings_path(home):
+    return home / ".claude" / "settings.json"
+
+
+def test_statusline_written_when_absent():
+    if ss is None:
+        return
+
+    def run(home):
+        ss._ensure_statusline_configured()
+        settings = json.loads(_settings_path(home).read_text(encoding="utf-8"))
+        assert "cognee-statusline.sh" in settings["statusLine"]["command"]
+
+    _with_temp_home(run)
+
+
+def test_existing_user_statusline_is_preserved():
+    if ss is None:
+        return
+
+    def run(home):
+        path = _settings_path(home)
+        path.parent.mkdir(parents=True)
+        original = {"type": "command", "command": "printf custom-status"}
+        path.write_text(json.dumps({"statusLine": original}) + "\n", encoding="utf-8")
+
+        ss._ensure_statusline_configured()
+
+        settings = json.loads(path.read_text(encoding="utf-8"))
+        assert settings["statusLine"] == original
+
+    _with_temp_home(run)
+
+
+def test_owned_statusline_can_be_refreshed():
+    if ss is None:
+        return
+
+    def run(home):
+        path = _settings_path(home)
+        path.parent.mkdir(parents=True)
+        stale = {"type": "command", "command": "old cognee-statusline command"}
+        path.write_text(json.dumps({"statusLine": stale}) + "\n", encoding="utf-8")
+
+        ss._ensure_statusline_configured()
+
+        settings = json.loads(path.read_text(encoding="utf-8"))
+        assert settings["statusLine"] != stale
+        assert "cognee-statusline.sh" in settings["statusLine"]["command"]
+
+    _with_temp_home(run)
+
+
+def test_statusline_setup_can_be_disabled_by_env():
+    if ss is None:
+        return
+
+    def run(home):
+        os.environ["COGNEE_STATUSLINE"] = "false"
+        ss._ensure_statusline_configured()
+        assert not _settings_path(home).exists()
+
+    _with_temp_home(run)
+
+
+if __name__ == "__main__":
+    if ss is None:
+        print("SKIP: session-start.py not importable in this environment")
+        sys.exit(0)
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
Fixes topoteretes/cognee#4068.

Summary:
- Do not overwrite an existing non-Cognee Claude Code statusLine setting.
- Keep refreshing Cognee-owned statusLine entries so stale plugin paths can still be repaired.
- Add COGNEE_STATUSLINE=false as an explicit opt-out.
- Document the behavior.

Testing:
- python3 integrations/claude-code/tests/test_statusline_config.py
- python3 integrations/claude-code/tests/test_memory_preference.py
- git diff --check

I affirm that all code in every commit of this pull request conforms to the terms of the Topoteretes Developer Certificate of Origin.