### PR TITLE
feat(integrations): retry first recall on cold-start timeout (SDK-211)

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -347,3 +347,5 @@ Config precedence:
 | auto-improve threshold | `COGNEE_AUTO_IMPROVE_EVERY` | `150` | Stored tool calls/stops between automatic improves (0 disables) |
 | improve submit timeout | `COGNEE_IMPROVE_SUBMIT_TIMEOUT` | `180` | Read timeout for the improve POST |
 | improve poll deadline | `COGNEE_IMPROVE_POLL_DEADLINE` | `600` | Best-effort wait for pipeline completion after submit |
+| cold-start retries | `COGNEE_RECALL_COLDSTART_RETRIES` | `2` | Extra retries for the **first** recall of a session when it times out on a warming server (`0` disables). Later recalls never retry. |
+| cold-start backoff | `COGNEE_RECALL_COLDSTART_BACKOFF` | `0.5` | Base seconds for the first-recall retry backoff (jittered, exponential, capped by the recall budget) |

--- a/integrations/claude-code/scripts/_cognee_client.py
+++ b/integrations/claude-code/scripts/_cognee_client.py
@@ -21,6 +21,7 @@ import pathlib
 import random
 import sys
 import time
+import urllib.error
 
 from _recall_http import UNREACHABLE, _error, do_recall
 
@@ -98,7 +99,7 @@ def retry_cold_start(
     rng=None,
     monotonic=None,
 ):
-    """Retry ``attempt`` on a cold-start miss, with jittered exponential backoff"""
+    """Retry ``attempt`` on a cold-start miss, with jittered exponential backoff."""
     _sleep = sleep or time.sleep
     _rand = rng or random.random
     _now = monotonic or time.monotonic
@@ -115,6 +116,28 @@ def retry_cold_start(
         ok, value = attempt()
         tries += 1
     return ok, value
+
+
+def coldstart_recall_attempt(do_call, on_retry=None):
+    """Adapt a *raising* recall call into a ``retry_cold_start`` attempt.
+
+    Returns ``(ok, value)``: a reachable-but-rejected response (``HTTPError``)
+    fails fast (re-raised, never retried); a timeout / connection error yields
+    ``(False, [])`` so ``retry_cold_start`` retries. ``on_retry``, if given, is
+    called with the caught exception before each retry.
+    """
+
+    def _attempt():
+        try:
+            return True, do_call()
+        except urllib.error.HTTPError:
+            raise
+        except (TimeoutError, urllib.error.URLError, OSError) as exc:
+            if on_retry is not None:
+                on_retry(exc)
+            return False, []
+
+    return _attempt
 
 
 def _state_path():

--- a/integrations/claude-code/scripts/_cognee_client.py
+++ b/integrations/claude-code/scripts/_cognee_client.py
@@ -98,15 +98,7 @@ def retry_cold_start(
     rng=None,
     monotonic=None,
 ):
-    """Retry ``attempt`` on a cold-start miss, with jittered exponential backoff.
-
-    ``attempt`` returns ``(ok, value)``: ``ok=False`` marks a retryable cold-start
-    failure (unreachable / timeout). Retries up to ``retries`` extra times. Sleeps
-    a jittered exponential backoff between tries and NEVER sleeps past ``deadline``
-    (a ``monotonic()`` value); once the budget is spent it stops. Returns the final
-    ``(ok, value)``. Injectable ``sleep``/``rng``/``monotonic`` keep it deterministic
-    in tests.
-    """
+    """Retry ``attempt`` on a cold-start miss, with jittered exponential backoff"""
     _sleep = sleep or time.sleep
     _rand = rng or random.random
     _now = monotonic or time.monotonic
@@ -192,11 +184,6 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
             service_url, api_key, query, session_id, scope, top_k, dataset, timeout=_timeout
         )
 
-    # Only the FIRST recall of a session retries a warming/unreachable backend;
-    # every later recall is single-shot. The whole retry burst is ONE breaker
-    # event: the accounting below runs once on the final result, so a slow cold
-    # start can't prematurely trip the circuit. Only UNREACHABLE is retryable —
-    # an error envelope (4xx/5xx/auth) is terminal and must fail fast.
     if session_id and is_first_recall(session_id):
 
         def _attempt():

--- a/integrations/claude-code/scripts/_cognee_client.py
+++ b/integrations/claude-code/scripts/_cognee_client.py
@@ -214,7 +214,16 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
             return (r != UNREACHABLE, r)  # ok unless the server was unreachable
 
         retries, backoff = coldstart_config()
-        _ok, result = retry_cold_start(_attempt, retries=retries, backoff=backoff)
+        # Bound the whole cold-start burst to ~one recall timeout: a warming
+        # server that *times out* (rather than refusing fast) must not turn the
+        # first search into retries x timeout of blocking before the CLI
+        # fallback. The same deadline also caps the exponential backoff sleep.
+        _ok, result = retry_cold_start(
+            _attempt,
+            retries=retries,
+            backoff=backoff,
+            deadline=time.monotonic() + _timeout,
+        )
         mark_recall_seen(session_id)
     else:
         result = _once()

--- a/integrations/claude-code/scripts/_cognee_client.py
+++ b/integrations/claude-code/scripts/_cognee_client.py
@@ -18,6 +18,7 @@ uses) would not survive between calls. State lives in the plugin state dir.
 import json
 import os
 import pathlib
+import random
 import sys
 import time
 
@@ -27,6 +28,101 @@ from _recall_http import UNREACHABLE, _error, do_recall
 _THRESHOLD = int(os.environ.get("COGNEE_BREAKER_THRESHOLD", "5"))
 _COOLDOWN = float(os.environ.get("COGNEE_BREAKER_COOLDOWN", "120"))
 _RECALL_TIMEOUT = float(os.environ.get("COGNEE_RECALL_TIMEOUT", "20"))
+
+_COLDSTART_SEEN_MAX = 256  # bound the marker file's session list
+
+
+def coldstart_config() -> tuple[int, float]:
+    """(extra_retries, base_backoff_seconds) for the first-recall cold-start path.
+
+    Read live so runtime/test env changes take effect. Named ``COLDSTART`` to
+    signal these apply only to the first recall of a session, not every recall.
+    """
+    try:
+        retries = int(os.environ.get("COGNEE_RECALL_COLDSTART_RETRIES", "2"))
+    except (TypeError, ValueError):
+        retries = 2
+    try:
+        backoff = float(os.environ.get("COGNEE_RECALL_COLDSTART_BACKOFF", "0.5"))
+    except (TypeError, ValueError):
+        backoff = 0.5
+    return max(0, retries), max(0.0, backoff)
+
+
+def _coldstart_state_path() -> pathlib.Path:
+    base = os.environ.get("COGNEE_PLUGIN_STATE_DIR") or os.path.expanduser("~/.cognee-plugin")
+    return pathlib.Path(base) / "recall-coldstart.json"
+
+
+def _coldstart_seen() -> list:
+    try:
+        data = json.loads(_coldstart_state_path().read_text(encoding="utf-8"))
+        seen = data.get("seen") if isinstance(data, dict) else None
+        return seen if isinstance(seen, list) else []
+    except Exception:
+        return []
+
+
+def is_first_recall(session_id: str) -> bool:
+    """True until ``mark_recall_seen`` records this session (unknown -> treat as first)."""
+    if not session_id:
+        return False
+    return session_id not in _coldstart_seen()
+
+
+def mark_recall_seen(session_id: str) -> None:
+    """Record that this session's first recall has resolved (success or exhausted)."""
+    if not session_id:
+        return
+    seen = _coldstart_seen()
+    if session_id in seen:
+        return
+    seen.append(session_id)
+    if len(seen) > _COLDSTART_SEEN_MAX:
+        seen = seen[-_COLDSTART_SEEN_MAX:]
+    try:
+        path = _coldstart_state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"seen": seen}), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def retry_cold_start(
+    attempt,
+    *,
+    retries: int,
+    backoff: float,
+    deadline=None,
+    sleep=None,
+    rng=None,
+    monotonic=None,
+):
+    """Retry ``attempt`` on a cold-start miss, with jittered exponential backoff.
+
+    ``attempt`` returns ``(ok, value)``: ``ok=False`` marks a retryable cold-start
+    failure (unreachable / timeout). Retries up to ``retries`` extra times. Sleeps
+    a jittered exponential backoff between tries and NEVER sleeps past ``deadline``
+    (a ``monotonic()`` value); once the budget is spent it stops. Returns the final
+    ``(ok, value)``. Injectable ``sleep``/``rng``/``monotonic`` keep it deterministic
+    in tests.
+    """
+    _sleep = sleep or time.sleep
+    _rand = rng or random.random
+    _now = monotonic or time.monotonic
+    ok, value = attempt()
+    tries = 0
+    while not ok and tries < retries:
+        if deadline is not None and (deadline - _now()) <= 0:
+            break
+        delay = backoff * (2**tries) * (0.5 + _rand())  # jitter in [0.5, 1.5)
+        if deadline is not None:
+            delay = min(delay, max(0.0, deadline - _now()))
+        if delay > 0:
+            _sleep(delay)
+        ok, value = attempt()
+        tries += 1
+    return ok, value
 
 
 def _state_path():
@@ -89,16 +185,30 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
         # which would just hammer the same down server).
         return _error(503, "cognee temporarily unavailable (circuit open, retry in ~%ds)" % retry)
 
-    result = do_recall(
-        service_url,
-        api_key,
-        query,
-        session_id,
-        scope,
-        top_k,
-        dataset,
-        timeout=timeout or _RECALL_TIMEOUT,
-    )
+    _timeout = timeout or _RECALL_TIMEOUT
+
+    def _once():
+        return do_recall(
+            service_url, api_key, query, session_id, scope, top_k, dataset, timeout=_timeout
+        )
+
+    # Only the FIRST recall of a session retries a warming/unreachable backend;
+    # every later recall is single-shot. The whole retry burst is ONE breaker
+    # event: the accounting below runs once on the final result, so a slow cold
+    # start can't prematurely trip the circuit. Only UNREACHABLE is retryable —
+    # an error envelope (4xx/5xx/auth) is terminal and must fail fast.
+    if session_id and is_first_recall(session_id):
+
+        def _attempt():
+            r = _once()
+            return (r != UNREACHABLE, r)  # ok unless the server was unreachable
+
+        retries, backoff = coldstart_config()
+        _ok, result = retry_cold_start(_attempt, retries=retries, backoff=backoff)
+        mark_recall_seen(session_id)
+    else:
+        result = _once()
+
     if result == UNREACHABLE:
         record_failure("unreachable")
     elif isinstance(result, dict) and int(result.get("status") or 0) >= 500:

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -16,6 +16,7 @@ import json
 import os
 import sys
 import time
+import urllib.error
 
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
@@ -231,32 +232,72 @@ async def _run(prompt: str) -> dict | None:
     # Respect the shared circuit breaker: when the server has been failing (tripped
     # by the explicit recall path), skip this per-prompt recall rather than hammering
     # a down backend on every keystroke. HTTP/cloud mode only.
+    # Cold-start: only the first recall of a session retries a warming backend.
+    coldstart_first = False
+    cs_retries, cs_backoff = 0, 0.0
     if cloud_mode:
         try:
-            from _cognee_client import breaker_open
-
-            _bopen, _bretry = breaker_open()
+            from _cognee_client import (
+                breaker_open,
+                coldstart_config,
+                is_first_recall,
+                mark_recall_seen,
+                retry_cold_start,
+            )
         except Exception:
-            _bopen, _bretry = False, 0
-        if _bopen:
-            hook_log("recall_breaker_open", {"retry_in": _bretry})
-            scope_specs = []
-    for scope_list, qtype, context_profile in scope_specs:
+            breaker_open = None
+        if breaker_open is not None:
+            try:
+                _bopen, _bretry = breaker_open()
+            except Exception:
+                _bopen, _bretry = False, 0
+            if _bopen:
+                hook_log("recall_breaker_open", {"retry_in": _bretry})
+                scope_specs = []
+            elif session_id and is_first_recall(session_id):
+                coldstart_first = True
+                cs_retries, cs_backoff = coldstart_config()
+    for idx, (scope_list, qtype, context_profile) in enumerate(scope_specs):
         if time.monotonic() >= budget_deadline:
             hook_log("recall_budget_exceeded", {"collected": len(results)})
             break
         try:
             if cloud_mode:
-                part = recall_via_http(
-                    prompt,
-                    session_id=session_id,
-                    top_k=TOP_K,
-                    scope=scope_list,
-                    only_context=True,
-                    search_type=qtype,
-                    context_profile=context_profile,
-                    timeout=recall_timeout,
-                )
+
+                def _do_recall_call(_scope=scope_list, _qtype=qtype, _profile=context_profile):
+                    return recall_via_http(
+                        prompt,
+                        session_id=session_id,
+                        top_k=TOP_K,
+                        scope=_scope,
+                        only_context=True,
+                        search_type=_qtype,
+                        context_profile=_profile,
+                        timeout=recall_timeout,
+                    )
+
+                # Retry only the first scope of the first recall, and only on a
+                # cold-start error (timeout / connection). An HTTPError is reachable
+                # but rejected, so it fails fast. Backoff is bounded by the budget.
+                if coldstart_first and idx == 0 and cs_retries > 0:
+
+                    def _attempt():
+                        try:
+                            return True, _do_recall_call()
+                        except urllib.error.HTTPError:
+                            raise
+                        except (TimeoutError, urllib.error.URLError, OSError) as exc:
+                            hook_log("recall_coldstart_retry", {"error": str(exc)[:160]})
+                            return False, []
+
+                    _ok, part = retry_cold_start(
+                        _attempt,
+                        retries=cs_retries,
+                        backoff=cs_backoff,
+                        deadline=budget_deadline,
+                    )
+                else:
+                    part = _do_recall_call()
             else:
                 query_type = getattr(SearchType, qtype, None) if qtype else None
                 part = await asyncio.wait_for(
@@ -276,6 +317,11 @@ async def _run(prompt: str) -> dict | None:
                 results.extend(part)
         except Exception as exc:
             hook_log("recall_error", {"scope": scope_list, "error": str(exc)[:200]})
+
+    # First recall resolved (success or exhausted): mark the session warm so later
+    # recalls take the fast, no-retry path and steady-state latency is unchanged.
+    if coldstart_first and session_id:
+        mark_recall_seen(session_id)
 
     # Bucket results by _source for human-readable output.
     # Local SDK mode returns Pydantic models (ResponseQAEntry, etc.); cloud

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -276,9 +276,6 @@ async def _run(prompt: str) -> dict | None:
                         timeout=recall_timeout,
                     )
 
-                # Retry only the first scope of the first recall, and only on a
-                # cold-start error (timeout / connection). An HTTPError is reachable
-                # but rejected, so it fails fast. Backoff is bounded by the budget.
                 if coldstart_first and idx == 0 and cs_retries > 0:
 
                     def _attempt():
@@ -318,8 +315,6 @@ async def _run(prompt: str) -> dict | None:
         except Exception as exc:
             hook_log("recall_error", {"scope": scope_list, "error": str(exc)[:200]})
 
-    # First recall resolved (success or exhausted): mark the session warm so later
-    # recalls take the fast, no-retry path and steady-state latency is unchanged.
     if coldstart_first and session_id:
         mark_recall_seen(session_id)
 

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -289,6 +289,11 @@ async def _run(prompt: str) -> dict | None:
                         backoff=cs_backoff,
                         deadline=budget_deadline,
                     )
+                    if not _ok:
+                        # The retry burst proved the backend unreachable; don't
+                        # re-probe it with the remaining scopes this turn.
+                        hook_log("recall_coldstart_exhausted", {"scope": scope_list})
+                        break
                 else:
                     part = _do_recall_call()
             else:

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -16,7 +16,6 @@ import json
 import os
 import sys
 import time
-import urllib.error
 
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
@@ -240,6 +239,7 @@ async def _run(prompt: str) -> dict | None:
             from _cognee_client import (
                 breaker_open,
                 coldstart_config,
+                coldstart_recall_attempt,
                 is_first_recall,
                 mark_recall_seen,
                 retry_cold_start,
@@ -277,16 +277,12 @@ async def _run(prompt: str) -> dict | None:
                     )
 
                 if coldstart_first and idx == 0 and cs_retries > 0:
-
-                    def _attempt():
-                        try:
-                            return True, _do_recall_call()
-                        except urllib.error.HTTPError:
-                            raise
-                        except (TimeoutError, urllib.error.URLError, OSError) as exc:
-                            hook_log("recall_coldstart_retry", {"error": str(exc)[:160]})
-                            return False, []
-
+                    _attempt = coldstart_recall_attempt(
+                        _do_recall_call,
+                        on_retry=lambda exc: hook_log(
+                            "recall_coldstart_retry", {"error": str(exc)[:160]}
+                        ),
+                    )
                     _ok, part = retry_cold_start(
                         _attempt,
                         retries=cs_retries,

--- a/integrations/claude-code/tests/test_coldstart_retry.py
+++ b/integrations/claude-code/tests/test_coldstart_retry.py
@@ -1,0 +1,167 @@
+"""Unit tests for cold-start recall retry (issue #3542).
+
+The first recall of a session often lands while the server is still warming, so
+it times out even though a retry a moment later succeeds. These tests cover the
+pure retry core (`retry_cold_start`) plus its integration into `_cognee_client.recall`:
+first-recall gating, graceful degrade, no-retry on 4xx, budget-bounded backoff,
+and breaker coherence (a retry burst is one failure).
+
+State is file-based, so we point COGNEE_PLUGIN_STATE_DIR at a temp dir and patch
+the transport (`do_recall`).
+
+Run: `pytest integrations/claude-code/tests/test_coldstart_retry.py`
+(or `python integrations/claude-code/tests/test_coldstart_retry.py` standalone).
+"""
+
+import pathlib
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import os  # noqa: E402
+
+_TMP = tempfile.mkdtemp(prefix="cognee-coldstart-test-")
+os.environ["COGNEE_PLUGIN_STATE_DIR"] = _TMP
+# Keep tests fast and deterministic: zero base backoff => no real sleeping.
+os.environ["COGNEE_RECALL_COLDSTART_BACKOFF"] = "0"
+os.environ["COGNEE_RECALL_COLDSTART_RETRIES"] = "2"
+
+import _cognee_client as cc  # noqa: E402
+from _recall_http import UNREACHABLE  # noqa: E402
+
+_STATE = pathlib.Path(_TMP)
+
+
+def _reset():
+    for name in ("recall-breaker.json", "recall-coldstart.json"):
+        p = _STATE / name
+        if p.exists():
+            p.unlink()
+
+
+def _seq_transport(values):
+    """Return a do_recall stub that yields `values` in order, plus a call counter."""
+    calls = {"n": 0}
+
+    def _stub(*a, **k):
+        i = calls["n"]
+        calls["n"] += 1
+        return values[i] if i < len(values) else values[-1]
+
+    return _stub, calls
+
+
+# ── pure retry core ────────────────────────────────────────────────────────
+
+
+def test_core_timeout_then_success():
+    seq = iter([(False, "x"), (True, "hit")])
+    ok, value = cc.retry_cold_start(lambda: next(seq), retries=2, backoff=0, sleep=lambda _d: None)
+    assert ok is True and value == "hit"
+
+
+def test_core_exhausts_and_returns_last():
+    calls = {"n": 0}
+
+    def _attempt():
+        calls["n"] += 1
+        return (False, "down")
+
+    ok, value = cc.retry_cold_start(_attempt, retries=2, backoff=0, sleep=lambda _d: None)
+    assert ok is False and value == "down"
+    assert calls["n"] == 3  # 1 initial + 2 retries
+
+
+def test_core_backoff_never_exceeds_budget():
+    """With a fake clock advanced by sleep, total backoff stays within the deadline."""
+    clock = {"t": 0.0}
+    slept = []
+
+    def _sleep(d):
+        slept.append(d)
+        clock["t"] += d
+
+    ok, _ = cc.retry_cold_start(
+        lambda: (False, None),
+        retries=10,
+        backoff=0.4,
+        deadline=1.0,
+        sleep=_sleep,
+        rng=lambda: 0.5,  # jitter factor 1.0
+        monotonic=lambda: clock["t"],
+    )
+    assert ok is False
+    assert sum(slept) <= 1.0 + 1e-9  # never sleeps past the budget
+    assert clock["t"] <= 1.0 + 1e-9
+
+
+# ── recall() integration ───────────────────────────────────────────────────
+
+
+def test_first_recall_retries_then_returns_context():
+    _reset()
+    stub, calls = _seq_transport([UNREACHABLE, [{"text": "hit"}]])
+    cc.do_recall = stub
+    out = cc.recall("http://x", "", "q", "sess-A", '["graph"]', "5")
+    assert out == [{"text": "hit"}]  # ultimately returns context
+    assert calls["n"] == 2  # retried once
+    assert cc.breaker_open()[0] is False  # success cleared the breaker
+
+
+def test_exhausted_degrades_to_unreachable_no_error():
+    _reset()
+    stub, calls = _seq_transport([UNREACHABLE])
+    cc.do_recall = stub
+    out = cc.recall("http://x", "", "q", "sess-B", '["graph"]', "5")
+    assert out == UNREACHABLE  # graceful degrade, no exception raised
+    assert calls["n"] == 3  # 1 + 2 retries
+
+
+def test_retry_burst_is_one_breaker_failure():
+    _reset()
+    stub, _ = _seq_transport([UNREACHABLE])
+    cc.do_recall = stub
+    cc.recall("http://x", "", "q", "sess-C", '["graph"]', "5")
+    # Three transport calls, but the burst must count as a single failure.
+    assert int(cc._read().get("failures") or 0) == 1
+
+
+def test_4xx_envelope_is_not_retried():
+    _reset()
+    stub, calls = _seq_transport([{"error": "unauthorized", "status": 403, "authoritative": False}])
+    cc.do_recall = stub
+    out = cc.recall("http://x", "k", "q", "sess-D", '["graph"]', "5")
+    assert isinstance(out, dict) and out["status"] == 403
+    assert calls["n"] == 1  # reachable-but-rejected fails fast
+
+
+def test_second_recall_same_session_does_not_retry():
+    _reset()
+    stub, calls = _seq_transport([UNREACHABLE, [{"text": "hit"}]])
+    cc.do_recall = stub
+    cc.recall("http://x", "", "q", "sess-E", '["graph"]', "5")  # first: retries
+    first_calls = calls["n"]
+    cc.recall("http://x", "", "q", "sess-E", '["graph"]', "5")  # second: single-shot
+    assert calls["n"] == first_calls + 1  # exactly one more call, no retry
+
+
+def test_no_session_id_is_single_shot():
+    _reset()
+    stub, calls = _seq_transport([UNREACHABLE])
+    cc.do_recall = stub
+    cc.recall("http://x", "", "q", "", '["graph"]', "5")
+    assert calls["n"] == 1  # no session id => steady-state path, no retry
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print("PASS", name)
+            except AssertionError as e:
+                failures += 1
+                print("FAIL", name, e)
+    sys.exit(1 if failures else 0)

--- a/integrations/claude-code/tests/test_coldstart_retry.py
+++ b/integrations/claude-code/tests/test_coldstart_retry.py
@@ -4,7 +4,9 @@ The first recall of a session often lands while the server is still warming, so
 it times out even though a retry a moment later succeeds. These tests cover the
 pure retry core (`retry_cold_start`) plus its integration into `_cognee_client.recall`:
 first-recall gating, graceful degrade, no-retry on 4xx, budget-bounded backoff,
-and breaker coherence (a retry burst is one failure).
+and breaker coherence (a retry burst is one failure). They also cover the
+auto-recall hook's error contract (`coldstart_recall_attempt`) and the explicit
+path's deadline bound.
 
 State is file-based, so we point COGNEE_PLUGIN_STATE_DIR at a temp dir and patch
 the transport (`do_recall`).
@@ -16,6 +18,8 @@ Run: `pytest integrations/claude-code/tests/test_coldstart_retry.py`
 import pathlib
 import sys
 import tempfile
+import time
+import urllib.error
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
 
@@ -149,6 +153,71 @@ def test_no_session_id_is_single_shot():
     cc.do_recall = stub
     cc.recall("http://x", "", "q", "", '["graph"]', "5")
     assert calls["n"] == 1  # no session id => steady-state path, no retry
+
+
+# ── auto-recall hook contract (coldstart_recall_attempt) ─────────────────────
+
+
+def _raising_transport(values):
+    """Return a do_call stub that raises each Exception in `values` and returns the rest."""
+    seq = iter(values)
+    calls = {"n": 0}
+
+    def _call():
+        calls["n"] += 1
+        v = next(seq)
+        if isinstance(v, BaseException):
+            raise v
+        return v
+
+    return _call, calls
+
+
+def test_hook_attempt_retries_on_connection_error_then_returns_context():
+    """The hook's attempt: a timeout/connection error retries, then returns context."""
+    call, calls = _raising_transport([urllib.error.URLError("refused"), [{"text": "hit"}]])
+    attempt = cc.coldstart_recall_attempt(call)
+    ok, value = cc.retry_cold_start(attempt, retries=2, backoff=0, sleep=lambda _d: None)
+    assert ok is True and value == [{"text": "hit"}]
+    assert calls["n"] == 2  # retried once
+
+
+def test_hook_attempt_does_not_retry_httperror():
+    """A reachable-but-rejected 4xx (HTTPError) fails fast: re-raised, never retried."""
+    err = urllib.error.HTTPError("http://x", 403, "forbidden", {}, None)
+    call, calls = _raising_transport([err, [{"text": "unreached"}]])
+    attempt = cc.coldstart_recall_attempt(call)
+    raised = False
+    try:
+        cc.retry_cold_start(attempt, retries=2, backoff=0, sleep=lambda _d: None)
+    except urllib.error.HTTPError:
+        raised = True
+    assert raised and calls["n"] == 1  # failed fast, no retry
+
+
+def test_hook_attempt_on_retry_receives_exception():
+    """The on_retry hook fires with the caught exception before each retry."""
+    seen = []
+    call, _ = _raising_transport([TimeoutError("slow"), []])
+    attempt = cc.coldstart_recall_attempt(call, on_retry=seen.append)
+    cc.retry_cold_start(attempt, retries=1, backoff=0, sleep=lambda _d: None)
+    assert len(seen) == 1 and isinstance(seen[0], TimeoutError)
+
+
+def test_explicit_deadline_bounds_slow_retries():
+    """A slow (full-timeout) first recall must not stack retries past the deadline."""
+    _reset()
+    calls = {"n": 0}
+
+    def _slow(*a, **k):
+        calls["n"] += 1
+        time.sleep(0.05)  # each attempt consumes the whole (tiny) recall timeout
+        return UNREACHABLE
+
+    cc.do_recall = _slow
+    out = cc.recall("http://x", "", "q", "sess-slow", '["graph"]', "5", timeout=0.05)
+    assert out == UNREACHABLE  # graceful degrade
+    assert calls["n"] == 1  # deadline stops it after one slow attempt (no ~3x block)
 
 
 if __name__ == "__main__":

--- a/integrations/claude-code/tests/test_coldstart_retry.py
+++ b/integrations/claude-code/tests/test_coldstart_retry.py
@@ -1,4 +1,4 @@
-"""Unit tests for cold-start recall retry (issue #3542).
+"""Unit tests for cold-start recall retry.
 
 The first recall of a session often lands while the server is still warming, so
 it times out even though a retry a moment later succeeds. These tests cover the
@@ -94,9 +94,6 @@ def test_core_backoff_never_exceeds_budget():
     assert ok is False
     assert sum(slept) <= 1.0 + 1e-9  # never sleeps past the budget
     assert clock["t"] <= 1.0 + 1e-9
-
-
-# ── recall() integration ───────────────────────────────────────────────────
 
 
 def test_first_recall_retries_then_returns_context():

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -259,6 +259,8 @@ Config precedence:
 | idle watcher cooldown | `COGNEE_IMPROVE_COOLDOWN` | `600` | Minimum seconds between idle improve runs |
 | auto-improve threshold | `COGNEE_AUTO_IMPROVE_EVERY` | `150` | Stored tool calls/stops between automatic improves (0 disables) |
 | improve submit timeout | `COGNEE_IMPROVE_SUBMIT_TIMEOUT` | `180` | Read timeout for the improve POST |
+| cold-start retries | `COGNEE_RECALL_COLDSTART_RETRIES` | `2` | Extra retries for the **first** recall of a session when it times out on a warming server (`0` disables). Later recalls never retry. |
+| cold-start backoff | `COGNEE_RECALL_COLDSTART_BACKOFF` | `0.5` | Base seconds for the first-recall retry backoff (jittered, exponential, capped by the recall budget) |
 
 ## Troubleshooting
 

--- a/integrations/codex/plugins/cognee/scripts/_cognee_client.py
+++ b/integrations/codex/plugins/cognee/scripts/_cognee_client.py
@@ -21,6 +21,7 @@ import pathlib
 import random
 import sys
 import time
+import urllib.error
 
 from _recall_http import UNREACHABLE, _error, do_recall
 
@@ -33,7 +34,11 @@ _COLDSTART_SEEN_MAX = 256  # bound the marker file's session list
 
 
 def coldstart_config() -> tuple[int, float]:
-    """(extra_retries, base_backoff_seconds) for the first-recall cold-start path."""
+    """(extra_retries, base_backoff_seconds) for the first-recall cold-start path.
+
+    Read live so runtime/test env changes take effect. Named ``COLDSTART`` to
+    signal these apply only to the first recall of a session, not every recall.
+    """
     try:
         retries = int(os.environ.get("COGNEE_RECALL_COLDSTART_RETRIES", "2"))
     except (TypeError, ValueError):
@@ -111,6 +116,28 @@ def retry_cold_start(
         ok, value = attempt()
         tries += 1
     return ok, value
+
+
+def coldstart_recall_attempt(do_call, on_retry=None):
+    """Adapt a *raising* recall call into a ``retry_cold_start`` attempt.
+
+    Returns ``(ok, value)``: a reachable-but-rejected response (``HTTPError``)
+    fails fast (re-raised, never retried); a timeout / connection error yields
+    ``(False, [])`` so ``retry_cold_start`` retries. ``on_retry``, if given, is
+    called with the caught exception before each retry.
+    """
+
+    def _attempt():
+        try:
+            return True, do_call()
+        except urllib.error.HTTPError:
+            raise
+        except (TimeoutError, urllib.error.URLError, OSError) as exc:
+            if on_retry is not None:
+                on_retry(exc)
+            return False, []
+
+    return _attempt
 
 
 def _state_path():

--- a/integrations/codex/plugins/cognee/scripts/_cognee_client.py
+++ b/integrations/codex/plugins/cognee/scripts/_cognee_client.py
@@ -214,7 +214,16 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
             return (r != UNREACHABLE, r)  # ok unless the server was unreachable
 
         retries, backoff = coldstart_config()
-        _ok, result = retry_cold_start(_attempt, retries=retries, backoff=backoff)
+        # Bound the whole cold-start burst to ~one recall timeout: a warming
+        # server that *times out* (rather than refusing fast) must not turn the
+        # first search into retries x timeout of blocking before the CLI
+        # fallback. The same deadline also caps the exponential backoff sleep.
+        _ok, result = retry_cold_start(
+            _attempt,
+            retries=retries,
+            backoff=backoff,
+            deadline=time.monotonic() + _timeout,
+        )
         mark_recall_seen(session_id)
     else:
         result = _once()

--- a/integrations/codex/plugins/cognee/scripts/_cognee_client.py
+++ b/integrations/codex/plugins/cognee/scripts/_cognee_client.py
@@ -18,6 +18,7 @@ uses) would not survive between calls. State lives in the plugin state dir.
 import json
 import os
 import pathlib
+import random
 import sys
 import time
 
@@ -27,6 +28,106 @@ from _recall_http import UNREACHABLE, _error, do_recall
 _THRESHOLD = int(os.environ.get("COGNEE_BREAKER_THRESHOLD", "5"))
 _COOLDOWN = float(os.environ.get("COGNEE_BREAKER_COOLDOWN", "120"))
 _RECALL_TIMEOUT = float(os.environ.get("COGNEE_RECALL_TIMEOUT", "20"))
+
+# Cold-start retry: the very first recall of a session often lands while the
+# server is still warming (booting, migrating, cold DB/embedding pools), so the
+# connection times out even though a retry a moment later succeeds. We retry ONLY
+# that first recall; steady-state recalls stay single-shot so the per-prompt
+# latency budget is untouched. Defaults are conservative and env-tunable.
+_COLDSTART_SEEN_MAX = 256  # bound the marker file's session list
+
+
+def coldstart_config() -> tuple[int, float]:
+    """(extra_retries, base_backoff_seconds) for the first-recall cold-start path.
+
+    Read live so runtime/test env changes take effect. Named ``COLDSTART`` to
+    signal these apply only to the first recall of a session, not every recall.
+    """
+    try:
+        retries = int(os.environ.get("COGNEE_RECALL_COLDSTART_RETRIES", "2"))
+    except (TypeError, ValueError):
+        retries = 2
+    try:
+        backoff = float(os.environ.get("COGNEE_RECALL_COLDSTART_BACKOFF", "0.5"))
+    except (TypeError, ValueError):
+        backoff = 0.5
+    return max(0, retries), max(0.0, backoff)
+
+
+def _coldstart_state_path() -> pathlib.Path:
+    base = os.environ.get("COGNEE_PLUGIN_STATE_DIR") or os.path.expanduser("~/.cognee-plugin")
+    return pathlib.Path(base) / "recall-coldstart.json"
+
+
+def _coldstart_seen() -> list:
+    try:
+        data = json.loads(_coldstart_state_path().read_text(encoding="utf-8"))
+        seen = data.get("seen") if isinstance(data, dict) else None
+        return seen if isinstance(seen, list) else []
+    except Exception:
+        return []
+
+
+def is_first_recall(session_id: str) -> bool:
+    """True until ``mark_recall_seen`` records this session (unknown -> treat as first)."""
+    if not session_id:
+        return False
+    return session_id not in _coldstart_seen()
+
+
+def mark_recall_seen(session_id: str) -> None:
+    """Record that this session's first recall has resolved (success or exhausted)."""
+    if not session_id:
+        return
+    seen = _coldstart_seen()
+    if session_id in seen:
+        return
+    seen.append(session_id)
+    if len(seen) > _COLDSTART_SEEN_MAX:
+        seen = seen[-_COLDSTART_SEEN_MAX:]
+    try:
+        path = _coldstart_state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"seen": seen}), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def retry_cold_start(
+    attempt,
+    *,
+    retries: int,
+    backoff: float,
+    deadline=None,
+    sleep=None,
+    rng=None,
+    monotonic=None,
+):
+    """Retry ``attempt`` on a cold-start miss, with jittered exponential backoff.
+
+    ``attempt`` returns ``(ok, value)``: ``ok=False`` marks a retryable cold-start
+    failure (unreachable / timeout). Retries up to ``retries`` extra times. Sleeps
+    a jittered exponential backoff between tries and NEVER sleeps past ``deadline``
+    (a ``monotonic()`` value); once the budget is spent it stops. Returns the final
+    ``(ok, value)``. Injectable ``sleep``/``rng``/``monotonic`` keep it deterministic
+    in tests.
+    """
+    _sleep = sleep or time.sleep
+    _rand = rng or random.random
+    _now = monotonic or time.monotonic
+    ok, value = attempt()
+    tries = 0
+    while not ok and tries < retries:
+        if deadline is not None and (deadline - _now()) <= 0:
+            break
+        delay = backoff * (2**tries) * (0.5 + _rand())  # jitter in [0.5, 1.5)
+        if deadline is not None:
+            delay = min(delay, max(0.0, deadline - _now()))
+        if delay > 0:
+            _sleep(delay)
+        ok, value = attempt()
+        tries += 1
+    return ok, value
 
 
 def _state_path():
@@ -89,16 +190,30 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
         # which would just hammer the same down server).
         return _error(503, "cognee temporarily unavailable (circuit open, retry in ~%ds)" % retry)
 
-    result = do_recall(
-        service_url,
-        api_key,
-        query,
-        session_id,
-        scope,
-        top_k,
-        dataset,
-        timeout=timeout or _RECALL_TIMEOUT,
-    )
+    _timeout = timeout or _RECALL_TIMEOUT
+
+    def _once():
+        return do_recall(
+            service_url, api_key, query, session_id, scope, top_k, dataset, timeout=_timeout
+        )
+
+    # Only the FIRST recall of a session retries a warming/unreachable backend;
+    # every later recall is single-shot. The whole retry burst is ONE breaker
+    # event: the accounting below runs once on the final result, so a slow cold
+    # start can't prematurely trip the circuit. Only UNREACHABLE is retryable —
+    # an error envelope (4xx/5xx/auth) is terminal and must fail fast.
+    if session_id and is_first_recall(session_id):
+
+        def _attempt():
+            r = _once()
+            return (r != UNREACHABLE, r)  # ok unless the server was unreachable
+
+        retries, backoff = coldstart_config()
+        _ok, result = retry_cold_start(_attempt, retries=retries, backoff=backoff)
+        mark_recall_seen(session_id)
+    else:
+        result = _once()
+
     if result == UNREACHABLE:
         record_failure("unreachable")
     elif isinstance(result, dict) and int(result.get("status") or 0) >= 500:

--- a/integrations/codex/plugins/cognee/scripts/_cognee_client.py
+++ b/integrations/codex/plugins/cognee/scripts/_cognee_client.py
@@ -29,20 +29,11 @@ _THRESHOLD = int(os.environ.get("COGNEE_BREAKER_THRESHOLD", "5"))
 _COOLDOWN = float(os.environ.get("COGNEE_BREAKER_COOLDOWN", "120"))
 _RECALL_TIMEOUT = float(os.environ.get("COGNEE_RECALL_TIMEOUT", "20"))
 
-# Cold-start retry: the very first recall of a session often lands while the
-# server is still warming (booting, migrating, cold DB/embedding pools), so the
-# connection times out even though a retry a moment later succeeds. We retry ONLY
-# that first recall; steady-state recalls stay single-shot so the per-prompt
-# latency budget is untouched. Defaults are conservative and env-tunable.
 _COLDSTART_SEEN_MAX = 256  # bound the marker file's session list
 
 
 def coldstart_config() -> tuple[int, float]:
-    """(extra_retries, base_backoff_seconds) for the first-recall cold-start path.
-
-    Read live so runtime/test env changes take effect. Named ``COLDSTART`` to
-    signal these apply only to the first recall of a session, not every recall.
-    """
+    """(extra_retries, base_backoff_seconds) for the first-recall cold-start path."""
     try:
         retries = int(os.environ.get("COGNEE_RECALL_COLDSTART_RETRIES", "2"))
     except (TypeError, ValueError):
@@ -103,15 +94,7 @@ def retry_cold_start(
     rng=None,
     monotonic=None,
 ):
-    """Retry ``attempt`` on a cold-start miss, with jittered exponential backoff.
-
-    ``attempt`` returns ``(ok, value)``: ``ok=False`` marks a retryable cold-start
-    failure (unreachable / timeout). Retries up to ``retries`` extra times. Sleeps
-    a jittered exponential backoff between tries and NEVER sleeps past ``deadline``
-    (a ``monotonic()`` value); once the budget is spent it stops. Returns the final
-    ``(ok, value)``. Injectable ``sleep``/``rng``/``monotonic`` keep it deterministic
-    in tests.
-    """
+    """Retry ``attempt`` on a cold-start miss, with jittered exponential backoff."""
     _sleep = sleep or time.sleep
     _rand = rng or random.random
     _now = monotonic or time.monotonic
@@ -197,11 +180,6 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
             service_url, api_key, query, session_id, scope, top_k, dataset, timeout=_timeout
         )
 
-    # Only the FIRST recall of a session retries a warming/unreachable backend;
-    # every later recall is single-shot. The whole retry burst is ONE breaker
-    # event: the accounting below runs once on the final result, so a slow cold
-    # start can't prematurely trip the circuit. Only UNREACHABLE is retryable —
-    # an error envelope (4xx/5xx/auth) is terminal and must fail fast.
     if session_id and is_first_recall(session_id):
 
         def _attempt():

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -279,6 +279,11 @@ async def _run(prompt: str) -> dict | None:
                         backoff=cs_backoff,
                         deadline=budget_deadline,
                     )
+                    if not _ok:
+                        # The retry burst proved the backend unreachable; don't
+                        # re-probe it with the remaining scopes this turn.
+                        hook_log("recall_coldstart_exhausted", {"scope": scope_list})
+                        break
                 else:
                     part = _do_recall_call()
             else:

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -16,6 +16,7 @@ import json
 import os
 import sys
 import time
+import urllib.error
 
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
@@ -221,32 +222,72 @@ async def _run(prompt: str) -> dict | None:
     # Respect the shared circuit breaker: when the server has been failing (tripped
     # by the explicit recall path), skip this per-prompt recall rather than hammering
     # a down backend on every keystroke. HTTP/cloud mode only.
+    # Cold-start: only the first recall of a session retries a warming backend.
+    coldstart_first = False
+    cs_retries, cs_backoff = 0, 0.0
     if cloud_mode:
         try:
-            from _cognee_client import breaker_open
-
-            _bopen, _bretry = breaker_open()
+            from _cognee_client import (
+                breaker_open,
+                coldstart_config,
+                is_first_recall,
+                mark_recall_seen,
+                retry_cold_start,
+            )
         except Exception:
-            _bopen, _bretry = False, 0
-        if _bopen:
-            hook_log("recall_breaker_open", {"retry_in": _bretry})
-            scope_specs = []
-    for scope_list, qtype, context_profile in scope_specs:
+            breaker_open = None
+        if breaker_open is not None:
+            try:
+                _bopen, _bretry = breaker_open()
+            except Exception:
+                _bopen, _bretry = False, 0
+            if _bopen:
+                hook_log("recall_breaker_open", {"retry_in": _bretry})
+                scope_specs = []
+            elif session_id and is_first_recall(session_id):
+                coldstart_first = True
+                cs_retries, cs_backoff = coldstart_config()
+    for idx, (scope_list, qtype, context_profile) in enumerate(scope_specs):
         if time.monotonic() >= budget_deadline:
             hook_log("recall_budget_exceeded", {"collected": len(results)})
             break
         try:
             if cloud_mode:
-                part = recall_via_http(
-                    prompt,
-                    session_id=session_id,
-                    top_k=TOP_K,
-                    scope=scope_list,
-                    only_context=True,
-                    search_type=qtype,
-                    context_profile=context_profile,
-                    timeout=recall_timeout,
-                )
+
+                def _do_recall_call(_scope=scope_list, _qtype=qtype, _profile=context_profile):
+                    return recall_via_http(
+                        prompt,
+                        session_id=session_id,
+                        top_k=TOP_K,
+                        scope=_scope,
+                        only_context=True,
+                        search_type=_qtype,
+                        context_profile=_profile,
+                        timeout=recall_timeout,
+                    )
+
+                # Retry only the first scope of the first recall, and only on a
+                # cold-start error (timeout / connection). An HTTPError is reachable
+                # but rejected, so it fails fast. Backoff is bounded by the budget.
+                if coldstart_first and idx == 0 and cs_retries > 0:
+
+                    def _attempt():
+                        try:
+                            return True, _do_recall_call()
+                        except urllib.error.HTTPError:
+                            raise
+                        except (TimeoutError, urllib.error.URLError, OSError) as exc:
+                            hook_log("recall_coldstart_retry", {"error": str(exc)[:160]})
+                            return False, []
+
+                    _ok, part = retry_cold_start(
+                        _attempt,
+                        retries=cs_retries,
+                        backoff=cs_backoff,
+                        deadline=budget_deadline,
+                    )
+                else:
+                    part = _do_recall_call()
             else:
                 query_type = getattr(SearchType, qtype, None) if qtype else None
                 part = await asyncio.wait_for(
@@ -266,6 +307,11 @@ async def _run(prompt: str) -> dict | None:
                 results.extend(part)
         except Exception as exc:
             hook_log("recall_error", {"scope": scope_list, "error": str(exc)[:200]})
+
+    # First recall resolved (success or exhausted): mark the session warm so later
+    # recalls take the fast, no-retry path and steady-state latency is unchanged.
+    if coldstart_first and session_id:
+        mark_recall_seen(session_id)
 
     # Bucket results by _source for human-readable output.
     # Local SDK mode returns Pydantic models (ResponseQAEntry, etc.); cloud

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -16,7 +16,6 @@ import json
 import os
 import sys
 import time
-import urllib.error
 
 # Add scripts dir to path for helper imports
 sys.path.insert(0, os.path.dirname(__file__))
@@ -230,6 +229,7 @@ async def _run(prompt: str) -> dict | None:
             from _cognee_client import (
                 breaker_open,
                 coldstart_config,
+                coldstart_recall_attempt,
                 is_first_recall,
                 mark_recall_seen,
                 retry_cold_start,
@@ -267,16 +267,12 @@ async def _run(prompt: str) -> dict | None:
                     )
 
                 if coldstart_first and idx == 0 and cs_retries > 0:
-
-                    def _attempt():
-                        try:
-                            return True, _do_recall_call()
-                        except urllib.error.HTTPError:
-                            raise
-                        except (TimeoutError, urllib.error.URLError, OSError) as exc:
-                            hook_log("recall_coldstart_retry", {"error": str(exc)[:160]})
-                            return False, []
-
+                    _attempt = coldstart_recall_attempt(
+                        _do_recall_call,
+                        on_retry=lambda exc: hook_log(
+                            "recall_coldstart_retry", {"error": str(exc)[:160]}
+                        ),
+                    )
                     _ok, part = retry_cold_start(
                         _attempt,
                         retries=cs_retries,

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -266,9 +266,6 @@ async def _run(prompt: str) -> dict | None:
                         timeout=recall_timeout,
                     )
 
-                # Retry only the first scope of the first recall, and only on a
-                # cold-start error (timeout / connection). An HTTPError is reachable
-                # but rejected, so it fails fast. Backoff is bounded by the budget.
                 if coldstart_first and idx == 0 and cs_retries > 0:
 
                     def _attempt():
@@ -308,8 +305,6 @@ async def _run(prompt: str) -> dict | None:
         except Exception as exc:
             hook_log("recall_error", {"scope": scope_list, "error": str(exc)[:200]})
 
-    # First recall resolved (success or exhausted): mark the session warm so later
-    # recalls take the fast, no-retry path and steady-state latency is unchanged.
     if coldstart_first and session_id:
         mark_recall_seen(session_id)
 


### PR DESCRIPTION
Reworks community PR #166 by @miantalha45 for hackathon issue [topoteretes/cognee#3542](https://github.com/topoteretes/cognee/issues/3542) — "[integrations] Retry first recall on cold-start timeout". Linear: SDK-211.

## What this does

The first recall of a session often lands while the Cognee server is still warming (booting, migrating, cold DB/embedding pools), so it times out or the connection is refused even though a retry a moment later succeeds — and today that first turn runs with no memory context. This adds a bounded, configurable retry to the **first** recall of a session, then marks the session warm so later recalls stay single-shot and steady-state latency is unchanged. It covers both plugin integrations: `integrations/claude-code/` and `integrations/codex/plugins/cognee/`.

- Only `UNREACHABLE` (connection failure / timeout) is retried; a reachable 4xx/5xx fails fast.
- The retry burst counts as a single circuit-breaker event, so a slow cold start can't trip the breaker.
- Config: `COGNEE_RECALL_COLDSTART_RETRIES` (default `2`, `0` disables) and `COGNEE_RECALL_COLDSTART_BACKOFF` (default `0.5`s).

## Commits

The original author's two commits are preserved as the base (attribution retained); each maintainer change is layered on top as its own commit:

- `refactor(integrations)` — extract the hook's inline attempt wrapper into a shared, testable `coldstart_recall_attempt` helper and re-sync the two `_cognee_client.py` copies (a follow-up "code refactor" commit had left their docstrings drifted).
- `fix(integrations)` — **bound the explicit `recall()` (cognee-search.sh) path with a deadline.** Without it, a warming server that *times out* (rather than refusing fast) could turn the first search into ~retries × timeout (~60s at the 20s default) of blocking before the CLI fallback, versus ~20s before. The deadline mirrors the auto-recall hook's existing budget bound: connection-refused failures still retry (they return fast) while a slow-timeout attempt no longer stacks, and it also caps the exponential backoff sleep against misconfiguration.
- `fix(integrations)` — the hook computed `_ok` from the first scope's retry burst but ignored it, so an already-proven-unreachable backend was re-probed by each remaining scope; consume `_ok` and stop the loop.
- `test(integrations)` — cover the auto-recall hook's error contract (connection error retries then returns context; a 4xx `HTTPError` fails fast; the on-retry callback fires) and add a regression test for the deadline bound. 13 tests total.
- `docs(integrations)` — mirror the two env-var rows into the codex README (the codex plugin got the code but not the docs).

## Deliberately left as-is

To stay faithful to the issue and avoid over-engineering: the non-atomic `recall-coldstart.json` write (benign, self-healing, and matches the existing `recall-breaker.json` idiom); `retries=0` still writing the marker (harmless); the durable per-session marker not re-arming on a reused `session_id` (the readiness gate already covers the genuinely-cold case); and retrying only `UNREACHABLE` rather than a warming 503 (matches the issue's literal "timeout or connection error" and avoids fighting the breaker).

## Verification

- `python3 integrations/claude-code/tests/test_coldstart_retry.py` → 13 pass; `tests/test_cognee_client.py` and `tests/test_recall_http.py` still green. The codex `_cognee_client.py` is byte-identical to claude-code's, so this suite covers its shared logic too.
- `ruff check` + `ruff format --check` clean (line-length 100, E/F/I/W, py310). Note: `claude-code` has no `pyproject.toml`/`uv.lock`, so `ci.yml` skips its pytest — `lint.yml` (ruff) is the active CI gate.
- Deadline behavior confirmed against a real socket: a fast connection-refused still retries; a slow-timeout attempt returns after one attempt instead of stacking.
