### PR TITLE
feat(integrations): per-operation remember/register timeout env vars (SDK-209)

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -186,6 +186,18 @@ A write that *times out* is reported as "submitted; timed out waiting for confir
 and does **not** fall back to `cognee-cli` (the write likely landed — a fallback would
 risk a duplicate). Only a genuine connection failure falls back.
 
+### Per-operation timeouts
+
+Each operation has its own client timeout, tunable independently (all in seconds):
+
+| Env var | Default | Effect |
+|---|---|---|
+| `COGNEE_RECALL_TIMEOUT` | `20` | Client timeout for a recall request |
+| `COGNEE_REMEMBER_TIMEOUT` | `60` | Client timeout for remember writes (submit POST and per-turn entry store) |
+| `COGNEE_REGISTER_TIMEOUT` | `15` | Client timeout for the session register call |
+
+`COGNEE_REMEMBER_TIMEOUT` also caps the per-turn session-entry write (`/api/v1/remember/entry`); when the variable is unset that path uses 30s, while the explicit remember submit uses 60s.
+
 ## Status line
 
 The status line displays `cognee: <dataset> · <mode>`, for example:

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -193,10 +193,8 @@ Each operation has its own client timeout, tunable independently (all in seconds
 | Env var | Default | Effect |
 |---|---|---|
 | `COGNEE_RECALL_TIMEOUT` | `20` | Client timeout for a recall request |
-| `COGNEE_REMEMBER_TIMEOUT` | `60` | Client timeout for remember writes (submit POST and per-turn entry store) |
+| `COGNEE_REMEMBER_TIMEOUT` | `60` | Client timeout for the remember submit POST |
 | `COGNEE_REGISTER_TIMEOUT` | `15` | Client timeout for the session register call |
-
-`COGNEE_REMEMBER_TIMEOUT` also caps the per-turn session-entry write (`/api/v1/remember/entry`); when the variable is unset that path uses 30s, while the explicit remember submit uses 60s.
 
 ## Status line
 

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1457,11 +1457,7 @@ def _register_timeout() -> float:
     Tunable independently of recall/remember via ``COGNEE_REGISTER_TIMEOUT``;
     defaults to 15s to preserve the previous hardcoded behaviour.
     """
-    try:
-        raw = os.environ.get("COGNEE_REGISTER_TIMEOUT", "").strip()
-        return float(raw) if raw else 15.0
-    except (TypeError, ValueError):
-        return 15.0
+    return _float_env("COGNEE_REGISTER_TIMEOUT", 15.0)
 
 
 def register_agent_via_http(

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1426,12 +1426,26 @@ def wait_for_cognify(
         time.sleep(max(0.1, interval_seconds))  # floor avoids a tight spin if misconfigured to 0
 
 
+def _remember_entry_timeout() -> float:
+    """Client timeout (seconds) for the ``/remember/entry`` submit POST.
+
+    Honors ``COGNEE_REMEMBER_TIMEOUT`` (shared with the explicit remember command
+    in _remember_http.py), so per-turn session-entry writes are tunable too;
+    defaults to 30s to preserve the previous hardcoded behaviour.
+    """
+    try:
+        raw = os.environ.get("COGNEE_REMEMBER_TIMEOUT", "").strip()
+        return float(raw) if raw else 30.0
+    except (TypeError, ValueError):
+        return 30.0
+
+
 def remember_entry_via_http(
     dataset: str,
     session_id: str,
     entry: dict,
     *,
-    timeout: float = 30.0,
+    timeout: float | None = None,
 ) -> dict | None:
     """Store a typed QA/trace entry through the backend API.
 
@@ -1440,6 +1454,8 @@ def remember_entry_via_http(
     """
     if not dataset or not session_id:
         return None
+    if timeout is None:
+        timeout = _remember_entry_timeout()
     return _json_http_request(
         "/api/v1/remember/entry",
         {
@@ -1451,13 +1467,28 @@ def remember_entry_via_http(
     )
 
 
+def _register_timeout() -> float:
+    """Client timeout (seconds) for the agent register call.
+
+    Tunable independently of recall/remember via ``COGNEE_REGISTER_TIMEOUT``;
+    defaults to 15s to preserve the previous hardcoded behaviour.
+    """
+    try:
+        raw = os.environ.get("COGNEE_REGISTER_TIMEOUT", "").strip()
+        return float(raw) if raw else 15.0
+    except (TypeError, ValueError):
+        return 15.0
+
+
 def register_agent_via_http(
     *,
     agent_session_name: str,
     session_id: str = "",
     dataset_names: list[str] | None = None,
-    timeout: float = 15.0,
+    timeout: float | None = None,
 ) -> tuple[bool, dict]:
+    if timeout is None:
+        timeout = _register_timeout()
     payload = {
         "agent_session_name": agent_session_name,
         "type": "api",

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1426,26 +1426,12 @@ def wait_for_cognify(
         time.sleep(max(0.1, interval_seconds))  # floor avoids a tight spin if misconfigured to 0
 
 
-def _remember_entry_timeout() -> float:
-    """Client timeout (seconds) for the ``/remember/entry`` submit POST.
-
-    Honors ``COGNEE_REMEMBER_TIMEOUT`` (shared with the explicit remember command
-    in _remember_http.py), so per-turn session-entry writes are tunable too;
-    defaults to 30s to preserve the previous hardcoded behaviour.
-    """
-    try:
-        raw = os.environ.get("COGNEE_REMEMBER_TIMEOUT", "").strip()
-        return float(raw) if raw else 30.0
-    except (TypeError, ValueError):
-        return 30.0
-
-
 def remember_entry_via_http(
     dataset: str,
     session_id: str,
     entry: dict,
     *,
-    timeout: float | None = None,
+    timeout: float = 30.0,
 ) -> dict | None:
     """Store a typed QA/trace entry through the backend API.
 
@@ -1454,8 +1440,6 @@ def remember_entry_via_http(
     """
     if not dataset or not session_id:
         return None
-    if timeout is None:
-        timeout = _remember_entry_timeout()
     return _json_http_request(
         "/api/v1/remember/entry",
         {

--- a/integrations/claude-code/scripts/_remember_http.py
+++ b/integrations/claude-code/scripts/_remember_http.py
@@ -104,6 +104,15 @@ def _explicit_wait_seconds():
     return _float_env("COGNEE_REMEMBER_WAIT_SECONDS", 8.0)
 
 
+def _remember_timeout():
+    """Client timeout (seconds) for the remember submit POST.
+
+    Tunable independently of recall/register via ``COGNEE_REMEMBER_TIMEOUT``;
+    defaults to 60s to preserve the previous hardcoded behaviour.
+    """
+    return _float_env("COGNEE_REMEMBER_TIMEOUT", 60.0)
+
+
 def _poll_status(
     service_url,
     api_key,
@@ -266,7 +275,7 @@ def do_remember(
 def main(argv):
     # argv: service_url, api_key, content, dataset, node_set
     a = list(argv) + [""] * 5
-    result = do_remember(a[0], a[1], a[2], a[3], a[4])
+    result = do_remember(a[0], a[1], a[2], a[3], a[4], timeout=_remember_timeout())
     print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
 
 

--- a/integrations/claude-code/tests/test_cognee_client.py
+++ b/integrations/claude-code/tests/test_cognee_client.py
@@ -135,29 +135,6 @@ def test_register_timeout_bad_value_falls_back_to_default():
         os.environ.pop("COGNEE_REGISTER_TIMEOUT", None)
 
 
-def test_remember_entry_timeout_default_is_30():
-    # The per-turn /remember/entry write keeps its 30s default when the var is unset.
-    os.environ.pop("COGNEE_REMEMBER_TIMEOUT", None)
-    assert pc._remember_entry_timeout() == 30.0
-
-
-def test_remember_entry_timeout_reads_env():
-    # Setting COGNEE_REMEMBER_TIMEOUT also tunes the entry-store path.
-    try:
-        os.environ["COGNEE_REMEMBER_TIMEOUT"] = "45"
-        assert pc._remember_entry_timeout() == 45.0
-    finally:
-        os.environ.pop("COGNEE_REMEMBER_TIMEOUT", None)
-
-
-def test_remember_entry_timeout_bad_value_falls_back_to_default():
-    try:
-        os.environ["COGNEE_REMEMBER_TIMEOUT"] = "nope"
-        assert pc._remember_entry_timeout() == 30.0
-    finally:
-        os.environ.pop("COGNEE_REMEMBER_TIMEOUT", None)
-
-
 if __name__ == "__main__":
     failures = 0
     for name, fn in sorted(globals().items()):

--- a/integrations/claude-code/tests/test_cognee_client.py
+++ b/integrations/claude-code/tests/test_cognee_client.py
@@ -20,6 +20,7 @@ _TMP = tempfile.mkdtemp(prefix="cognee-breaker-test-")
 os.environ["COGNEE_PLUGIN_STATE_DIR"] = _TMP
 
 import _cognee_client as cc  # noqa: E402
+import _plugin_common as pc  # noqa: E402
 from _recall_http import UNREACHABLE  # noqa: E402
 
 
@@ -111,6 +112,50 @@ def test_dataset_forwarded_to_transport():
     cc.do_recall = _capture
     cc.recall("http://x", "", "q", "", '["graph"]', "5", "my_dataset")
     assert captured.get("dataset") == "my_dataset"
+
+
+def test_register_timeout_default_is_15():
+    os.environ.pop("COGNEE_REGISTER_TIMEOUT", None)
+    assert pc._register_timeout() == 15.0
+
+
+def test_register_timeout_reads_env():
+    try:
+        os.environ["COGNEE_REGISTER_TIMEOUT"] = "42"
+        assert pc._register_timeout() == 42.0
+    finally:
+        os.environ.pop("COGNEE_REGISTER_TIMEOUT", None)
+
+
+def test_register_timeout_bad_value_falls_back_to_default():
+    try:
+        os.environ["COGNEE_REGISTER_TIMEOUT"] = "nope"
+        assert pc._register_timeout() == 15.0
+    finally:
+        os.environ.pop("COGNEE_REGISTER_TIMEOUT", None)
+
+
+def test_remember_entry_timeout_default_is_30():
+    # The per-turn /remember/entry write keeps its 30s default when the var is unset.
+    os.environ.pop("COGNEE_REMEMBER_TIMEOUT", None)
+    assert pc._remember_entry_timeout() == 30.0
+
+
+def test_remember_entry_timeout_reads_env():
+    # Setting COGNEE_REMEMBER_TIMEOUT also tunes the entry-store path.
+    try:
+        os.environ["COGNEE_REMEMBER_TIMEOUT"] = "45"
+        assert pc._remember_entry_timeout() == 45.0
+    finally:
+        os.environ.pop("COGNEE_REMEMBER_TIMEOUT", None)
+
+
+def test_remember_entry_timeout_bad_value_falls_back_to_default():
+    try:
+        os.environ["COGNEE_REMEMBER_TIMEOUT"] = "nope"
+        assert pc._remember_entry_timeout() == 30.0
+    finally:
+        os.environ.pop("COGNEE_REMEMBER_TIMEOUT", None)
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/tests/test_remember_http.py
+++ b/integrations/claude-code/tests/test_remember_http.py
@@ -178,6 +178,45 @@ def test_explicit_wait_timeout():
         os.environ.pop("COGNEE_COGNIFY_POLL_INTERVAL", None)
 
 
+def test_remember_timeout_default_is_60():
+    os.environ.pop("COGNEE_REMEMBER_TIMEOUT", None)
+    assert rh._remember_timeout() == 60.0
+
+
+def test_remember_timeout_reads_env():
+    try:
+        os.environ["COGNEE_REMEMBER_TIMEOUT"] = "12.5"
+        assert rh._remember_timeout() == 12.5
+    finally:
+        os.environ.pop("COGNEE_REMEMBER_TIMEOUT", None)
+
+
+def test_remember_timeout_bad_value_falls_back_to_default():
+    try:
+        os.environ["COGNEE_REMEMBER_TIMEOUT"] = "not-a-number"
+        assert rh._remember_timeout() == 60.0
+    finally:
+        os.environ.pop("COGNEE_REMEMBER_TIMEOUT", None)
+
+
+def test_main_passes_remember_timeout_to_do_remember():
+    captured = {}
+    original = rh.do_remember
+
+    def _fake(*_args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        return {"ok": True}
+
+    rh.do_remember = _fake
+    try:
+        os.environ["COGNEE_REMEMBER_TIMEOUT"] = "7"
+        rh.main(["http://x", "", "content", "ds", "ns"])
+        assert captured["timeout"] == 7.0
+    finally:
+        rh.do_remember = original
+        os.environ.pop("COGNEE_REMEMBER_TIMEOUT", None)
+
+
 if __name__ == "__main__":
     failures = 0
     for _name, _fn in sorted(globals().items()):

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -260,6 +260,18 @@ Config precedence:
 | auto-improve threshold | `COGNEE_AUTO_IMPROVE_EVERY` | `150` | Stored tool calls/stops between automatic improves (0 disables) |
 | improve submit timeout | `COGNEE_IMPROVE_SUBMIT_TIMEOUT` | `180` | Read timeout for the improve POST |
 
+### Per-operation timeouts
+
+Each operation has its own client timeout, tunable independently (all in seconds):
+
+| Env var | Default | Effect |
+|---|---|---|
+| `COGNEE_RECALL_TIMEOUT` | `20` | Client timeout for a recall request |
+| `COGNEE_REMEMBER_TIMEOUT` | `60` | Client timeout for remember writes (submit POST and per-turn entry store) |
+| `COGNEE_REGISTER_TIMEOUT` | `15` | Client timeout for the session register call |
+
+`COGNEE_REMEMBER_TIMEOUT` also caps the per-turn session-entry write (`/api/v1/remember/entry`); when the variable is unset that path uses 30s, while the explicit remember submit uses 60s.
+
 ## Troubleshooting
 
 **Recall returns empty but data was ingested**

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -267,10 +267,8 @@ Each operation has its own client timeout, tunable independently (all in seconds
 | Env var | Default | Effect |
 |---|---|---|
 | `COGNEE_RECALL_TIMEOUT` | `20` | Client timeout for a recall request |
-| `COGNEE_REMEMBER_TIMEOUT` | `60` | Client timeout for remember writes (submit POST and per-turn entry store) |
+| `COGNEE_REMEMBER_TIMEOUT` | `60` | Client timeout for the remember submit POST |
 | `COGNEE_REGISTER_TIMEOUT` | `15` | Client timeout for the session register call |
-
-`COGNEE_REMEMBER_TIMEOUT` also caps the per-turn session-entry write (`/api/v1/remember/entry`); when the variable is unset that path uses 30s, while the explicit remember submit uses 60s.
 
 ## Troubleshooting
 

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -1317,12 +1317,26 @@ def _json_http_request(
         return json.loads(body)
 
 
+def _remember_entry_timeout() -> float:
+    """Client timeout (seconds) for the ``/remember/entry`` submit POST.
+
+    Honors ``COGNEE_REMEMBER_TIMEOUT`` (shared with the explicit remember command
+    in _remember_http.py), so per-turn session-entry writes are tunable too;
+    defaults to 30s to preserve the previous hardcoded behaviour.
+    """
+    try:
+        raw = os.environ.get("COGNEE_REMEMBER_TIMEOUT", "").strip()
+        return float(raw) if raw else 30.0
+    except (TypeError, ValueError):
+        return 30.0
+
+
 def remember_entry_via_http(
     dataset: str,
     session_id: str,
     entry: dict,
     *,
-    timeout: float = 30.0,
+    timeout: float | None = None,
 ) -> dict | None:
     """Store a typed QA/trace entry through the backend API.
 
@@ -1331,6 +1345,8 @@ def remember_entry_via_http(
     """
     if not dataset or not session_id:
         return None
+    if timeout is None:
+        timeout = _remember_entry_timeout()
     return _json_http_request(
         "/api/v1/remember/entry",
         {
@@ -1342,13 +1358,28 @@ def remember_entry_via_http(
     )
 
 
+def _register_timeout() -> float:
+    """Client timeout (seconds) for the agent register call.
+
+    Tunable independently of recall/remember via ``COGNEE_REGISTER_TIMEOUT``;
+    defaults to 15s to preserve the previous hardcoded behaviour.
+    """
+    try:
+        raw = os.environ.get("COGNEE_REGISTER_TIMEOUT", "").strip()
+        return float(raw) if raw else 15.0
+    except (TypeError, ValueError):
+        return 15.0
+
+
 def register_agent_via_http(
     *,
     agent_session_name: str,
     session_id: str = "",
     dataset_names: list[str] | None = None,
-    timeout: float = 15.0,
+    timeout: float | None = None,
 ) -> tuple[bool, dict]:
+    if timeout is None:
+        timeout = _register_timeout()
     payload = {
         "agent_session_name": agent_session_name,
         "type": "api",

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -1317,26 +1317,12 @@ def _json_http_request(
         return json.loads(body)
 
 
-def _remember_entry_timeout() -> float:
-    """Client timeout (seconds) for the ``/remember/entry`` submit POST.
-
-    Honors ``COGNEE_REMEMBER_TIMEOUT`` (shared with the explicit remember command
-    in _remember_http.py), so per-turn session-entry writes are tunable too;
-    defaults to 30s to preserve the previous hardcoded behaviour.
-    """
-    try:
-        raw = os.environ.get("COGNEE_REMEMBER_TIMEOUT", "").strip()
-        return float(raw) if raw else 30.0
-    except (TypeError, ValueError):
-        return 30.0
-
-
 def remember_entry_via_http(
     dataset: str,
     session_id: str,
     entry: dict,
     *,
-    timeout: float | None = None,
+    timeout: float = 30.0,
 ) -> dict | None:
     """Store a typed QA/trace entry through the backend API.
 
@@ -1345,8 +1331,6 @@ def remember_entry_via_http(
     """
     if not dataset or not session_id:
         return None
-    if timeout is None:
-        timeout = _remember_entry_timeout()
     return _json_http_request(
         "/api/v1/remember/entry",
         {

--- a/integrations/codex/plugins/cognee/scripts/_remember_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_remember_http.py
@@ -73,6 +73,19 @@ def _background_flag():
     return "false" if val in {"0", "false", "no", "off"} else "true"
 
 
+def _remember_timeout():
+    """Client timeout (seconds) for the remember submit POST.
+
+    Tunable independently of recall/register via ``COGNEE_REMEMBER_TIMEOUT``;
+    defaults to 60s to preserve the previous hardcoded behaviour.
+    """
+    try:
+        raw = os.environ.get("COGNEE_REMEMBER_TIMEOUT", "").strip()
+        return float(raw) if raw else 60.0
+    except (TypeError, ValueError):
+        return 60.0
+
+
 def _timeout_result(timeout):
     """A write timeout is NOT 'unreachable': the request likely reached the server and
     the write may have landed. Returning UNREACHABLE would make the caller re-write via
@@ -159,7 +172,7 @@ def do_remember(
 def main(argv):
     # argv: service_url, api_key, content, dataset, node_set
     a = list(argv) + [""] * 5
-    result = do_remember(a[0], a[1], a[2], a[3], a[4])
+    result = do_remember(a[0], a[1], a[2], a[3], a[4], timeout=_remember_timeout())
     print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
 
 


### PR DESCRIPTION
## Summary

Closes topoteretes/cognee#3543. Linear: SDK-209.

Only `COGNEE_RECALL_TIMEOUT` was wired, so the **remember** and **register** operations could not be tuned independently of recall. This adds named per-operation client-timeout env vars, symmetrically across the `claude-code` and `codex` integrations:

| Env var | Default | Effect |
|---|---|---|
| `COGNEE_RECALL_TIMEOUT` | `20` | Client timeout for a recall request (pre-existing) |
| `COGNEE_REMEMBER_TIMEOUT` | `60` | Client timeout for the explicit remember submit POST |
| `COGNEE_REGISTER_TIMEOUT` | `15` | Client timeout for the session register call |

Each var falls back to its previous hardcoded default when unset, so behaviour is unchanged for anyone who does not set them. All three are documented in both integration READMEs.

## Base: community contribution

This reworks community PR #167 by @RajdeepKushwaha5. That commit is preserved verbatim as the base of this branch (authorship retained); the maintainer changes are layered on top as separate single-concern commits.

## Design

- `COGNEE_REMEMBER_TIMEOUT` is resolved in `_remember_http.main()` and passed explicitly to `do_remember()` — the sole production entry point — keeping `do_remember` env-free and unit-testable.
- `COGNEE_REGISTER_TIMEOUT` is resolved inside `register_agent_via_http()` only when no explicit `timeout` is passed; its one production caller (`session-start.py`) passes none, and any explicit caller keeps overriding.
- Env parsing reuses the existing `_float_env` idiom (empty / malformed value → default).

## Maintainer rework (separate commits on top of the preserved original)

1. **Narrow to the issue's scope.** The original commit also made `COGNEE_REMEMBER_TIMEOUT` govern the per-turn entry write (`/api/v1/remember/entry`) through a second helper whose *unset* default is 30s — versus the submit's 60s — i.e. one env var carrying two different unset-defaults, which needed a dedicated README caveat to explain. That path is not part of #3543. It is reverted to its original hardcoded 30s, removing the dual-default, the extra helper in both trees, its three tests, and the caveat paragraph, so `COGNEE_REMEMBER_TIMEOUT` means exactly one thing.
2. **Reuse `_float_env`.** The claude-code `_plugin_common._register_timeout()` hand-rolled `os.environ` + `try/except` instead of the `_float_env` helper already defined in that file; it now delegates to it (behaviour-identical, matching the file's own convention).

## Verification

- claude-code test suites pass via their built-in runners, including the retained `COGNEE_REMEMBER_TIMEOUT` / `COGNEE_REGISTER_TIMEOUT` tests (default, env override, malformed-value fallback).
- Changed codex scripts `py_compile` clean; their helpers resolve the env vars.
- The env-unset path is byte-identical to pre-PR behaviour.

> Note: `test_bridge_poll.py` and `test_improve_sync.py` fail on `main` independently of this change (test doubles predate a `context=` kwarg on `urlopen`); they are untouched here and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
