### PR TITLE
feat(integrations): cloud cold-start warmup ping for claude-code and codex (SDK-210)

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -154,8 +154,8 @@ arrives, shaving cold-start latency off the first query.
 The warmup:
 - runs once per session, at `SessionStart`
 - never blocks or errors the session — it runs in a daemon thread and fails silently
-- is off by default (`COGNEE_WARMUP` unset or any value other than `true`)
-- is only useful for cloud/remote deployments; local mode has no cold-start problem
+- is off by default; enable with `COGNEE_WARMUP=true` (or `1`/`yes`)
+- only fires for remote/cloud endpoints — it is a no-op in local mode, which has no cold start
 
 ```bash
 export COGNEE_WARMUP=true   # enable for cloud deployments
@@ -359,7 +359,7 @@ Config precedence:
 | local URL override | `COGNEE_LOCAL_API_URL` | `http://localhost:8011` | Local API base URL |
 | local LLM | `LLM_API_KEY`, `LLM_MODEL` | unset | Required for local mode runtime |
 | demo auto-clear | `COGNEE_CLAUDE_CLEAR_AFTER_MESSAGE` | disabled | Clear transcript on Stop after capture |
-| warmup ping | `COGNEE_WARMUP` | `false` | Fire a non-blocking GET /health at session start to warm up a scale-to-zero cloud tenant before the first recall. Set to `true` to enable. |
+| warmup ping | `COGNEE_WARMUP` | `false` | Fire a non-blocking GET /health at session start to warm up a scale-to-zero cloud tenant before the first recall. Set to `true` (or `1`/`yes`) to enable; no-op in local mode. |
 | idle watcher poll | `COGNEE_IDLE_POLL` | `10` | Idle watcher poll interval in seconds |
 | idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle improve fires |
 | idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `600` | Minimum seconds between idle improve runs |

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -143,6 +143,24 @@ in the launching shell, if your Claude Code version supports it).
 |---|---|---|
 | `COGNEE_PREFER_MEMORY` | `true` | Inject SessionStart steer asserting Cognee as the preferred memory |
 
+## Cold-start warmup
+
+When using Cognee Cloud (or any scale-to-zero deployment), the first recall of a session
+may hit a cold tenant and time out before the server is ready. Setting `COGNEE_WARMUP=true`
+fires a single non-blocking `GET /health` ping immediately after the session URL is resolved
+at `SessionStart`. This warms the tenant in the background before the first real recall
+arrives, shaving cold-start latency off the first query.
+
+The warmup:
+- runs once per session, at `SessionStart`
+- never blocks or errors the session — it runs in a daemon thread and fails silently
+- is off by default (`COGNEE_WARMUP` unset or any value other than `true`)
+- is only useful for cloud/remote deployments; local mode has no cold-start problem
+
+```bash
+export COGNEE_WARMUP=true   # enable for cloud deployments
+```
+
 ## Session sync and watchers
 
 Session→graph sync runs through Cognee's session-aware `improve` endpoint: the server bridges the session from its own session cache (feedback weights, Q&A persist, compact trace-feedback persist, distillation, enrichment) instead of the plugin re-posting the full accumulated session text — which used to trigger a complete re-cognify of the whole transcript on every sync. Servers without session-aware improve automatically fall back to the legacy document bridge.
@@ -341,6 +359,7 @@ Config precedence:
 | local URL override | `COGNEE_LOCAL_API_URL` | `http://localhost:8011` | Local API base URL |
 | local LLM | `LLM_API_KEY`, `LLM_MODEL` | unset | Required for local mode runtime |
 | demo auto-clear | `COGNEE_CLAUDE_CLEAR_AFTER_MESSAGE` | disabled | Clear transcript on Stop after capture |
+| warmup ping | `COGNEE_WARMUP` | `false` | Fire a non-blocking GET /health at session start to warm up a scale-to-zero cloud tenant before the first recall. Set to `true` to enable. |
 | idle watcher poll | `COGNEE_IDLE_POLL` | `10` | Idle watcher poll interval in seconds |
 | idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle improve fires |
 | idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `600` | Minimum seconds between idle improve runs |

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -17,8 +17,8 @@ import signal
 import subprocess
 import sys
 import tempfile
-import time
 import threading
+import time
 import urllib.error
 import urllib.parse
 import urllib.request

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -344,6 +344,21 @@ def _health_ok(url: str = _HEALTH_URL, timeout: float = 2.0) -> bool:
         return False
 
 
+def _maybe_warmup_cloud(target_url: str) -> None:
+    """Warm a scale-to-zero cloud tenant so the first recall doesn't pay the cold start.
+
+    When COGNEE_WARMUP is truthy and the endpoint is remote, fire one GET /health in a
+    daemon thread. Non-blocking and fail-silent (daemon, no join, _health_ok swallows
+    errors): a slow or unreachable tenant never delays or breaks SessionStart. Local
+    mode has no cold start, so this is a no-op there.
+    """
+    if _is_local_url(target_url):
+        return
+    if os.environ.get("COGNEE_WARMUP", "").strip().lower() not in ("1", "true", "yes"):
+        return
+    threading.Thread(target=_health_ok, args=(_health_url(target_url),), daemon=True).start()
+
+
 def _wait_for_health(deadline_seconds: float, health_url: str = _HEALTH_URL) -> bool:
     """Poll /health until the server is serving or the deadline elapses.
 
@@ -1272,9 +1287,7 @@ async def _start(payload: dict | None = None) -> dict:
     target_url = configured_url or _LOCAL_SERVICE_URL
     config["base_url"] = target_url
     os.environ["COGNEE_BASE_URL"] = target_url
-    if os.environ.get("COGNEE_WARMUP", "").lower() == "true":
-        _warmup_url = _health_url(target_url)
-        threading.Thread(target=_health_ok, args=(_warmup_url, 2.0), daemon=True).start()
+    _maybe_warmup_cloud(target_url)
     if api_key:
         os.environ["COGNEE_API_KEY"] = api_key
 

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -1272,6 +1272,9 @@ async def _start(payload: dict | None = None) -> dict:
     target_url = configured_url or _LOCAL_SERVICE_URL
     config["base_url"] = target_url
     os.environ["COGNEE_BASE_URL"] = target_url
+    if os.environ.get("COGNEE_WARMUP", "").lower() == "true":
+        _warmup_url = _health_url(target_url)
+        threading.Thread(target=_health_ok, args=(_warmup_url, 2.0), daemon=True).start()
     if api_key:
         os.environ["COGNEE_API_KEY"] = api_key
 

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import threading
 import urllib.error
 import urllib.parse
 import urllib.request

--- a/integrations/claude-code/tests/test_warmup_ping.py
+++ b/integrations/claude-code/tests/test_warmup_ping.py
@@ -1,0 +1,132 @@
+"""Tests for the COGNEE_WARMUP cold-start warmup ping (session-start.py).
+
+When COGNEE_WARMUP=true, SessionStart fires a non-blocking GET /health daemon
+thread immediately after the service URL is resolved, warming a scale-to-zero
+cloud tenant before the first real recall. These tests drive the warmup logic
+directly without requiring a live server.
+
+Run: python integrations/claude-code/tests/test_warmup_ping.py
+(or via pytest).
+"""
+import importlib.util
+import os
+import pathlib
+import sys
+import threading
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "session_start_mod", _SCRIPTS / "session-start.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+try:
+    ss = _load()
+except Exception:  # pragma: no cover - hook deps not importable in this environment
+    ss = None
+
+
+def test_warmup_thread_spawned_when_enabled():
+    """A daemon thread is started when COGNEE_WARMUP=true."""
+    spawned = []
+    original_thread_init = threading.Thread.__init__
+
+    os.environ["COGNEE_WARMUP"] = "true"
+    try:
+        target_url = "http://localhost:8011"
+        warmup_url = f"{target_url}/health"
+
+        if os.environ.get("COGNEE_WARMUP", "").lower() == "true":
+            t = threading.Thread(
+                target=lambda: None,  # no-op so it exits immediately
+                daemon=True,
+            )
+            spawned.append(t)
+            t.start()
+    finally:
+        os.environ.pop("COGNEE_WARMUP", None)
+
+    assert len(spawned) == 1, "Expected exactly one warmup thread"
+    assert spawned[0].daemon, "Warmup thread must be a daemon thread"
+
+
+def test_warmup_not_spawned_when_disabled():
+    """No warmup thread is started when COGNEE_WARMUP is unset."""
+    os.environ.pop("COGNEE_WARMUP", None)
+    spawned = []
+
+    if os.environ.get("COGNEE_WARMUP", "").lower() == "true":
+        spawned.append("thread")  # should not be reached
+
+    assert len(spawned) == 0, "No warmup thread should be spawned when COGNEE_WARMUP is unset"
+
+
+def test_warmup_not_spawned_when_false():
+    """No warmup thread is started when COGNEE_WARMUP=false."""
+    os.environ["COGNEE_WARMUP"] = "false"
+    spawned = []
+    try:
+        if os.environ.get("COGNEE_WARMUP", "").lower() == "true":
+            spawned.append("thread")  # should not be reached
+    finally:
+        os.environ.pop("COGNEE_WARMUP", None)
+
+    assert len(spawned) == 0, "No warmup thread should be spawned when COGNEE_WARMUP=false"
+
+
+def test_warmup_fails_silently():
+    """A failed warmup ping never raises — session startup continues normally."""
+    def always_fail():
+        raise OSError("connection refused")
+
+    os.environ["COGNEE_WARMUP"] = "true"
+    try:
+        if os.environ.get("COGNEE_WARMUP", "").lower() == "true":
+            t = threading.Thread(target=always_fail, daemon=True)
+            t.start()
+            t.join(timeout=3.0)
+            # thread may have raised internally — that's fine, daemon threads
+            # never propagate exceptions to the caller
+    except Exception as exc:
+        raise AssertionError(f"Warmup failure should not propagate to session startup: {exc}")
+    finally:
+        os.environ.pop("COGNEE_WARMUP", None)
+
+
+def test_health_ok_exists():
+    """_health_ok is defined in session-start.py and callable."""
+    if ss is None:
+        return
+    assert callable(ss._health_ok), "_health_ok must be a callable"
+
+
+def test_health_url_format():
+    """_health_url appends /health to the service URL."""
+    if ss is None:
+        return
+    result = ss._health_url("http://localhost:8011")
+    assert result == "http://localhost:8011/health", f"Unexpected health URL: {result}"
+
+
+if __name__ == "__main__":
+    if ss is None:
+        print("SKIP: session-start.py not importable in this environment")
+        sys.exit(0)
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -129,6 +129,24 @@ Data added outside of Claude to the dataset (via SDK or the server for example) 
 | `PreCompact` | memory anchor build before compaction |
 | `SessionEnd` | trigger detached final sync worker |
 
+## Cold-start warmup
+
+When using Cognee Cloud (or any scale-to-zero deployment), the first recall of a session
+may hit a cold tenant and time out before the server is ready. Setting `COGNEE_WARMUP=true`
+fires a single non-blocking `GET /health` ping immediately after the session URL is resolved
+at `SessionStart`. This warms the tenant in the background before the first real recall
+arrives, shaving cold-start latency off the first query.
+
+The warmup:
+- runs once per session, at `SessionStart`
+- never blocks or errors the session — it runs in a daemon thread and fails silently
+- is off by default; enable with `COGNEE_WARMUP=true` (or `1`/`yes`)
+- only fires for remote/cloud endpoints — it is a no-op in local mode, which has no cold start
+
+```bash
+export COGNEE_WARMUP=true   # enable for cloud deployments
+```
+
 ## Session sync and watchers
 
 Session→graph sync runs through Cognee's session-aware `improve` endpoint: the server bridges the session from its own session cache (feedback weights, Q&A persist, compact trace-feedback persist, distillation, enrichment) instead of the plugin re-posting the full accumulated session text — which used to trigger a complete re-cognify of the whole transcript on every sync. Servers without session-aware improve automatically fall back to the legacy document bridge.
@@ -254,6 +272,7 @@ Config precedence:
 | `api_key` | `COGNEE_API_KEY` | unset | API key; auto-minted if absent in local mode |
 | local URL override | `COGNEE_LOCAL_API_URL` | `http://localhost:8011` | Local API base URL |
 | local LLM | `LLM_API_KEY`, `LLM_MODEL` | unset | Required for local mode runtime |
+| warmup ping | `COGNEE_WARMUP` | `false` | Fire a non-blocking GET /health at session start to warm up a scale-to-zero cloud tenant before the first recall. Set to `true` (or `1`/`yes`) to enable; no-op in local mode. |
 | idle watcher poll | `COGNEE_IDLE_POLL` | `10` | Idle watcher poll interval in seconds |
 | idle watcher threshold | `COGNEE_IDLE_THRESHOLD` | `60` | Seconds of inactivity before idle improve fires |
 | idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `600` | Minimum seconds between idle improve runs |

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -17,6 +17,7 @@ import signal
 import subprocess
 import sys
 import time
+import threading
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -1098,6 +1099,9 @@ async def _start(payload: dict | None = None) -> dict:
     target_url = configured_url or _LOCAL_SERVICE_URL
     config["base_url"] = target_url
     os.environ["COGNEE_BASE_URL"] = target_url
+    if os.environ.get("COGNEE_WARMUP", "").lower() == "true":
+        _warmup_url = _health_url(target_url)
+        threading.Thread(target=_health_ok, args=(_warmup_url, 2.0), daemon=True).start()
     if api_key:
         os.environ["COGNEE_API_KEY"] = api_key
 

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -343,6 +343,21 @@ def _health_ok(url: str = _HEALTH_URL, timeout: float = 2.0) -> bool:
         return False
 
 
+def _maybe_warmup_cloud(target_url: str) -> None:
+    """Warm a scale-to-zero cloud tenant so the first recall doesn't pay the cold start.
+
+    When COGNEE_WARMUP is truthy and the endpoint is remote, fire one GET /health in a
+    daemon thread. Non-blocking and fail-silent (daemon, no join, _health_ok swallows
+    errors): a slow or unreachable tenant never delays or breaks SessionStart. Local
+    mode has no cold start, so this is a no-op there.
+    """
+    if _is_local_url(target_url):
+        return
+    if os.environ.get("COGNEE_WARMUP", "").strip().lower() not in ("1", "true", "yes"):
+        return
+    threading.Thread(target=_health_ok, args=(_health_url(target_url),), daemon=True).start()
+
+
 def _wait_for_health(deadline_seconds: float, health_url: str = _HEALTH_URL) -> bool:
     """Poll /health until the server is serving or the deadline elapses.
 
@@ -1099,9 +1114,7 @@ async def _start(payload: dict | None = None) -> dict:
     target_url = configured_url or _LOCAL_SERVICE_URL
     config["base_url"] = target_url
     os.environ["COGNEE_BASE_URL"] = target_url
-    if os.environ.get("COGNEE_WARMUP", "").lower() == "true":
-        _warmup_url = _health_url(target_url)
-        threading.Thread(target=_health_ok, args=(_warmup_url, 2.0), daemon=True).start()
+    _maybe_warmup_cloud(target_url)
     if api_key:
         os.environ["COGNEE_API_KEY"] = api_key
 

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -16,8 +16,8 @@ import shutil
 import signal
 import subprocess
 import sys
-import time
 import threading
+import time
 import urllib.error
 import urllib.parse
 import urllib.request

--- a/integrations/codex/tests/test_warmup_ping.py
+++ b/integrations/codex/tests/test_warmup_ping.py
@@ -7,7 +7,7 @@ threading.Thread that records the spawn, so no live server is needed. Local endp
 and falsey/unset flags must not spawn anything; the ping target (_health_ok) must never
 raise so the daemon thread can fail silently.
 
-Run: python integrations/claude-code/tests/test_warmup_ping.py (or via pytest).
+Run: python integrations/codex/tests/test_warmup_ping.py (or via pytest).
 """
 
 import importlib.util
@@ -16,7 +16,7 @@ import pathlib
 import sys
 import types
 
-_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "plugins" / "cognee" / "scripts"
 
 
 def _load():


### PR DESCRIPTION
Closes topoteretes/cognee#3541 (hackathon). Reworks community PR #230 by @asthaww.

## Summary

An opt-in `COGNEE_WARMUP` flag that fires a single, bounded, **non-blocking** `GET /health` at `SessionStart` so a scale-to-zero (cold) cloud tenant starts waking before the user's first recall — shaving cold-start latency off the first real query. Implemented in both plugin integrations in scope, `claude-code` and `codex`, on top of each file's existing `_health_url()` / `_health_ok()` helpers (no new HTTP surface).

- Runs once per session, at `SessionStart`.
- Fail-silent and non-blocking: a daemon thread with no join, and `_health_ok` swallows all connection/timeout errors, so a slow or dead tenant never delays or breaks the session.
- Gated by `COGNEE_WARMUP` (truthy `true`/`1`/`yes`), off by default.
- Fires only for remote/cloud endpoints — a no-op in local mode, which has no cold start.
- Documented in both integration READMEs.

## Attribution

Based on the community contribution in #230. The original author's 5 commits are preserved verbatim (authorship intact); maintainer changes are added as separate, single-concern commits on top.

## Scope note (for reviewers)

Worth flagging honestly: `_start()` already contacts the tenant at `SessionStart` regardless of this flag. A few lines below the warmup call it runs a synchronous `_health_ok(_health_url(target_url))` (to decide boot-vs-connect), and on the cloud path it then runs `_run_heavy(...)` inline (authenticated login / key / register / dataset calls to the same tenant). So the warmup's marginal benefit is a fractionally-earlier, parallel, non-blocking wake rather than a wake that wouldn't otherwise happen. It is kept because the issue explicitly asks for an opt-in warmup flag, and it is now gated so it never fires pointlessly. The surrounding boot logic was deliberately left untouched — de-duplicating against it would be a riskier change to core session startup, out of scope for this rework.

## Maintainer rework

Each improvement lands as its own commit on top of the preserved author commits:

1. **`fix`** — order the `threading` import (`threading` before `time`). The submitted PR placed it after `import time`, which ruff's import sorter (rule `I`) flags as `I001`; the repo's `ruff check integrations/` lint CI fails on it.
2. **`refactor`** — consolidate the inline block into one `_maybe_warmup_cloud()` helper per file, and:
   - gate on a remote endpoint (`_is_local_url` short-circuit) so it honours the README's "cloud only" promise instead of firing a guaranteed-to-fail `GET localhost/health` in the default local mode;
   - accept the codebase's truthy set (`1`/`true`/`yes`, matching `COGNEE_IDLE_DISABLED` and the sibling flags) so `COGNEE_WARMUP=1` isn't silently ignored;
   - drop the redundant explicit `2.0` timeout (already the `_health_ok` default) and the throwaway temp var.
3. **`test`** — replace the tautological tests (4 of 6 re-implemented the gate inline and spawned their own throwaway threads, so they passed even with the feature deleted; the other 2 only checked symbol existence behind a silent import-skip) with genuine unit tests that drive the real `_maybe_warmup_cloud`, and add the missing codex test (mirroring the existing `test_warmup_drain.py` split across both plugins).
4. **`docs`** — document `COGNEE_WARMUP` in the codex README too (the issue requires README docs and codex was in scope but undocumented), and correct the claude-code wording for the truthy set and the local no-op.

Net effect on production code: the feature is smaller and more correct — one gated, documented, testable helper per file instead of an inline block.

## Verification

Ran locally (Python 3.13 via `uvx`):

- `ruff check integrations/` and `ruff format --check integrations/` clean at the repo's `line-length = 100` (the submitted PR failed `ruff check`).
- `pytest tests/test_warmup_ping.py` passes in both integrations — **5 passed** each. The tests assert the real gate: remote + `true`/`1`/`yes` spawns a daemon `GET /health` to the correct URL; local endpoints and falsey/unset spawn nothing; `_health_ok` returns `False` (never raises) on an unreachable host.

Refs: SDK-210.
