### PR TITLE
feat(integrations): re-register agent session on mid-session COGNEE_BASE_URL change (SDK-212)

### DIFF
--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -356,6 +356,380 @@ def _resolve_agent_name() -> str:
     return _normalize("claude-code-agent")
 
 
+def _login_default_user_via_http(service_url: str, config: dict) -> str:
+    base = _normalize_service_url(service_url)
+    email = config.get("user_email") or "default_user@example.com"
+    password = config.get("user_password") or "default_password"
+
+    params = urllib.parse.urlencode({"username": email, "password": password}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base}/api/v1/auth/login",
+        data=params,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10.0) as resp:
+            if resp.status != 200:
+                return ""
+            login_data = json.loads(resp.read().decode("utf-8"))
+            jwt = str(login_data.get("access_token", "") or "")
+    except Exception as exc:
+        hook_log("sync_login_failed", {"error": str(exc)[:200]})
+        return ""
+
+    if not jwt:
+        return ""
+
+    req_keys = urllib.request.Request(
+        f"{base}/api/v1/auth/api-keys",
+        headers={"Cookie": f"auth_token={jwt}"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req_keys, timeout=10.0) as resp:
+            if resp.status == 200:
+                keys = json.loads(resp.read().decode("utf-8"))
+                if isinstance(keys, list) and keys:
+                    key = str(keys[0].get("key", "") or "")
+                    if key:
+                        return key
+    except Exception:
+        pass
+
+    req_mint = urllib.request.Request(
+        f"{base}/api/v1/auth/api-keys",
+        data=json.dumps({"name": "claude-owner-bootstrap"}).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "Cookie": f"auth_token={jwt}"
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req_mint, timeout=10.0) as resp:
+            if resp.status == 200:
+                payload = json.loads(resp.read().decode("utf-8"))
+                return str(payload.get("key", "") or "")
+    except Exception as exc:
+        hook_log("sync_mint_failed", {"error": str(exc)[:200]})
+    return ""
+
+
+def _ensure_dataset_ready_via_http(service_url: str, api_key: str, dataset: str) -> None:
+    if not service_url or not api_key or not dataset:
+        return
+    base = service_url.rstrip("/")
+    headers = {
+        "Content-Type": "application/json",
+        "X-Api-Key": api_key,
+    }
+    payload = json.dumps({"name": dataset}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base}/api/v1/datasets",
+        data=payload,
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=15.0) as resp:
+        if resp.status not in (200, 201):
+            raise RuntimeError(f"remote dataset ensure failed ({resp.status})")
+
+
+def _find_parent_pid() -> int:
+    import subprocess
+    import re
+    fallback = os.getppid()
+    try:
+        raw = subprocess.check_output(
+            ["ps", "-axo", "pid=,ppid=,command="],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception as exc:
+        hook_log("find_parent_pid_failed", {"error": str(exc)[:200]})
+        return fallback
+
+    table: dict[int, tuple[int, str]] = {}
+    for line in raw.splitlines():
+        parts = line.strip().split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        table[pid] = (ppid, parts[2])
+
+    host_re = re.compile(r"(?:^|/)(?:claude|codex)(?:-[\w.]+)?(?:\s|$)")
+    pid = fallback
+    seen: set[int] = set()
+    while pid > 1 and pid not in seen:
+        seen.add(pid)
+        if pid not in table:
+            break
+        ppid, command = table[pid]
+        if command and host_re.search(command):
+            return pid
+        pid = ppid
+    return fallback
+
+
+def _spawn_idle_watcher_helper(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str):
+    import subprocess
+    if os.environ.get("COGNEE_IDLE_DISABLED", "").lower() in ("1", "true", "yes"):
+        return
+    _WATCHER_SCRIPT = Path(__file__).parent / "idle-watcher.py"
+    if not _WATCHER_SCRIPT.exists():
+        return
+    bootstrap = {
+        "session_id": session_id,
+        "dataset": dataset,
+        "session_key": session_key,
+        "config": {
+            "base_url": current_url,
+            "dataset": dataset,
+        },
+    }
+    log_path = _PLUGIN_DIR / "watcher.log"
+    try:
+        log_fh = log_path.open("a", encoding="utf-8")
+    except Exception:
+        log_fh = subprocess.DEVNULL
+    try:
+        env = os.environ.copy()
+        if session_key:
+            env["COGNEE_SESSION_KEY"] = session_key
+        env["COGNEE_BASE_URL"] = current_url
+        if api_key:
+            env["COGNEE_API_KEY"] = api_key
+        subprocess.Popen(
+            [sys.executable, str(_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            env=env,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except Exception as e:
+        hook_log("idle_watcher_restart_spawn_failed", {"error": str(e)[:300]})
+
+
+def _spawn_exit_watcher_helper(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str, parent_pid: int):
+    import subprocess
+    _EXIT_WATCHER_SCRIPT = Path(__file__).parent / "exit-watcher.py"
+    if not _EXIT_WATCHER_SCRIPT.exists():
+        return
+    bootstrap = {
+        "parent_pid": parent_pid,
+        "session_id": session_id,
+        "dataset": dataset,
+        "session_key": session_key,
+        "agent_session_name": conn_uuid,
+        "api_key": api_key,
+        "base_url": current_url,
+        "pidfile": str(_PLUGIN_DIR / "exit-watchers" / f"{parent_pid}.pid"),
+    }
+    log_path = _PLUGIN_DIR / "exit-watcher.log"
+    try:
+        log_fh = log_path.open("a", encoding="utf-8")
+    except Exception:
+        log_fh = subprocess.DEVNULL
+    try:
+        env = os.environ.copy()
+        if session_key:
+            env["COGNEE_SESSION_KEY"] = session_key
+        env["COGNEE_BASE_URL"] = current_url
+        if api_key:
+            env["COGNEE_API_KEY"] = api_key
+        subprocess.Popen(
+            [sys.executable, str(_EXIT_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            env=env,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except Exception as e:
+        hook_log("exit_watcher_restart_spawn_failed", {"error": str(e)[:300]})
+
+
+def _restart_watchers(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str):
+    # Kill idle watcher
+    watcher_pid_file = _PLUGIN_DIR / "watcher.pid"
+    if watcher_pid_file.exists():
+        try:
+            pid = int(watcher_pid_file.read_text(encoding="utf-8").strip())
+            os.kill(pid, 15) # SIGTERM
+        except Exception as exc:
+            hook_log("idle_watcher_kill_failed", {"error": str(exc)[:200]})
+
+    # Kill exit watcher
+    parent_pid = _find_parent_pid()
+    exit_pid_file = _PLUGIN_DIR / "exit-watchers" / f"{parent_pid}.pid"
+    if exit_pid_file.exists():
+        try:
+            pid = int(exit_pid_file.read_text(encoding="utf-8").strip())
+            os.kill(pid, 15) # SIGTERM
+        except Exception as exc:
+            hook_log("exit_watcher_kill_failed", {"error": str(exc)[:200]})
+
+    # Spawn idle watcher
+    _spawn_idle_watcher_helper(session_id, dataset, conn_uuid, api_key, current_url, session_key)
+
+    # Spawn exit watcher
+    _spawn_exit_watcher_helper(session_id, dataset, conn_uuid, api_key, current_url, session_key, parent_pid)
+
+
+def _do_re_registration(session_key: str, current_url: str, last_registered_url: str, resolved: dict, conn_uuid: str, cognee_session_id: str):
+    try:
+        from config import load_config, get_dataset
+        config = load_config()
+        dataset = get_dataset(config)
+    except Exception:
+        config = {}
+        dataset = "agent_sessions"
+
+    # Resolve credentials for the new URL
+    cached_old_key = ""
+    try:
+        key_data = _load_json_file(_API_KEY_CACHE)
+        if isinstance(key_data, dict):
+            cached_old_key = str(key_data.get("api_key") or "").strip()
+    except Exception:
+        pass
+
+    # If env key matches the old cached key, temporarily clear it
+    env_key = os.environ.get("COGNEE_API_KEY", "")
+    if env_key and cached_old_key and env_key == cached_old_key:
+        env_key = ""
+
+    new_api_key = load_cached_api_key(current_url)
+    if not new_api_key and env_key:
+        new_api_key = env_key
+
+    if not new_api_key:
+        # Perform sync login
+        new_api_key = _login_default_user_via_http(current_url, config)
+        if new_api_key:
+            save_cached_api_key(current_url, new_api_key)
+
+    # Set new key
+    if new_api_key:
+        os.environ["COGNEE_API_KEY"] = new_api_key
+        resolved["api_key"] = new_api_key
+
+    # 1. ensure dataset is ready via HTTP
+    try:
+        _ensure_dataset_ready_via_http(current_url, new_api_key, dataset)
+    except Exception as exc:
+        hook_log("dataset_ready_via_http_failed", {"error": str(exc)[:200]})
+        raise exc
+
+    # 2. Register agent via HTTP on new URL
+    reg_ok, registration = register_agent_via_http(
+        agent_session_name=conn_uuid,
+        session_id=cognee_session_id,
+        dataset_names=[dataset],
+    )
+
+    if reg_ok:
+        hook_log("re-registered_on_new_target", {
+            "base_url": current_url,
+            "agent_session_name": conn_uuid,
+            "session_id": cognee_session_id
+        })
+
+        # 3. Update server readiness marker
+        mark_server_ready(current_url)
+
+        # 4. Unregister agent on old URL best-effort
+        if cached_old_key:
+            old_env_url = os.environ.get("COGNEE_BASE_URL")
+            old_env_key = os.environ.get("COGNEE_API_KEY")
+            try:
+                os.environ["COGNEE_BASE_URL"] = last_registered_url
+                os.environ["COGNEE_API_KEY"] = cached_old_key
+                unregister_agent_via_http(agent_session_name=conn_uuid)
+            except Exception as exc:
+                hook_log("unregister_old_target_failed", {"error": str(exc)[:200]})
+            finally:
+                if old_env_url is not None:
+                    os.environ["COGNEE_BASE_URL"] = old_env_url
+                if old_env_key is not None:
+                    os.environ["COGNEE_API_KEY"] = old_env_key
+
+        # 5. Restart watchers
+        _restart_watchers(cognee_session_id, dataset, conn_uuid, new_api_key, current_url, session_key)
+    else:
+        raise RuntimeError("Agent registration failed on new target URL")
+
+
+def _resolve_url_mismatch(session_key: str, current_url: str, last_registered_url: str, resolved: dict, conn_uuid: str, cognee_session_id: str):
+    import time
+    lock_file = _PLUGIN_DIR / "reregister.lock"
+    timeout = 10.0
+    poll = 0.2
+    start_time = time.monotonic()
+    
+    while time.monotonic() - start_time < timeout:
+        # Check if mismatch is already resolved by another process
+        try:
+            if _SERVER_READY_MARKER.exists():
+                ready_data = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
+                marked_url = _normalize_service_url(ready_data.get("base_url", ""))
+                if marked_url == current_url:
+                    return
+        except Exception:
+            pass
+            
+        # Try to acquire lock
+        acquired = False
+        now = datetime.now(timezone.utc).timestamp()
+        if lock_file.exists():
+            try:
+                current = json.loads(lock_file.read_text(encoding="utf-8"))
+                pid = int(current.get("pid", 0))
+                created_at = float(current.get("created_at", 0))
+                pid_alive = False
+                if pid > 0:
+                    try:
+                        os.kill(pid, 0)
+                        pid_alive = True
+                    except ProcessLookupError:
+                        pid_alive = False
+                    except Exception:
+                        pid_alive = True
+                if not pid_alive or now - created_at > 60: # 1 min timeout
+                    try:
+                        lock_file.unlink()
+                    except Exception:
+                        pass
+            except Exception:
+                pass
+        try:
+            fd = os.open(str(lock_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump({"pid": os.getpid(), "created_at": now}, fh)
+            acquired = True
+        except FileExistsError:
+            time.sleep(poll)
+            continue
+            
+        if acquired:
+            try:
+                _do_re_registration(session_key, current_url, last_registered_url, resolved, conn_uuid, cognee_session_id)
+                return
+            finally:
+                try:
+                    lock_file.unlink()
+                except Exception:
+                    pass
+
+
 def load_resolved(session_key: str = "") -> dict:
     """Load runtime state from Cognee HTTP endpoints (no file cache)."""
     resolved: dict = {}
@@ -375,6 +749,21 @@ def load_resolved(session_key: str = "") -> dict:
     service_url = _local_api_url().strip()
     if service_url:
         resolved["base_url"] = service_url
+
+    last_registered_url = ""
+    if _SERVER_READY_MARKER.exists():
+        try:
+            ready_data = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
+            last_registered_url = _normalize_service_url(ready_data.get("base_url", ""))
+        except Exception:
+            pass
+
+    current_url = _normalize_service_url(service_url)
+    if last_registered_url and current_url and last_registered_url != current_url:
+        try:
+            _resolve_url_mismatch(active_session_key, current_url, last_registered_url, resolved, conn_uuid, cognee_session_id)
+        except Exception as exc:
+            hook_log("resolve_url_mismatch_failed", {"error": str(exc)[:200]})
 
     api_key = _api_key().strip()
     if api_key:

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -356,6 +356,15 @@ def _resolve_agent_name() -> str:
     return _normalize("claude-code-agent")
 
 
+# --- Mid-session target switch --------------------------------------------------
+# When COGNEE_BASE_URL changes after a session has started, the next interactive
+# hook notices the mismatch (resolved env URL vs the server-ready marker) and
+# re-registers this session's connection on the new target so recall and the
+# background writers follow it (gh #3544). Kept best-effort and off the hot path.
+_REREGISTER_COOLDOWN_SECONDS = 30
+_REREGISTER_LOCK_STALE_SECONDS = 120
+
+
 def _login_default_user_via_http(service_url: str, config: dict) -> str:
     """Mint (or reuse) the default-user API key on service_url over HTTP.
 
@@ -418,29 +427,11 @@ def _login_default_user_via_http(service_url: str, config: dict) -> str:
     return ""
 
 
-def _ensure_dataset_ready_via_http(service_url: str, api_key: str, dataset: str) -> None:
-    if not service_url or not api_key or not dataset:
-        return
-    base = service_url.rstrip("/")
-    headers = {
-        "Content-Type": "application/json",
-        "X-Api-Key": api_key,
-    }
-    payload = json.dumps({"name": dataset}).encode("utf-8")
-    req = urllib.request.Request(
-        f"{base}/api/v1/datasets",
-        data=payload,
-        headers=headers,
-        method="POST",
-    )
-    with urllib.request.urlopen(req, timeout=15.0) as resp:
-        if resp.status not in (200, 201):
-            raise RuntimeError(f"remote dataset ensure failed ({resp.status})")
-
-
 def _find_parent_pid() -> int:
-    import subprocess
+    """Nearest live claude/codex ancestor pid (the exit-watcher pidfile key)."""
     import re
+    import subprocess
+
     fallback = os.getppid()
     try:
         raw = subprocess.check_output(
@@ -478,36 +469,38 @@ def _find_parent_pid() -> int:
     return fallback
 
 
-def _spawn_idle_watcher_helper(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str):
+def _spawn_watcher(
+    *,
+    script_name: str,
+    bootstrap: dict,
+    current_url: str,
+    api_key: str,
+    session_key: str,
+    log_name: str,
+) -> None:
+    """Spawn a detached watcher script with its env pointed at the new target.
+
+    COGNEE_IN_WATCHER marks the child so its own load_resolved() never drives a
+    further re-registration (which would fight the interactive hooks)."""
     import subprocess
-    if os.environ.get("COGNEE_IDLE_DISABLED", "").lower() in ("1", "true", "yes"):
+
+    script = Path(__file__).parent / script_name
+    if not script.exists():
         return
-    _WATCHER_SCRIPT = Path(__file__).parent / "idle-watcher.py"
-    if not _WATCHER_SCRIPT.exists():
-        return
-    bootstrap = {
-        "session_id": session_id,
-        "dataset": dataset,
-        "session_key": session_key,
-        "config": {
-            "base_url": current_url,
-            "dataset": dataset,
-        },
-    }
-    log_path = _PLUGIN_DIR / "watcher.log"
     try:
-        log_fh = log_path.open("a", encoding="utf-8")
+        log_fh = (_PLUGIN_DIR / log_name).open("a", encoding="utf-8")
     except Exception:
         log_fh = subprocess.DEVNULL
+    env = os.environ.copy()
+    env["COGNEE_IN_WATCHER"] = "1"
+    env["COGNEE_BASE_URL"] = current_url
+    if session_key:
+        env["COGNEE_SESSION_KEY"] = session_key
+    if api_key:
+        env["COGNEE_API_KEY"] = api_key
     try:
-        env = os.environ.copy()
-        if session_key:
-            env["COGNEE_SESSION_KEY"] = session_key
-        env["COGNEE_BASE_URL"] = current_url
-        if api_key:
-            env["COGNEE_API_KEY"] = api_key
         subprocess.Popen(
-            [sys.executable, str(_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            [sys.executable, str(script), json.dumps(bootstrap)],
             stdin=subprocess.DEVNULL,
             stdout=log_fh,
             stderr=log_fh,
@@ -515,221 +508,218 @@ def _spawn_idle_watcher_helper(session_id: str, dataset: str, conn_uuid: str, ap
             start_new_session=True,
             close_fds=True,
         )
-    except Exception as e:
-        hook_log("idle_watcher_restart_spawn_failed", {"error": str(e)[:300]})
+    except Exception as exc:
+        hook_log("watcher_restart_spawn_failed", {"script": script_name, "error": str(exc)[:200]})
+    finally:
+        if hasattr(log_fh, "close"):
+            try:
+                log_fh.close()
+            except Exception:
+                pass
 
 
-def _spawn_exit_watcher_helper(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str, parent_pid: int):
-    import subprocess
-    _EXIT_WATCHER_SCRIPT = Path(__file__).parent / "exit-watcher.py"
-    if not _EXIT_WATCHER_SCRIPT.exists():
-        return
-    bootstrap = {
-        "parent_pid": parent_pid,
-        "session_id": session_id,
-        "dataset": dataset,
-        "session_key": session_key,
-        "agent_session_name": conn_uuid,
-        "api_key": api_key,
-        "base_url": current_url,
-        "pidfile": str(_PLUGIN_DIR / "exit-watchers" / f"{parent_pid}.pid"),
-    }
-    log_path = _PLUGIN_DIR / "exit-watcher.log"
-    try:
-        log_fh = log_path.open("a", encoding="utf-8")
-    except Exception:
-        log_fh = subprocess.DEVNULL
-    try:
-        env = os.environ.copy()
-        if session_key:
-            env["COGNEE_SESSION_KEY"] = session_key
-        env["COGNEE_BASE_URL"] = current_url
-        if api_key:
-            env["COGNEE_API_KEY"] = api_key
-        subprocess.Popen(
-            [sys.executable, str(_EXIT_WATCHER_SCRIPT), json.dumps(bootstrap)],
-            stdin=subprocess.DEVNULL,
-            stdout=log_fh,
-            stderr=log_fh,
-            env=env,
-            start_new_session=True,
-            close_fds=True,
-        )
-    except Exception as e:
-        hook_log("exit_watcher_restart_spawn_failed", {"error": str(e)[:300]})
-
-
-def _restart_watchers(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str):
-    # Kill idle watcher
-    watcher_pid_file = _PLUGIN_DIR / "watcher.pid"
-    if watcher_pid_file.exists():
-        try:
-            pid = int(watcher_pid_file.read_text(encoding="utf-8").strip())
-            os.kill(pid, 15) # SIGTERM
-        except Exception as exc:
-            hook_log("idle_watcher_kill_failed", {"error": str(exc)[:200]})
-
-    # Kill exit watcher
+def _restart_watchers(
+    *,
+    session_id: str,
+    dataset: str,
+    conn_uuid: str,
+    api_key: str,
+    current_url: str,
+    session_key: str,
+) -> None:
+    """Stop and respawn the idle + exit watchers so background writes follow the
+    switch (they were spawned at SessionStart with the old URL in their env)."""
     parent_pid = _find_parent_pid()
-    exit_pid_file = _PLUGIN_DIR / "exit-watchers" / f"{parent_pid}.pid"
-    if exit_pid_file.exists():
+    exit_pidfile = _PLUGIN_DIR / "exit-watchers" / f"{parent_pid}.pid"
+    for pid_file in (_PLUGIN_DIR / "watcher.pid", exit_pidfile):
         try:
-            pid = int(exit_pid_file.read_text(encoding="utf-8").strip())
-            os.kill(pid, 15) # SIGTERM
+            if pid_file.exists():
+                os.kill(int(pid_file.read_text(encoding="utf-8").strip()), 15)  # SIGTERM
         except Exception as exc:
-            hook_log("exit_watcher_kill_failed", {"error": str(exc)[:200]})
+            hook_log("watcher_kill_failed", {"pid_file": str(pid_file), "error": str(exc)[:200]})
+    # Clear the exit-watcher pidfile (its respawn refuses while it names a live pid)
+    # and the idle-watcher stop sentinel (a leftover would exit the new watcher).
+    for stale in (exit_pidfile, _PLUGIN_DIR / "watcher.stop"):
+        try:
+            stale.unlink()
+        except Exception:
+            pass
 
-    # Spawn idle watcher
-    _spawn_idle_watcher_helper(session_id, dataset, conn_uuid, api_key, current_url, session_key)
+    if os.environ.get("COGNEE_IDLE_DISABLED", "").lower() not in ("1", "true", "yes"):
+        _spawn_watcher(
+            script_name="idle-watcher.py",
+            bootstrap={
+                "session_id": session_id,
+                "dataset": dataset,
+                "session_key": session_key,
+                "config": {"base_url": current_url, "dataset": dataset},
+            },
+            current_url=current_url,
+            api_key=api_key,
+            session_key=session_key,
+            log_name="watcher.log",
+        )
+    _spawn_watcher(
+        script_name="exit-watcher.py",
+        bootstrap={
+            "parent_pid": parent_pid,
+            "session_id": session_id,
+            "dataset": dataset,
+            "session_key": session_key,
+            "agent_session_name": conn_uuid,
+            "api_key": api_key,
+            "base_url": current_url,
+            "pidfile": str(exit_pidfile),
+        },
+        current_url=current_url,
+        api_key=api_key,
+        session_key=session_key,
+        log_name="exit-watcher.log",
+    )
 
-    # Spawn exit watcher
-    _spawn_exit_watcher_helper(session_id, dataset, conn_uuid, api_key, current_url, session_key, parent_pid)
 
+def _do_re_registration(
+    *, session_key: str, current_url: str, conn_uuid: str, cognee_session_id: str
+) -> bool:
+    """Register this session's connection on current_url. Returns True on success.
 
-def _do_re_registration(session_key: str, current_url: str, last_registered_url: str, resolved: dict, conn_uuid: str, cognee_session_id: str):
+    Credentials, dataset, and watchers are all re-pointed at the new target; the
+    old connection is left to the server's own agent-mode teardown."""
     try:
-        from config import load_config, get_dataset
+        from config import get_dataset, load_config
+
         config = load_config()
         dataset = get_dataset(config)
     except Exception:
-        config = {}
-        dataset = "agent_sessions"
+        config, dataset = {}, "agent_sessions"
 
-    # Resolve credentials for the new URL
+    # Resolve a key for the NEW target. api_key.json is keyed by base_url, so a key
+    # cached for the OLD target is not returned for current_url. An env key that only
+    # echoes that stale cached key is dropped (it belongs to the old server); a
+    # user-provided env key (e.g. Cognee Cloud) is kept. Else mint from the default
+    # local user.
     cached_old_key = ""
-    try:
-        key_data = _load_json_file(_API_KEY_CACHE)
-        if isinstance(key_data, dict):
-            cached_old_key = str(key_data.get("api_key") or "").strip()
-    except Exception:
-        pass
-
-    # If env key matches the old cached key, temporarily clear it
-    env_key = os.environ.get("COGNEE_API_KEY", "")
-    if env_key and cached_old_key and env_key == cached_old_key:
+    key_data = _load_json_file(_API_KEY_CACHE)
+    if isinstance(key_data, dict):
+        cached_old_key = str(key_data.get("api_key") or "").strip()
+    env_key = os.environ.get("COGNEE_API_KEY", "").strip()
+    if env_key and env_key == cached_old_key:
         env_key = ""
-
-    new_api_key = load_cached_api_key(current_url)
-    if not new_api_key and env_key:
-        new_api_key = env_key
-
+    new_api_key = load_cached_api_key(current_url) or env_key
     if not new_api_key:
-        # Perform sync login
         new_api_key = _login_default_user_via_http(current_url, config)
         if new_api_key:
             save_cached_api_key(current_url, new_api_key)
 
-    # Set new key
+    # Point the shared HTTP helpers at the new target: both ensure_dataset_via_http
+    # and register_agent_via_http resolve URL + key from the environment.
+    os.environ["COGNEE_BASE_URL"] = current_url
     if new_api_key:
         os.environ["COGNEE_API_KEY"] = new_api_key
-        resolved["api_key"] = new_api_key
 
-    # 1. ensure dataset is ready via HTTP
-    try:
-        _ensure_dataset_ready_via_http(current_url, new_api_key, dataset)
-    except Exception as exc:
-        hook_log("dataset_ready_via_http_failed", {"error": str(exc)[:200]})
-        raise exc
-
-    # 2. Register agent via HTTP on new URL
-    reg_ok, registration = register_agent_via_http(
-        agent_session_name=conn_uuid,
-        session_id=cognee_session_id,
-        dataset_names=[dataset],
+    ensure_dataset_via_http(dataset)
+    reg_ok, _ = register_agent_via_http(
+        agent_session_name=conn_uuid, session_id=cognee_session_id, dataset_names=[dataset]
     )
+    if not reg_ok:
+        hook_log("reregister_failed", {"base_url": current_url})
+        return False
 
-    if reg_ok:
-        hook_log("re-registered_on_new_target", {
-            "base_url": current_url,
-            "agent_session_name": conn_uuid,
-            "session_id": cognee_session_id
-        })
-
-        # 3. Update server readiness marker
-        mark_server_ready(current_url)
-
-        # 4. Unregister agent on old URL best-effort
-        if cached_old_key:
-            old_env_url = os.environ.get("COGNEE_BASE_URL")
-            old_env_key = os.environ.get("COGNEE_API_KEY")
-            try:
-                os.environ["COGNEE_BASE_URL"] = last_registered_url
-                os.environ["COGNEE_API_KEY"] = cached_old_key
-                unregister_agent_via_http(agent_session_name=conn_uuid)
-            except Exception as exc:
-                hook_log("unregister_old_target_failed", {"error": str(exc)[:200]})
-            finally:
-                if old_env_url is not None:
-                    os.environ["COGNEE_BASE_URL"] = old_env_url
-                if old_env_key is not None:
-                    os.environ["COGNEE_API_KEY"] = old_env_key
-
-        # 5. Restart watchers
-        _restart_watchers(cognee_session_id, dataset, conn_uuid, new_api_key, current_url, session_key)
-    else:
-        raise RuntimeError("Agent registration failed on new target URL")
+    hook_log(
+        "re-registered_on_new_target",
+        {"base_url": current_url, "agent_session_name": conn_uuid, "session_id": cognee_session_id},
+    )
+    # Marker last: only advertise the new target once the connection is on it.
+    mark_server_ready(current_url)
+    _restart_watchers(
+        session_id=cognee_session_id,
+        dataset=dataset,
+        conn_uuid=conn_uuid,
+        api_key=new_api_key,
+        current_url=current_url,
+        session_key=session_key,
+    )
+    return True
 
 
-def _resolve_url_mismatch(session_key: str, current_url: str, last_registered_url: str, resolved: dict, conn_uuid: str, cognee_session_id: str):
-    import time
+def _resolve_url_mismatch(
+    *, session_key: str, current_url: str, conn_uuid: str, cognee_session_id: str
+) -> None:
+    """Re-register on current_url after a mid-session switch. Best-effort and
+    non-blocking on the hot path:
+
+      - never runs inside the watcher daemons (they carry stale env);
+      - skips (with a short cooldown) when the new target is unreachable or a
+        recent attempt failed, so a down target can't stall every hook;
+      - takes the lock with a single non-blocking attempt — if another hook holds
+        it, return at once rather than spin.
+    """
+    if os.environ.get("COGNEE_IN_WATCHER") == "1":
+        return
+
+    now = datetime.now(timezone.utc).timestamp()
+    cooldown_file = _PLUGIN_DIR / "reregister-cooldown.json"
+    data = _load_json_file(cooldown_file)
+    if isinstance(data, dict) and now < float(data.get("until", 0) or 0):
+        return
+
+    if not server_health_ok(current_url, timeout=1.5):
+        _write_json_file(cooldown_file, {"until": now + _REREGISTER_COOLDOWN_SECONDS})
+        return
+
     lock_file = _PLUGIN_DIR / "reregister.lock"
-    timeout = 10.0
-    poll = 0.2
-    start_time = time.monotonic()
-    
-    while time.monotonic() - start_time < timeout:
-        # Check if mismatch is already resolved by another process
+    # Reclaim a lock left by a dead or long-stuck holder (mirrors the bootstrap
+    # single-flight reclaim).
+    if lock_file.exists():
         try:
-            if _SERVER_READY_MARKER.exists():
-                ready_data = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
-                marked_url = _normalize_service_url(ready_data.get("base_url", ""))
-                if marked_url == current_url:
-                    return
+            held = json.loads(lock_file.read_text(encoding="utf-8"))
+            pid = int(held.get("pid", 0) or 0)
+            created_at = float(held.get("created_at", 0) or 0)
+            alive = pid > 0
+            if pid > 0:
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    alive = False
+                except Exception:
+                    alive = True
+            if not alive or now - created_at > _REREGISTER_LOCK_STALE_SECONDS:
+                lock_file.unlink()
         except Exception:
             pass
-            
-        # Try to acquire lock
-        acquired = False
-        now = datetime.now(timezone.utc).timestamp()
-        if lock_file.exists():
+
+    try:
+        fd = os.open(str(lock_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        return  # another hook is already handling the switch
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"pid": os.getpid(), "created_at": now}, fh)
+        # A peer may have completed the switch between our check and the lock.
+        marker = _load_json_file(_SERVER_READY_MARKER)
+        marked = ""
+        if isinstance(marker, dict):
+            marked = _normalize_service_url(marker.get("base_url", ""))
+        if marked == current_url:
+            return
+        ok = _do_re_registration(
+            session_key=session_key,
+            current_url=current_url,
+            conn_uuid=conn_uuid,
+            cognee_session_id=cognee_session_id,
+        )
+        if ok:
             try:
-                current = json.loads(lock_file.read_text(encoding="utf-8"))
-                pid = int(current.get("pid", 0))
-                created_at = float(current.get("created_at", 0))
-                pid_alive = False
-                if pid > 0:
-                    try:
-                        os.kill(pid, 0)
-                        pid_alive = True
-                    except ProcessLookupError:
-                        pid_alive = False
-                    except Exception:
-                        pid_alive = True
-                if not pid_alive or now - created_at > 60: # 1 min timeout
-                    try:
-                        lock_file.unlink()
-                    except Exception:
-                        pass
+                cooldown_file.unlink()
             except Exception:
                 pass
+        else:
+            _write_json_file(cooldown_file, {"until": now + _REREGISTER_COOLDOWN_SECONDS})
+    finally:
         try:
-            fd = os.open(str(lock_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                json.dump({"pid": os.getpid(), "created_at": now}, fh)
-            acquired = True
-        except FileExistsError:
-            time.sleep(poll)
-            continue
-            
-        if acquired:
-            try:
-                _do_re_registration(session_key, current_url, last_registered_url, resolved, conn_uuid, cognee_session_id)
-                return
-            finally:
-                try:
-                    lock_file.unlink()
-                except Exception:
-                    pass
+            lock_file.unlink()
+        except Exception:
+            pass
 
 
 def load_resolved(session_key: str = "") -> dict:
@@ -763,7 +753,12 @@ def load_resolved(session_key: str = "") -> dict:
     current_url = _normalize_service_url(service_url)
     if last_registered_url and current_url and last_registered_url != current_url:
         try:
-            _resolve_url_mismatch(active_session_key, current_url, last_registered_url, resolved, conn_uuid, cognee_session_id)
+            _resolve_url_mismatch(
+                session_key=active_session_key,
+                current_url=current_url,
+                conn_uuid=conn_uuid,
+                cognee_session_id=cognee_session_id,
+            )
         except Exception as exc:
             hook_log("resolve_url_mismatch_failed", {"error": str(exc)[:200]})
 

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -357,6 +357,11 @@ def _resolve_agent_name() -> str:
 
 
 def _login_default_user_via_http(service_url: str, config: dict) -> str:
+    """Mint (or reuse) the default-user API key on service_url over HTTP.
+
+    Best-effort: returns "" on any failure so the caller can fall back or retry.
+    Sync sibling of session-start's async _login_default_user_for_owner_api_key;
+    it lives here because that one cannot be imported from this lower layer."""
     base = _normalize_service_url(service_url)
     email = config.get("user_email") or "default_user@example.com"
     password = config.get("user_password") or "default_password"
@@ -369,7 +374,7 @@ def _login_default_user_via_http(service_url: str, config: dict) -> str:
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=10.0) as resp:
+        with urllib.request.urlopen(req, timeout=10.0, context=_https_context()) as resp:
             if resp.status != 200:
                 return ""
             login_data = json.loads(resp.read().decode("utf-8"))
@@ -387,7 +392,7 @@ def _login_default_user_via_http(service_url: str, config: dict) -> str:
         method="GET",
     )
     try:
-        with urllib.request.urlopen(req_keys, timeout=10.0) as resp:
+        with urllib.request.urlopen(req_keys, timeout=10.0, context=_https_context()) as resp:
             if resp.status == 200:
                 keys = json.loads(resp.read().decode("utf-8"))
                 if isinstance(keys, list) and keys:
@@ -400,14 +405,11 @@ def _login_default_user_via_http(service_url: str, config: dict) -> str:
     req_mint = urllib.request.Request(
         f"{base}/api/v1/auth/api-keys",
         data=json.dumps({"name": "claude-owner-bootstrap"}).encode("utf-8"),
-        headers={
-            "Content-Type": "application/json",
-            "Cookie": f"auth_token={jwt}"
-        },
+        headers={"Content-Type": "application/json", "Cookie": f"auth_token={jwt}"},
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req_mint, timeout=10.0) as resp:
+        with urllib.request.urlopen(req_mint, timeout=10.0, context=_https_context()) as resp:
             if resp.status == 200:
                 payload = json.loads(resp.read().decode("utf-8"))
                 return str(payload.get("key", "") or "")

--- a/integrations/claude-code/tests/test_mid_session_reregister.py
+++ b/integrations/claude-code/tests/test_mid_session_reregister.py
@@ -1,181 +1,232 @@
+"""Mid-session COGNEE_BASE_URL switch -> re-register on the new target (gh #3544).
+
+Standalone-runnable (python3 tests/test_mid_session_reregister.py) and
+pytest-discoverable. Uses in-process mock Cognee servers on ephemeral ports; no
+cognee install, network, or LLM key required.
+"""
+
 import json
 import os
 import pathlib
+import socket
 import sys
 import tempfile
 import threading
-import time
-import urllib.parse
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-# Adjust sys.path to find the scripts folder
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
-
-# Redirect plugin directory to a temp folder BEFORE importing common plugin module
-_TMP_DIR = tempfile.mkdtemp(prefix="cognee-reregister-test-")
-os.environ["COGNEE_PLUGIN_STATE_DIR"] = _TMP_DIR
 
 import _plugin_common  # noqa: E402
 
-# Force path variables to point to our temp folder so we don't mess up real data
-_TMP_PATH = pathlib.Path(_TMP_DIR)
-_plugin_common._SHARED_PLUGIN_ROOT = _TMP_PATH
-_plugin_common._PLUGIN_DIR = _TMP_PATH / "claude-code"
-_plugin_common._HOOK_LOG = _plugin_common._PLUGIN_DIR / "hook.log"
-_plugin_common._COUNTER_FILE = _plugin_common._PLUGIN_DIR / "counter.json"
-_plugin_common._ACTIVITY_FILE = _plugin_common._PLUGIN_DIR / "activity.ts"
-_plugin_common._ACTIVITY_LOG = _plugin_common._PLUGIN_DIR / "activity.log"
-_plugin_common._SAVE_COUNTER = _plugin_common._PLUGIN_DIR / "save_counter.json"
-_plugin_common._SERVER_READY_MARKER = _TMP_PATH / "server-ready.json"
-_plugin_common._SYNC_LOCK = _plugin_common._PLUGIN_DIR / "sync.lock"
-_plugin_common._BRIDGE_DIR = _plugin_common._PLUGIN_DIR / "bridge"
-_plugin_common._PENDING_DIR = _plugin_common._PLUGIN_DIR / "pending"
-_plugin_common._SUBPROCESS_LOG = _plugin_common._PLUGIN_DIR / "subprocess.log"
-_plugin_common._API_KEY_CACHE = _TMP_PATH / "api_key.json"
-_plugin_common._SESSIONS_MAP_DIR = _plugin_common._PLUGIN_DIR / "sessions"
+
+def _point_plugin_dirs(tmp: pathlib.Path) -> None:
+    """Redirect the module's on-disk state into a throwaway temp dir."""
+    _plugin_common._SHARED_PLUGIN_ROOT = tmp
+    _plugin_common._PLUGIN_DIR = tmp / "claude-code"
+    _plugin_common._PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+    _plugin_common._SERVER_READY_MARKER = tmp / "server-ready.json"
+    _plugin_common._API_KEY_CACHE = tmp / "api_key.json"
+    _plugin_common._HOOK_LOG = _plugin_common._PLUGIN_DIR / "hook.log"
 
 
-class MockServerRequestHandler(BaseHTTPRequestHandler):
-    def log_message(self, format, *args):
+class _MockHandler(BaseHTTPRequestHandler):
+    def log_message(self, *_):  # silence
         pass
 
+    def _record(self, method, body=""):
+        self.server.calls.append(
+            {
+                "method": method,
+                "path": self.path,
+                "body": body,
+                "api_key": self.headers.get("X-Api-Key", ""),
+            }
+        )
+
+    def _json(self, code, payload):
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(payload).encode("utf-8"))
+
     def do_GET(self):
-        self.server.calls.append(("GET", self.path))
+        self._record("GET")
         if self.path == "/health":
             self.send_response(200)
             self.end_headers()
             self.wfile.write(b"OK")
         elif self.path.startswith("/api/v1/users/me"):
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps({"id": "user_123"}).encode("utf-8"))
+            self._json(200, {"id": "user_123"})
         elif self.path.startswith("/api/v1/agents/connections/me"):
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps({"agent": {"agent_session_name": "some_conn", "status": "active"}}).encode("utf-8"))
+            self._json(200, {"agent": {"agent_session_name": "conn", "status": "active"}})
         elif self.path.startswith("/api/v1/auth/api-keys"):
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps([{"key": "test_api_key"}]).encode("utf-8"))
+            self._json(200, [{"key": "minted_key"}])
         else:
             self.send_response(404)
             self.end_headers()
 
     def do_POST(self):
-        content_length = int(self.headers.get("Content-Length", 0))
-        body = self.rfile.read(content_length).decode("utf-8") if content_length > 0 else ""
-        self.server.calls.append(("POST", self.path, body))
-
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length).decode("utf-8") if length else ""
+        self._record("POST", body)
         if self.path == "/api/v1/agents/register":
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps({"id": "conn_registered"}).encode("utf-8"))
+            self._json(200, {"id": "conn_registered"})
         elif self.path == "/api/v1/datasets":
-            self.send_response(201)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps({"name": "dataset_123"}).encode("utf-8"))
+            self._json(201, {"name": "dataset_123"})
         elif self.path == "/api/v1/agents/unregister":
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps({"activeAgents": 0}).encode("utf-8"))
+            self._json(200, {"activeAgents": 0})
         elif self.path == "/api/v1/auth/login":
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps({"access_token": "token_123"}).encode("utf-8"))
+            self._json(200, {"access_token": "token_123"})
         elif self.path == "/api/v1/auth/api-keys":
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.end_headers()
-            self.wfile.write(json.dumps({"key": "test_api_key"}).encode("utf-8"))
+            self._json(200, {"key": "minted_key"})
         else:
             self.send_response(404)
             self.end_headers()
 
 
-def test_mid_session_reregister():
-    # Spin up Server A and Server B on dynamic ports
-    server_a = HTTPServer(("localhost", 0), MockServerRequestHandler)
-    server_a.calls = []
-    thread_a = threading.Thread(target=server_a.serve_forever)
-    thread_a.daemon = True
-    thread_a.start()
+def _start_server():
+    srv = HTTPServer(("localhost", 0), _MockHandler)
+    srv.calls = []
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, f"http://localhost:{srv.server_port}"
 
-    server_b = HTTPServer(("localhost", 0), MockServerRequestHandler)
-    server_b.calls = []
-    thread_b = threading.Thread(target=server_b.serve_forever)
-    thread_b.daemon = True
-    thread_b.start()
 
-    url_a = f"http://localhost:{server_a.server_port}"
-    url_b = f"http://localhost:{server_b.server_port}"
+def _closed_url() -> str:
+    """A URL whose port is bound then freed -> connection refused (unreachable)."""
+    s = socket.socket()
+    s.bind(("localhost", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return f"http://localhost:{port}"
 
-    # Setup the initial session on Server A
-    os.environ["COGNEE_SESSION_KEY"] = "test-session-key"
-    os.environ["COGNEE_BASE_URL"] = url_a
-    _plugin_common.mark_server_ready(url_a)
 
-    # Resolve initial status to make sure we're on Server A
-    resolved = _plugin_common.load_resolved()
-    assert resolved.get("base_url") == url_a
+def _registers(calls):
+    return [c for c in calls if c["path"] == "/api/v1/agents/register"]
 
-    # Now change COGNEE_BASE_URL to Server B
-    os.environ["COGNEE_BASE_URL"] = url_b
 
-    # Mock subprocess.Popen and os.kill so we don't start real processes or kill things
-    with patch("subprocess.Popen") as mock_popen, patch("os.kill") as mock_kill:
-        mock_popen.return_value = MagicMock()
+def _run(fn):
+    """Run one test with fresh plugin state and a restored environment."""
+    saved_env = dict(os.environ)
+    tmp = pathlib.Path(tempfile.mkdtemp(prefix="cognee-reregister-"))
+    _point_plugin_dirs(tmp)
+    # os.kill / check_output / Popen are stubbed so the switch touches no real
+    # processes; the check_output stub keeps _find_parent_pid off real `ps`.
+    with (
+        patch("subprocess.Popen") as popen,
+        patch("os.kill"),
+        patch("subprocess.check_output", return_value=""),
+    ):
+        try:
+            fn(popen)
+        finally:
+            os.environ.clear()
+            os.environ.update(saved_env)
 
-        # Trigger load_resolved, which should detect the mismatch
-        resolved_new = _plugin_common.load_resolved()
 
-        # Assertions:
-        # 1. Base URL has switched to B
-        assert resolved_new.get("base_url") == url_b
+def test_switch_registers_on_new_target():
+    """The connection lands on the NEW target, not the old one (issue done-when)."""
 
-        # 2. server-ready.json was updated to url_b
-        assert _plugin_common._SERVER_READY_MARKER.exists()
-        ready_data = json.loads(_plugin_common._SERVER_READY_MARKER.read_text(encoding="utf-8"))
-        assert ready_data.get("base_url") == url_b
+    def body(popen):
+        srv_a, url_a = _start_server()
+        srv_b, url_b = _start_server()
+        try:
+            os.environ["COGNEE_SESSION_KEY"] = "k"
+            os.environ["COGNEE_BASE_URL"] = url_a
+            _plugin_common.mark_server_ready(url_a)
 
-        # 3. Server B received the registration and dataset requests
-        register_calls = [c for c in server_b.calls if c[1] == "/api/v1/agents/register"]
-        dataset_calls = [c for c in server_b.calls if c[1] == "/api/v1/datasets"]
-        assert len(register_calls) > 0
-        assert len(dataset_calls) > 0
+            os.environ["COGNEE_BASE_URL"] = url_b
+            _plugin_common.load_resolved()
 
-        # 4. Mock popen was called to restart watchers with B config
-        # (check that popen args contain B's url)
-        assert mock_popen.call_count >= 2
-        called_args = [call[0][0] for call in mock_popen.call_args_list]
-        called_envs = [call[1].get("env", {}) for call in mock_popen.call_args_list]
+            # Registration + dataset landed on B, and B is now the ready marker.
+            assert _registers(srv_b.calls), "no register on the new target"
+            assert any(c["path"] == "/api/v1/datasets" for c in srv_b.calls)
+            marker = json.loads(_plugin_common._SERVER_READY_MARKER.read_text())
+            assert marker["base_url"] == url_b
+            # The switch must not register on the OLD target.
+            assert not _registers(srv_a.calls), "unexpected register on the old target"
+            # Both watchers restarted, pointed at B and flagged as watchers.
+            assert popen.call_count >= 2
+            scripts = [str(c[0][0]) for c in popen.call_args_list]
+            envs = [c.kwargs.get("env", {}) for c in popen.call_args_list]
+            assert any("idle-watcher.py" in s for s in scripts)
+            assert any("exit-watcher.py" in s for s in scripts)
+            assert all(e.get("COGNEE_BASE_URL") == url_b for e in envs if "COGNEE_BASE_URL" in e)
+            assert all(e.get("COGNEE_IN_WATCHER") == "1" for e in envs)
+        finally:
+            srv_a.shutdown()
+            srv_b.shutdown()
 
-        # Verify idle-watcher and exit-watcher arguments
-        assert any("idle-watcher.py" in str(arg) for arg in called_args)
-        assert any("exit-watcher.py" in str(arg) for arg in called_args)
-        assert any(url_b in str(env.get("COGNEE_BASE_URL")) for env in called_envs)
+    _run(body)
 
-    # Clean up mock servers
-    server_a.shutdown()
-    server_b.shutdown()
-    thread_a.join()
-    thread_b.join()
+
+def test_stale_key_not_sent_to_new_target():
+    """A key cached/env-set for the OLD target must not be posted to the NEW one."""
+
+    def body(_popen):
+        srv_a, url_a = _start_server()
+        srv_b, url_b = _start_server()
+        try:
+            os.environ["COGNEE_SESSION_KEY"] = "k"
+            os.environ["COGNEE_BASE_URL"] = url_a
+            os.environ["COGNEE_API_KEY"] = "key_a"
+            _plugin_common.save_cached_api_key(url_a, "key_a")
+            _plugin_common.mark_server_ready(url_a)
+
+            os.environ["COGNEE_BASE_URL"] = url_b
+            _plugin_common.load_resolved()
+
+            regs = _registers(srv_b.calls)
+            assert regs, "no register on the new target"
+            # It must carry B's freshly minted key, never A's stale key.
+            assert all(c["api_key"] != "key_a" for c in regs)
+            assert regs[0]["api_key"] == "minted_key"
+        finally:
+            srv_a.shutdown()
+            srv_b.shutdown()
+
+    _run(body)
+
+
+def test_down_target_is_skipped():
+    """An unreachable new target: no re-registration, marker untouched, cooldown set."""
+
+    def body(_popen):
+        srv_a, url_a = _start_server()
+        down = _closed_url()
+        try:
+            os.environ["COGNEE_SESSION_KEY"] = "k"
+            os.environ["COGNEE_BASE_URL"] = url_a
+            _plugin_common.mark_server_ready(url_a)
+
+            os.environ["COGNEE_BASE_URL"] = down
+            _plugin_common.load_resolved()
+
+            # Marker unchanged (still A), so a later healthy hook re-tries.
+            marker = json.loads(_plugin_common._SERVER_READY_MARKER.read_text())
+            assert marker["base_url"] == url_a
+            assert (_plugin_common._PLUGIN_DIR / "reregister-cooldown.json").exists()
+        finally:
+            srv_a.shutdown()
+
+    _run(body)
 
 
 if __name__ == "__main__":
-    try:
-        test_mid_session_reregister()
-        print("PASS test_mid_session_reregister")
-        sys.exit(0)
-    except AssertionError as e:
-        import traceback
-        traceback.print_exc()
-        print("FAIL test_mid_session_reregister")
-        sys.exit(1)
+    tests = [
+        test_switch_registers_on_new_target,
+        test_stale_key_not_sent_to_new_target,
+        test_down_target_is_skipped,
+    ]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print("PASS", t.__name__)
+        except AssertionError as exc:
+            failures += 1
+            import traceback
+
+            traceback.print_exc()
+            print("FAIL", t.__name__, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/claude-code/tests/test_mid_session_reregister.py
+++ b/integrations/claude-code/tests/test_mid_session_reregister.py
@@ -1,0 +1,181 @@
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import threading
+import time
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import MagicMock, patch
+
+# Adjust sys.path to find the scripts folder
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+# Redirect plugin directory to a temp folder BEFORE importing common plugin module
+_TMP_DIR = tempfile.mkdtemp(prefix="cognee-reregister-test-")
+os.environ["COGNEE_PLUGIN_STATE_DIR"] = _TMP_DIR
+
+import _plugin_common  # noqa: E402
+
+# Force path variables to point to our temp folder so we don't mess up real data
+_TMP_PATH = pathlib.Path(_TMP_DIR)
+_plugin_common._SHARED_PLUGIN_ROOT = _TMP_PATH
+_plugin_common._PLUGIN_DIR = _TMP_PATH / "claude-code"
+_plugin_common._HOOK_LOG = _plugin_common._PLUGIN_DIR / "hook.log"
+_plugin_common._COUNTER_FILE = _plugin_common._PLUGIN_DIR / "counter.json"
+_plugin_common._ACTIVITY_FILE = _plugin_common._PLUGIN_DIR / "activity.ts"
+_plugin_common._ACTIVITY_LOG = _plugin_common._PLUGIN_DIR / "activity.log"
+_plugin_common._SAVE_COUNTER = _plugin_common._PLUGIN_DIR / "save_counter.json"
+_plugin_common._SERVER_READY_MARKER = _TMP_PATH / "server-ready.json"
+_plugin_common._SYNC_LOCK = _plugin_common._PLUGIN_DIR / "sync.lock"
+_plugin_common._BRIDGE_DIR = _plugin_common._PLUGIN_DIR / "bridge"
+_plugin_common._PENDING_DIR = _plugin_common._PLUGIN_DIR / "pending"
+_plugin_common._SUBPROCESS_LOG = _plugin_common._PLUGIN_DIR / "subprocess.log"
+_plugin_common._API_KEY_CACHE = _TMP_PATH / "api_key.json"
+_plugin_common._SESSIONS_MAP_DIR = _plugin_common._PLUGIN_DIR / "sessions"
+
+
+class MockServerRequestHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        pass
+
+    def do_GET(self):
+        self.server.calls.append(("GET", self.path))
+        if self.path == "/health":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"OK")
+        elif self.path.startswith("/api/v1/users/me"):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"id": "user_123"}).encode("utf-8"))
+        elif self.path.startswith("/api/v1/agents/connections/me"):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"agent": {"agent_session_name": "some_conn", "status": "active"}}).encode("utf-8"))
+        elif self.path.startswith("/api/v1/auth/api-keys"):
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps([{"key": "test_api_key"}]).encode("utf-8"))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length).decode("utf-8") if content_length > 0 else ""
+        self.server.calls.append(("POST", self.path, body))
+
+        if self.path == "/api/v1/agents/register":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"id": "conn_registered"}).encode("utf-8"))
+        elif self.path == "/api/v1/datasets":
+            self.send_response(201)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"name": "dataset_123"}).encode("utf-8"))
+        elif self.path == "/api/v1/agents/unregister":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"activeAgents": 0}).encode("utf-8"))
+        elif self.path == "/api/v1/auth/login":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"access_token": "token_123"}).encode("utf-8"))
+        elif self.path == "/api/v1/auth/api-keys":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"key": "test_api_key"}).encode("utf-8"))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def test_mid_session_reregister():
+    # Spin up Server A and Server B on dynamic ports
+    server_a = HTTPServer(("localhost", 0), MockServerRequestHandler)
+    server_a.calls = []
+    thread_a = threading.Thread(target=server_a.serve_forever)
+    thread_a.daemon = True
+    thread_a.start()
+
+    server_b = HTTPServer(("localhost", 0), MockServerRequestHandler)
+    server_b.calls = []
+    thread_b = threading.Thread(target=server_b.serve_forever)
+    thread_b.daemon = True
+    thread_b.start()
+
+    url_a = f"http://localhost:{server_a.server_port}"
+    url_b = f"http://localhost:{server_b.server_port}"
+
+    # Setup the initial session on Server A
+    os.environ["COGNEE_SESSION_KEY"] = "test-session-key"
+    os.environ["COGNEE_BASE_URL"] = url_a
+    _plugin_common.mark_server_ready(url_a)
+
+    # Resolve initial status to make sure we're on Server A
+    resolved = _plugin_common.load_resolved()
+    assert resolved.get("base_url") == url_a
+
+    # Now change COGNEE_BASE_URL to Server B
+    os.environ["COGNEE_BASE_URL"] = url_b
+
+    # Mock subprocess.Popen and os.kill so we don't start real processes or kill things
+    with patch("subprocess.Popen") as mock_popen, patch("os.kill") as mock_kill:
+        mock_popen.return_value = MagicMock()
+
+        # Trigger load_resolved, which should detect the mismatch
+        resolved_new = _plugin_common.load_resolved()
+
+        # Assertions:
+        # 1. Base URL has switched to B
+        assert resolved_new.get("base_url") == url_b
+
+        # 2. server-ready.json was updated to url_b
+        assert _plugin_common._SERVER_READY_MARKER.exists()
+        ready_data = json.loads(_plugin_common._SERVER_READY_MARKER.read_text(encoding="utf-8"))
+        assert ready_data.get("base_url") == url_b
+
+        # 3. Server B received the registration and dataset requests
+        register_calls = [c for c in server_b.calls if c[1] == "/api/v1/agents/register"]
+        dataset_calls = [c for c in server_b.calls if c[1] == "/api/v1/datasets"]
+        assert len(register_calls) > 0
+        assert len(dataset_calls) > 0
+
+        # 4. Mock popen was called to restart watchers with B config
+        # (check that popen args contain B's url)
+        assert mock_popen.call_count >= 2
+        called_args = [call[0][0] for call in mock_popen.call_args_list]
+        called_envs = [call[1].get("env", {}) for call in mock_popen.call_args_list]
+
+        # Verify idle-watcher and exit-watcher arguments
+        assert any("idle-watcher.py" in str(arg) for arg in called_args)
+        assert any("exit-watcher.py" in str(arg) for arg in called_args)
+        assert any(url_b in str(env.get("COGNEE_BASE_URL")) for env in called_envs)
+
+    # Clean up mock servers
+    server_a.shutdown()
+    server_b.shutdown()
+    thread_a.join()
+    thread_b.join()
+
+
+if __name__ == "__main__":
+    try:
+        test_mid_session_reregister()
+        print("PASS test_mid_session_reregister")
+        sys.exit(0)
+    except AssertionError as e:
+        import traceback
+        traceback.print_exc()
+        print("FAIL test_mid_session_reregister")
+        sys.exit(1)

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -354,6 +354,380 @@ def _resolve_agent_name() -> str:
     return _normalize("codex-agent")
 
 
+def _login_default_user_via_http(service_url: str, config: dict) -> str:
+    base = _normalize_service_url(service_url)
+    email = config.get("user_email") or "default_user@example.com"
+    password = config.get("user_password") or "default_password"
+
+    params = urllib.parse.urlencode({"username": email, "password": password}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base}/api/v1/auth/login",
+        data=params,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10.0) as resp:
+            if resp.status != 200:
+                return ""
+            login_data = json.loads(resp.read().decode("utf-8"))
+            jwt = str(login_data.get("access_token", "") or "")
+    except Exception as exc:
+        hook_log("sync_login_failed", {"error": str(exc)[:200]})
+        return ""
+
+    if not jwt:
+        return ""
+
+    req_keys = urllib.request.Request(
+        f"{base}/api/v1/auth/api-keys",
+        headers={"Cookie": f"auth_token={jwt}"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req_keys, timeout=10.0) as resp:
+            if resp.status == 200:
+                keys = json.loads(resp.read().decode("utf-8"))
+                if isinstance(keys, list) and keys:
+                    key = str(keys[0].get("key", "") or "")
+                    if key:
+                        return key
+    except Exception:
+        pass
+
+    req_mint = urllib.request.Request(
+        f"{base}/api/v1/auth/api-keys",
+        data=json.dumps({"name": "claude-owner-bootstrap"}).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "Cookie": f"auth_token={jwt}"
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req_mint, timeout=10.0) as resp:
+            if resp.status == 200:
+                payload = json.loads(resp.read().decode("utf-8"))
+                return str(payload.get("key", "") or "")
+    except Exception as exc:
+        hook_log("sync_mint_failed", {"error": str(exc)[:200]})
+    return ""
+
+
+def _ensure_dataset_ready_via_http(service_url: str, api_key: str, dataset: str) -> None:
+    if not service_url or not api_key or not dataset:
+        return
+    base = service_url.rstrip("/")
+    headers = {
+        "Content-Type": "application/json",
+        "X-Api-Key": api_key,
+    }
+    payload = json.dumps({"name": dataset}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base}/api/v1/datasets",
+        data=payload,
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=15.0) as resp:
+        if resp.status not in (200, 201):
+            raise RuntimeError(f"remote dataset ensure failed ({resp.status})")
+
+
+def _find_parent_pid() -> int:
+    import subprocess
+    import re
+    fallback = os.getppid()
+    try:
+        raw = subprocess.check_output(
+            ["ps", "-axo", "pid=,ppid=,command="],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception as exc:
+        hook_log("find_parent_pid_failed", {"error": str(exc)[:200]})
+        return fallback
+
+    table: dict[int, tuple[int, str]] = {}
+    for line in raw.splitlines():
+        parts = line.strip().split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        table[pid] = (ppid, parts[2])
+
+    host_re = re.compile(r"(?:^|/)(?:claude|codex)(?:-[\w.]+)?(?:\s|$)")
+    pid = fallback
+    seen: set[int] = set()
+    while pid > 1 and pid not in seen:
+        seen.add(pid)
+        if pid not in table:
+            break
+        ppid, command = table[pid]
+        if command and host_re.search(command):
+            return pid
+        pid = ppid
+    return fallback
+
+
+def _spawn_idle_watcher_helper(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str):
+    import subprocess
+    if os.environ.get("COGNEE_IDLE_DISABLED", "").lower() in ("1", "true", "yes"):
+        return
+    _WATCHER_SCRIPT = Path(__file__).parent / "idle-watcher.py"
+    if not _WATCHER_SCRIPT.exists():
+        return
+    bootstrap = {
+        "session_id": session_id,
+        "dataset": dataset,
+        "session_key": session_key,
+        "config": {
+            "base_url": current_url,
+            "dataset": dataset,
+        },
+    }
+    log_path = _PLUGIN_DIR / "watcher.log"
+    try:
+        log_fh = log_path.open("a", encoding="utf-8")
+    except Exception:
+        log_fh = subprocess.DEVNULL
+    try:
+        env = os.environ.copy()
+        if session_key:
+            env["COGNEE_SESSION_KEY"] = session_key
+        env["COGNEE_BASE_URL"] = current_url
+        if api_key:
+            env["COGNEE_API_KEY"] = api_key
+        subprocess.Popen(
+            [sys.executable, str(_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            env=env,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except Exception as e:
+        hook_log("idle_watcher_restart_spawn_failed", {"error": str(e)[:300]})
+
+
+def _spawn_exit_watcher_helper(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str, parent_pid: int):
+    import subprocess
+    _EXIT_WATCHER_SCRIPT = Path(__file__).parent / "exit-watcher.py"
+    if not _EXIT_WATCHER_SCRIPT.exists():
+        return
+    bootstrap = {
+        "parent_pid": parent_pid,
+        "session_id": session_id,
+        "dataset": dataset,
+        "session_key": session_key,
+        "agent_session_name": conn_uuid,
+        "api_key": api_key,
+        "base_url": current_url,
+        "pidfile": str(_PLUGIN_DIR / "exit-watchers" / f"{parent_pid}.pid"),
+    }
+    log_path = _PLUGIN_DIR / "exit-watcher.log"
+    try:
+        log_fh = log_path.open("a", encoding="utf-8")
+    except Exception:
+        log_fh = subprocess.DEVNULL
+    try:
+        env = os.environ.copy()
+        if session_key:
+            env["COGNEE_SESSION_KEY"] = session_key
+        env["COGNEE_BASE_URL"] = current_url
+        if api_key:
+            env["COGNEE_API_KEY"] = api_key
+        subprocess.Popen(
+            [sys.executable, str(_EXIT_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=log_fh,
+            env=env,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except Exception as e:
+        hook_log("exit_watcher_restart_spawn_failed", {"error": str(e)[:300]})
+
+
+def _restart_watchers(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str):
+    # Kill idle watcher
+    watcher_pid_file = _PLUGIN_DIR / "watcher.pid"
+    if watcher_pid_file.exists():
+        try:
+            pid = int(watcher_pid_file.read_text(encoding="utf-8").strip())
+            os.kill(pid, 15) # SIGTERM
+        except Exception as exc:
+            hook_log("idle_watcher_kill_failed", {"error": str(exc)[:200]})
+
+    # Kill exit watcher
+    parent_pid = _find_parent_pid()
+    exit_pid_file = _PLUGIN_DIR / "exit-watchers" / f"{parent_pid}.pid"
+    if exit_pid_file.exists():
+        try:
+            pid = int(exit_pid_file.read_text(encoding="utf-8").strip())
+            os.kill(pid, 15) # SIGTERM
+        except Exception as exc:
+            hook_log("exit_watcher_kill_failed", {"error": str(exc)[:200]})
+
+    # Spawn idle watcher
+    _spawn_idle_watcher_helper(session_id, dataset, conn_uuid, api_key, current_url, session_key)
+
+    # Spawn exit watcher
+    _spawn_exit_watcher_helper(session_id, dataset, conn_uuid, api_key, current_url, session_key, parent_pid)
+
+
+def _do_re_registration(session_key: str, current_url: str, last_registered_url: str, resolved: dict, conn_uuid: str, cognee_session_id: str):
+    try:
+        from config import load_config, get_dataset
+        config = load_config()
+        dataset = get_dataset(config)
+    except Exception:
+        config = {}
+        dataset = "agent_sessions"
+
+    # Resolve credentials for the new URL
+    cached_old_key = ""
+    try:
+        key_data = _load_json_file(_API_KEY_CACHE)
+        if isinstance(key_data, dict):
+            cached_old_key = str(key_data.get("api_key") or "").strip()
+    except Exception:
+        pass
+
+    # If env key matches the old cached key, temporarily clear it
+    env_key = os.environ.get("COGNEE_API_KEY", "")
+    if env_key and cached_old_key and env_key == cached_old_key:
+        env_key = ""
+
+    new_api_key = load_cached_api_key(current_url)
+    if not new_api_key and env_key:
+        new_api_key = env_key
+
+    if not new_api_key:
+        # Perform sync login
+        new_api_key = _login_default_user_via_http(current_url, config)
+        if new_api_key:
+            save_cached_api_key(current_url, new_api_key)
+
+    # Set new key
+    if new_api_key:
+        os.environ["COGNEE_API_KEY"] = new_api_key
+        resolved["api_key"] = new_api_key
+
+    # 1. ensure dataset is ready via HTTP
+    try:
+        _ensure_dataset_ready_via_http(current_url, new_api_key, dataset)
+    except Exception as exc:
+        hook_log("dataset_ready_via_http_failed", {"error": str(exc)[:200]})
+        raise exc
+
+    # 2. Register agent via HTTP on new URL
+    reg_ok, registration = register_agent_via_http(
+        agent_session_name=conn_uuid,
+        session_id=cognee_session_id,
+        dataset_names=[dataset],
+    )
+
+    if reg_ok:
+        hook_log("re-registered_on_new_target", {
+            "base_url": current_url,
+            "agent_session_name": conn_uuid,
+            "session_id": cognee_session_id
+        })
+
+        # 3. Update server readiness marker
+        mark_server_ready(current_url)
+
+        # 4. Unregister agent on old URL best-effort
+        if cached_old_key:
+            old_env_url = os.environ.get("COGNEE_BASE_URL")
+            old_env_key = os.environ.get("COGNEE_API_KEY")
+            try:
+                os.environ["COGNEE_BASE_URL"] = last_registered_url
+                os.environ["COGNEE_API_KEY"] = cached_old_key
+                unregister_agent_via_http(agent_session_name=conn_uuid)
+            except Exception as exc:
+                hook_log("unregister_old_target_failed", {"error": str(exc)[:200]})
+            finally:
+                if old_env_url is not None:
+                    os.environ["COGNEE_BASE_URL"] = old_env_url
+                if old_env_key is not None:
+                    os.environ["COGNEE_API_KEY"] = old_env_key
+
+        # 5. Restart watchers
+        _restart_watchers(cognee_session_id, dataset, conn_uuid, new_api_key, current_url, session_key)
+    else:
+        raise RuntimeError("Agent registration failed on new target URL")
+
+
+def _resolve_url_mismatch(session_key: str, current_url: str, last_registered_url: str, resolved: dict, conn_uuid: str, cognee_session_id: str):
+    import time
+    lock_file = _PLUGIN_DIR / "reregister.lock"
+    timeout = 10.0
+    poll = 0.2
+    start_time = time.monotonic()
+    
+    while time.monotonic() - start_time < timeout:
+        # Check if mismatch is already resolved by another process
+        try:
+            if _SERVER_READY_MARKER.exists():
+                ready_data = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
+                marked_url = _normalize_service_url(ready_data.get("base_url", ""))
+                if marked_url == current_url:
+                    return
+        except Exception:
+            pass
+            
+        # Try to acquire lock
+        acquired = False
+        now = datetime.now(timezone.utc).timestamp()
+        if lock_file.exists():
+            try:
+                current = json.loads(lock_file.read_text(encoding="utf-8"))
+                pid = int(current.get("pid", 0))
+                created_at = float(current.get("created_at", 0))
+                pid_alive = False
+                if pid > 0:
+                    try:
+                        os.kill(pid, 0)
+                        pid_alive = True
+                    except ProcessLookupError:
+                        pid_alive = False
+                    except Exception:
+                        pid_alive = True
+                if not pid_alive or now - created_at > 60: # 1 min timeout
+                    try:
+                        lock_file.unlink()
+                    except Exception:
+                        pass
+            except Exception:
+                pass
+        try:
+            fd = os.open(str(lock_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump({"pid": os.getpid(), "created_at": now}, fh)
+            acquired = True
+        except FileExistsError:
+            time.sleep(poll)
+            continue
+            
+        if acquired:
+            try:
+                _do_re_registration(session_key, current_url, last_registered_url, resolved, conn_uuid, cognee_session_id)
+                return
+            finally:
+                try:
+                    lock_file.unlink()
+                except Exception:
+                    pass
+
+
 def load_resolved(session_key: str = "") -> dict:
     """Load runtime state from Cognee HTTP endpoints (no file cache)."""
     resolved: dict = {}
@@ -373,6 +747,21 @@ def load_resolved(session_key: str = "") -> dict:
     service_url = _local_api_url().strip()
     if service_url:
         resolved["base_url"] = service_url
+
+    last_registered_url = ""
+    if _SERVER_READY_MARKER.exists():
+        try:
+            ready_data = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
+            last_registered_url = _normalize_service_url(ready_data.get("base_url", ""))
+        except Exception:
+            pass
+
+    current_url = _normalize_service_url(service_url)
+    if last_registered_url and current_url and last_registered_url != current_url:
+        try:
+            _resolve_url_mismatch(active_session_key, current_url, last_registered_url, resolved, conn_uuid, cognee_session_id)
+        except Exception as exc:
+            hook_log("resolve_url_mismatch_failed", {"error": str(exc)[:200]})
 
     api_key = _api_key().strip()
     if api_key:

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -354,6 +354,15 @@ def _resolve_agent_name() -> str:
     return _normalize("codex-agent")
 
 
+# --- Mid-session target switch --------------------------------------------------
+# When COGNEE_BASE_URL changes after a session has started, the next interactive
+# hook notices the mismatch (resolved env URL vs the server-ready marker) and
+# re-registers this session's connection on the new target so recall and the
+# background writers follow it (gh #3544). Kept best-effort and off the hot path.
+_REREGISTER_COOLDOWN_SECONDS = 30
+_REREGISTER_LOCK_STALE_SECONDS = 120
+
+
 def _login_default_user_via_http(service_url: str, config: dict) -> str:
     """Mint (or reuse) the default-user API key on service_url over HTTP.
 
@@ -416,29 +425,11 @@ def _login_default_user_via_http(service_url: str, config: dict) -> str:
     return ""
 
 
-def _ensure_dataset_ready_via_http(service_url: str, api_key: str, dataset: str) -> None:
-    if not service_url or not api_key or not dataset:
-        return
-    base = service_url.rstrip("/")
-    headers = {
-        "Content-Type": "application/json",
-        "X-Api-Key": api_key,
-    }
-    payload = json.dumps({"name": dataset}).encode("utf-8")
-    req = urllib.request.Request(
-        f"{base}/api/v1/datasets",
-        data=payload,
-        headers=headers,
-        method="POST",
-    )
-    with urllib.request.urlopen(req, timeout=15.0) as resp:
-        if resp.status not in (200, 201):
-            raise RuntimeError(f"remote dataset ensure failed ({resp.status})")
-
-
 def _find_parent_pid() -> int:
-    import subprocess
+    """Nearest live claude/codex ancestor pid (the exit-watcher pidfile key)."""
     import re
+    import subprocess
+
     fallback = os.getppid()
     try:
         raw = subprocess.check_output(
@@ -476,36 +467,38 @@ def _find_parent_pid() -> int:
     return fallback
 
 
-def _spawn_idle_watcher_helper(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str):
+def _spawn_watcher(
+    *,
+    script_name: str,
+    bootstrap: dict,
+    current_url: str,
+    api_key: str,
+    session_key: str,
+    log_name: str,
+) -> None:
+    """Spawn a detached watcher script with its env pointed at the new target.
+
+    COGNEE_IN_WATCHER marks the child so its own load_resolved() never drives a
+    further re-registration (which would fight the interactive hooks)."""
     import subprocess
-    if os.environ.get("COGNEE_IDLE_DISABLED", "").lower() in ("1", "true", "yes"):
+
+    script = Path(__file__).parent / script_name
+    if not script.exists():
         return
-    _WATCHER_SCRIPT = Path(__file__).parent / "idle-watcher.py"
-    if not _WATCHER_SCRIPT.exists():
-        return
-    bootstrap = {
-        "session_id": session_id,
-        "dataset": dataset,
-        "session_key": session_key,
-        "config": {
-            "base_url": current_url,
-            "dataset": dataset,
-        },
-    }
-    log_path = _PLUGIN_DIR / "watcher.log"
     try:
-        log_fh = log_path.open("a", encoding="utf-8")
+        log_fh = (_PLUGIN_DIR / log_name).open("a", encoding="utf-8")
     except Exception:
         log_fh = subprocess.DEVNULL
+    env = os.environ.copy()
+    env["COGNEE_IN_WATCHER"] = "1"
+    env["COGNEE_BASE_URL"] = current_url
+    if session_key:
+        env["COGNEE_SESSION_KEY"] = session_key
+    if api_key:
+        env["COGNEE_API_KEY"] = api_key
     try:
-        env = os.environ.copy()
-        if session_key:
-            env["COGNEE_SESSION_KEY"] = session_key
-        env["COGNEE_BASE_URL"] = current_url
-        if api_key:
-            env["COGNEE_API_KEY"] = api_key
         subprocess.Popen(
-            [sys.executable, str(_WATCHER_SCRIPT), json.dumps(bootstrap)],
+            [sys.executable, str(script), json.dumps(bootstrap)],
             stdin=subprocess.DEVNULL,
             stdout=log_fh,
             stderr=log_fh,
@@ -513,221 +506,218 @@ def _spawn_idle_watcher_helper(session_id: str, dataset: str, conn_uuid: str, ap
             start_new_session=True,
             close_fds=True,
         )
-    except Exception as e:
-        hook_log("idle_watcher_restart_spawn_failed", {"error": str(e)[:300]})
+    except Exception as exc:
+        hook_log("watcher_restart_spawn_failed", {"script": script_name, "error": str(exc)[:200]})
+    finally:
+        if hasattr(log_fh, "close"):
+            try:
+                log_fh.close()
+            except Exception:
+                pass
 
 
-def _spawn_exit_watcher_helper(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str, parent_pid: int):
-    import subprocess
-    _EXIT_WATCHER_SCRIPT = Path(__file__).parent / "exit-watcher.py"
-    if not _EXIT_WATCHER_SCRIPT.exists():
-        return
-    bootstrap = {
-        "parent_pid": parent_pid,
-        "session_id": session_id,
-        "dataset": dataset,
-        "session_key": session_key,
-        "agent_session_name": conn_uuid,
-        "api_key": api_key,
-        "base_url": current_url,
-        "pidfile": str(_PLUGIN_DIR / "exit-watchers" / f"{parent_pid}.pid"),
-    }
-    log_path = _PLUGIN_DIR / "exit-watcher.log"
-    try:
-        log_fh = log_path.open("a", encoding="utf-8")
-    except Exception:
-        log_fh = subprocess.DEVNULL
-    try:
-        env = os.environ.copy()
-        if session_key:
-            env["COGNEE_SESSION_KEY"] = session_key
-        env["COGNEE_BASE_URL"] = current_url
-        if api_key:
-            env["COGNEE_API_KEY"] = api_key
-        subprocess.Popen(
-            [sys.executable, str(_EXIT_WATCHER_SCRIPT), json.dumps(bootstrap)],
-            stdin=subprocess.DEVNULL,
-            stdout=log_fh,
-            stderr=log_fh,
-            env=env,
-            start_new_session=True,
-            close_fds=True,
-        )
-    except Exception as e:
-        hook_log("exit_watcher_restart_spawn_failed", {"error": str(e)[:300]})
-
-
-def _restart_watchers(session_id: str, dataset: str, conn_uuid: str, api_key: str, current_url: str, session_key: str):
-    # Kill idle watcher
-    watcher_pid_file = _PLUGIN_DIR / "watcher.pid"
-    if watcher_pid_file.exists():
-        try:
-            pid = int(watcher_pid_file.read_text(encoding="utf-8").strip())
-            os.kill(pid, 15) # SIGTERM
-        except Exception as exc:
-            hook_log("idle_watcher_kill_failed", {"error": str(exc)[:200]})
-
-    # Kill exit watcher
+def _restart_watchers(
+    *,
+    session_id: str,
+    dataset: str,
+    conn_uuid: str,
+    api_key: str,
+    current_url: str,
+    session_key: str,
+) -> None:
+    """Stop and respawn the idle + exit watchers so background writes follow the
+    switch (they were spawned at SessionStart with the old URL in their env)."""
     parent_pid = _find_parent_pid()
-    exit_pid_file = _PLUGIN_DIR / "exit-watchers" / f"{parent_pid}.pid"
-    if exit_pid_file.exists():
+    exit_pidfile = _PLUGIN_DIR / "exit-watchers" / f"{parent_pid}.pid"
+    for pid_file in (_PLUGIN_DIR / "watcher.pid", exit_pidfile):
         try:
-            pid = int(exit_pid_file.read_text(encoding="utf-8").strip())
-            os.kill(pid, 15) # SIGTERM
+            if pid_file.exists():
+                os.kill(int(pid_file.read_text(encoding="utf-8").strip()), 15)  # SIGTERM
         except Exception as exc:
-            hook_log("exit_watcher_kill_failed", {"error": str(exc)[:200]})
+            hook_log("watcher_kill_failed", {"pid_file": str(pid_file), "error": str(exc)[:200]})
+    # Clear the exit-watcher pidfile (its respawn refuses while it names a live pid)
+    # and the idle-watcher stop sentinel (a leftover would exit the new watcher).
+    for stale in (exit_pidfile, _PLUGIN_DIR / "watcher.stop"):
+        try:
+            stale.unlink()
+        except Exception:
+            pass
 
-    # Spawn idle watcher
-    _spawn_idle_watcher_helper(session_id, dataset, conn_uuid, api_key, current_url, session_key)
+    if os.environ.get("COGNEE_IDLE_DISABLED", "").lower() not in ("1", "true", "yes"):
+        _spawn_watcher(
+            script_name="idle-watcher.py",
+            bootstrap={
+                "session_id": session_id,
+                "dataset": dataset,
+                "session_key": session_key,
+                "config": {"base_url": current_url, "dataset": dataset},
+            },
+            current_url=current_url,
+            api_key=api_key,
+            session_key=session_key,
+            log_name="watcher.log",
+        )
+    _spawn_watcher(
+        script_name="exit-watcher.py",
+        bootstrap={
+            "parent_pid": parent_pid,
+            "session_id": session_id,
+            "dataset": dataset,
+            "session_key": session_key,
+            "agent_session_name": conn_uuid,
+            "api_key": api_key,
+            "base_url": current_url,
+            "pidfile": str(exit_pidfile),
+        },
+        current_url=current_url,
+        api_key=api_key,
+        session_key=session_key,
+        log_name="exit-watcher.log",
+    )
 
-    # Spawn exit watcher
-    _spawn_exit_watcher_helper(session_id, dataset, conn_uuid, api_key, current_url, session_key, parent_pid)
 
+def _do_re_registration(
+    *, session_key: str, current_url: str, conn_uuid: str, cognee_session_id: str
+) -> bool:
+    """Register this session's connection on current_url. Returns True on success.
 
-def _do_re_registration(session_key: str, current_url: str, last_registered_url: str, resolved: dict, conn_uuid: str, cognee_session_id: str):
+    Credentials, dataset, and watchers are all re-pointed at the new target; the
+    old connection is left to the server's own agent-mode teardown."""
     try:
-        from config import load_config, get_dataset
+        from config import get_dataset, load_config
+
         config = load_config()
         dataset = get_dataset(config)
     except Exception:
-        config = {}
-        dataset = "agent_sessions"
+        config, dataset = {}, "agent_sessions"
 
-    # Resolve credentials for the new URL
+    # Resolve a key for the NEW target. api_key.json is keyed by base_url, so a key
+    # cached for the OLD target is not returned for current_url. An env key that only
+    # echoes that stale cached key is dropped (it belongs to the old server); a
+    # user-provided env key (e.g. Cognee Cloud) is kept. Else mint from the default
+    # local user.
     cached_old_key = ""
-    try:
-        key_data = _load_json_file(_API_KEY_CACHE)
-        if isinstance(key_data, dict):
-            cached_old_key = str(key_data.get("api_key") or "").strip()
-    except Exception:
-        pass
-
-    # If env key matches the old cached key, temporarily clear it
-    env_key = os.environ.get("COGNEE_API_KEY", "")
-    if env_key and cached_old_key and env_key == cached_old_key:
+    key_data = _load_json_file(_API_KEY_CACHE)
+    if isinstance(key_data, dict):
+        cached_old_key = str(key_data.get("api_key") or "").strip()
+    env_key = os.environ.get("COGNEE_API_KEY", "").strip()
+    if env_key and env_key == cached_old_key:
         env_key = ""
-
-    new_api_key = load_cached_api_key(current_url)
-    if not new_api_key and env_key:
-        new_api_key = env_key
-
+    new_api_key = load_cached_api_key(current_url) or env_key
     if not new_api_key:
-        # Perform sync login
         new_api_key = _login_default_user_via_http(current_url, config)
         if new_api_key:
             save_cached_api_key(current_url, new_api_key)
 
-    # Set new key
+    # Point the shared HTTP helpers at the new target: both ensure_dataset_via_http
+    # and register_agent_via_http resolve URL + key from the environment.
+    os.environ["COGNEE_BASE_URL"] = current_url
     if new_api_key:
         os.environ["COGNEE_API_KEY"] = new_api_key
-        resolved["api_key"] = new_api_key
 
-    # 1. ensure dataset is ready via HTTP
-    try:
-        _ensure_dataset_ready_via_http(current_url, new_api_key, dataset)
-    except Exception as exc:
-        hook_log("dataset_ready_via_http_failed", {"error": str(exc)[:200]})
-        raise exc
-
-    # 2. Register agent via HTTP on new URL
-    reg_ok, registration = register_agent_via_http(
-        agent_session_name=conn_uuid,
-        session_id=cognee_session_id,
-        dataset_names=[dataset],
+    ensure_dataset_via_http(dataset)
+    reg_ok, _ = register_agent_via_http(
+        agent_session_name=conn_uuid, session_id=cognee_session_id, dataset_names=[dataset]
     )
+    if not reg_ok:
+        hook_log("reregister_failed", {"base_url": current_url})
+        return False
 
-    if reg_ok:
-        hook_log("re-registered_on_new_target", {
-            "base_url": current_url,
-            "agent_session_name": conn_uuid,
-            "session_id": cognee_session_id
-        })
-
-        # 3. Update server readiness marker
-        mark_server_ready(current_url)
-
-        # 4. Unregister agent on old URL best-effort
-        if cached_old_key:
-            old_env_url = os.environ.get("COGNEE_BASE_URL")
-            old_env_key = os.environ.get("COGNEE_API_KEY")
-            try:
-                os.environ["COGNEE_BASE_URL"] = last_registered_url
-                os.environ["COGNEE_API_KEY"] = cached_old_key
-                unregister_agent_via_http(agent_session_name=conn_uuid)
-            except Exception as exc:
-                hook_log("unregister_old_target_failed", {"error": str(exc)[:200]})
-            finally:
-                if old_env_url is not None:
-                    os.environ["COGNEE_BASE_URL"] = old_env_url
-                if old_env_key is not None:
-                    os.environ["COGNEE_API_KEY"] = old_env_key
-
-        # 5. Restart watchers
-        _restart_watchers(cognee_session_id, dataset, conn_uuid, new_api_key, current_url, session_key)
-    else:
-        raise RuntimeError("Agent registration failed on new target URL")
+    hook_log(
+        "re-registered_on_new_target",
+        {"base_url": current_url, "agent_session_name": conn_uuid, "session_id": cognee_session_id},
+    )
+    # Marker last: only advertise the new target once the connection is on it.
+    mark_server_ready(current_url)
+    _restart_watchers(
+        session_id=cognee_session_id,
+        dataset=dataset,
+        conn_uuid=conn_uuid,
+        api_key=new_api_key,
+        current_url=current_url,
+        session_key=session_key,
+    )
+    return True
 
 
-def _resolve_url_mismatch(session_key: str, current_url: str, last_registered_url: str, resolved: dict, conn_uuid: str, cognee_session_id: str):
-    import time
+def _resolve_url_mismatch(
+    *, session_key: str, current_url: str, conn_uuid: str, cognee_session_id: str
+) -> None:
+    """Re-register on current_url after a mid-session switch. Best-effort and
+    non-blocking on the hot path:
+
+      - never runs inside the watcher daemons (they carry stale env);
+      - skips (with a short cooldown) when the new target is unreachable or a
+        recent attempt failed, so a down target can't stall every hook;
+      - takes the lock with a single non-blocking attempt — if another hook holds
+        it, return at once rather than spin.
+    """
+    if os.environ.get("COGNEE_IN_WATCHER") == "1":
+        return
+
+    now = datetime.now(timezone.utc).timestamp()
+    cooldown_file = _PLUGIN_DIR / "reregister-cooldown.json"
+    data = _load_json_file(cooldown_file)
+    if isinstance(data, dict) and now < float(data.get("until", 0) or 0):
+        return
+
+    if not server_health_ok(current_url, timeout=1.5):
+        _write_json_file(cooldown_file, {"until": now + _REREGISTER_COOLDOWN_SECONDS})
+        return
+
     lock_file = _PLUGIN_DIR / "reregister.lock"
-    timeout = 10.0
-    poll = 0.2
-    start_time = time.monotonic()
-    
-    while time.monotonic() - start_time < timeout:
-        # Check if mismatch is already resolved by another process
+    # Reclaim a lock left by a dead or long-stuck holder (mirrors the bootstrap
+    # single-flight reclaim).
+    if lock_file.exists():
         try:
-            if _SERVER_READY_MARKER.exists():
-                ready_data = json.loads(_SERVER_READY_MARKER.read_text(encoding="utf-8"))
-                marked_url = _normalize_service_url(ready_data.get("base_url", ""))
-                if marked_url == current_url:
-                    return
+            held = json.loads(lock_file.read_text(encoding="utf-8"))
+            pid = int(held.get("pid", 0) or 0)
+            created_at = float(held.get("created_at", 0) or 0)
+            alive = pid > 0
+            if pid > 0:
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    alive = False
+                except Exception:
+                    alive = True
+            if not alive or now - created_at > _REREGISTER_LOCK_STALE_SECONDS:
+                lock_file.unlink()
         except Exception:
             pass
-            
-        # Try to acquire lock
-        acquired = False
-        now = datetime.now(timezone.utc).timestamp()
-        if lock_file.exists():
+
+    try:
+        fd = os.open(str(lock_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        return  # another hook is already handling the switch
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"pid": os.getpid(), "created_at": now}, fh)
+        # A peer may have completed the switch between our check and the lock.
+        marker = _load_json_file(_SERVER_READY_MARKER)
+        marked = ""
+        if isinstance(marker, dict):
+            marked = _normalize_service_url(marker.get("base_url", ""))
+        if marked == current_url:
+            return
+        ok = _do_re_registration(
+            session_key=session_key,
+            current_url=current_url,
+            conn_uuid=conn_uuid,
+            cognee_session_id=cognee_session_id,
+        )
+        if ok:
             try:
-                current = json.loads(lock_file.read_text(encoding="utf-8"))
-                pid = int(current.get("pid", 0))
-                created_at = float(current.get("created_at", 0))
-                pid_alive = False
-                if pid > 0:
-                    try:
-                        os.kill(pid, 0)
-                        pid_alive = True
-                    except ProcessLookupError:
-                        pid_alive = False
-                    except Exception:
-                        pid_alive = True
-                if not pid_alive or now - created_at > 60: # 1 min timeout
-                    try:
-                        lock_file.unlink()
-                    except Exception:
-                        pass
+                cooldown_file.unlink()
             except Exception:
                 pass
+        else:
+            _write_json_file(cooldown_file, {"until": now + _REREGISTER_COOLDOWN_SECONDS})
+    finally:
         try:
-            fd = os.open(str(lock_file), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                json.dump({"pid": os.getpid(), "created_at": now}, fh)
-            acquired = True
-        except FileExistsError:
-            time.sleep(poll)
-            continue
-            
-        if acquired:
-            try:
-                _do_re_registration(session_key, current_url, last_registered_url, resolved, conn_uuid, cognee_session_id)
-                return
-            finally:
-                try:
-                    lock_file.unlink()
-                except Exception:
-                    pass
+            lock_file.unlink()
+        except Exception:
+            pass
 
 
 def load_resolved(session_key: str = "") -> dict:
@@ -761,7 +751,12 @@ def load_resolved(session_key: str = "") -> dict:
     current_url = _normalize_service_url(service_url)
     if last_registered_url and current_url and last_registered_url != current_url:
         try:
-            _resolve_url_mismatch(active_session_key, current_url, last_registered_url, resolved, conn_uuid, cognee_session_id)
+            _resolve_url_mismatch(
+                session_key=active_session_key,
+                current_url=current_url,
+                conn_uuid=conn_uuid,
+                cognee_session_id=cognee_session_id,
+            )
         except Exception as exc:
             hook_log("resolve_url_mismatch_failed", {"error": str(exc)[:200]})
 

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -355,6 +355,11 @@ def _resolve_agent_name() -> str:
 
 
 def _login_default_user_via_http(service_url: str, config: dict) -> str:
+    """Mint (or reuse) the default-user API key on service_url over HTTP.
+
+    Best-effort: returns "" on any failure so the caller can fall back or retry.
+    Sync sibling of session-start's async _login_default_user_for_owner_api_key;
+    it lives here because that one cannot be imported from this lower layer."""
     base = _normalize_service_url(service_url)
     email = config.get("user_email") or "default_user@example.com"
     password = config.get("user_password") or "default_password"
@@ -367,7 +372,7 @@ def _login_default_user_via_http(service_url: str, config: dict) -> str:
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=10.0) as resp:
+        with urllib.request.urlopen(req, timeout=10.0, context=_https_context()) as resp:
             if resp.status != 200:
                 return ""
             login_data = json.loads(resp.read().decode("utf-8"))
@@ -385,7 +390,7 @@ def _login_default_user_via_http(service_url: str, config: dict) -> str:
         method="GET",
     )
     try:
-        with urllib.request.urlopen(req_keys, timeout=10.0) as resp:
+        with urllib.request.urlopen(req_keys, timeout=10.0, context=_https_context()) as resp:
             if resp.status == 200:
                 keys = json.loads(resp.read().decode("utf-8"))
                 if isinstance(keys, list) and keys:
@@ -398,14 +403,11 @@ def _login_default_user_via_http(service_url: str, config: dict) -> str:
     req_mint = urllib.request.Request(
         f"{base}/api/v1/auth/api-keys",
         data=json.dumps({"name": "claude-owner-bootstrap"}).encode("utf-8"),
-        headers={
-            "Content-Type": "application/json",
-            "Cookie": f"auth_token={jwt}"
-        },
+        headers={"Content-Type": "application/json", "Cookie": f"auth_token={jwt}"},
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req_mint, timeout=10.0) as resp:
+        with urllib.request.urlopen(req_mint, timeout=10.0, context=_https_context()) as resp:
             if resp.status == 200:
                 payload = json.loads(resp.read().decode("utf-8"))
                 return str(payload.get("key", "") or "")

--- a/integrations/codex/tests/test_mid_session_reregister.py
+++ b/integrations/codex/tests/test_mid_session_reregister.py
@@ -1,0 +1,120 @@
+"""Codex mirror of the mid-session COGNEE_BASE_URL switch test (gh #3544).
+
+The re-registration block is byte-identical to claude-code's; this focused smoke
+test guards the codex-specific wiring (state dir, watcher script paths, imports).
+Standalone-runnable and pytest-discoverable; no cognee/network/LLM key needed.
+"""
+
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import patch
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "plugins" / "cognee" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+import _plugin_common  # noqa: E402
+
+
+class _MockHandler(BaseHTTPRequestHandler):
+    def log_message(self, *_):
+        pass
+
+    def _json(self, code, payload):
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(payload).encode("utf-8"))
+
+    def do_GET(self):
+        self.server.calls.append(("GET", self.path))
+        if self.path == "/health":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"OK")
+        elif self.path.startswith("/api/v1/users/me"):
+            self._json(200, {"id": "user_123"})
+        elif self.path.startswith("/api/v1/agents/connections/me"):
+            self._json(200, {"agent": {"agent_session_name": "conn", "status": "active"}})
+        elif self.path.startswith("/api/v1/auth/api-keys"):
+            self._json(200, [{"key": "minted_key"}])
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length) if length else b""
+        self.server.calls.append(("POST", self.path))
+        if self.path == "/api/v1/agents/register":
+            self._json(200, {"id": "conn_registered"})
+        elif self.path == "/api/v1/datasets":
+            self._json(201, {"name": "dataset_123"})
+        elif self.path == "/api/v1/auth/login":
+            self._json(200, {"access_token": "token_123"})
+        elif self.path == "/api/v1/auth/api-keys":
+            self._json(200, {"key": "minted_key"})
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def _start_server():
+    srv = HTTPServer(("localhost", 0), _MockHandler)
+    srv.calls = []
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, f"http://localhost:{srv.server_port}"
+
+
+def test_switch_registers_on_new_target():
+    saved_env = dict(os.environ)
+    tmp = pathlib.Path(tempfile.mkdtemp(prefix="cognee-reregister-codex-"))
+    _plugin_common._SHARED_PLUGIN_ROOT = tmp
+    _plugin_common._PLUGIN_DIR = tmp / "codex"
+    _plugin_common._PLUGIN_DIR.mkdir(parents=True, exist_ok=True)
+    _plugin_common._SERVER_READY_MARKER = tmp / "server-ready.json"
+    _plugin_common._API_KEY_CACHE = tmp / "api_key.json"
+    _plugin_common._HOOK_LOG = _plugin_common._PLUGIN_DIR / "hook.log"
+
+    srv_a, url_a = _start_server()
+    srv_b, url_b = _start_server()
+    with (
+        patch("subprocess.Popen"),
+        patch("os.kill"),
+        patch("subprocess.check_output", return_value=""),
+    ):
+        try:
+            os.environ["COGNEE_SESSION_KEY"] = "k"
+            os.environ["COGNEE_BASE_URL"] = url_a
+            _plugin_common.mark_server_ready(url_a)
+
+            os.environ["COGNEE_BASE_URL"] = url_b
+            _plugin_common.load_resolved()
+
+            assert any(c[1] == "/api/v1/agents/register" for c in srv_b.calls)
+            assert any(c[1] == "/api/v1/datasets" for c in srv_b.calls)
+            marker = json.loads(_plugin_common._SERVER_READY_MARKER.read_text())
+            assert marker["base_url"] == url_b
+            assert not any(c[1] == "/api/v1/agents/register" for c in srv_a.calls)
+        finally:
+            srv_a.shutdown()
+            srv_b.shutdown()
+            os.environ.clear()
+            os.environ.update(saved_env)
+
+
+if __name__ == "__main__":
+    try:
+        test_switch_registers_on_new_target()
+        print("PASS test_switch_registers_on_new_target")
+        sys.exit(0)
+    except AssertionError:
+        import traceback
+
+        traceback.print_exc()
+        print("FAIL test_switch_registers_on_new_target")
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Rework of community PR #192 (by @SaviPandey), closing topoteretes/cognee#3544 — "[integrations] Re-register agent session on mid-session mode change".

When `COGNEE_BASE_URL` changes after a session has started, the plugin must register this session's connection on the **new** target so recall and the background writers follow it, instead of silently staying bound to the old server. The author's approach — detect the mismatch in `load_resolved()`, then re-register on the new target — is kept. This rework makes it correct, hot-path-safe, and free of the duplication/gold-plating, and applies it identically to the claude-code and codex plugins.

The author's original commit is preserved as the base; each maintainer change is a separate single-concern commit on top.

Linear: SDK-212.

## What the change does

On every `load_resolved()`, the resolved `COGNEE_BASE_URL` is compared against the `server-ready.json` marker. On a mismatch, and only from an interactive hook (never the watcher daemons), the session is re-registered on the new target under a non-blocking file lock: resolve a key for the new target (URL-keyed cache → env → mint from the default local user), ensure the dataset, register the connection, advance the readiness marker, and restart the idle + exit watchers so background/exit writes follow the switch.

## Concerns found in #192 and how this rework addresses them

- **Dataset-ensure aborted the switch.** The added `_ensure_dataset_ready_via_http` duplicated the existing `ensure_dataset_via_http` but raised on any non-2xx and re-raised into the caller — so a "dataset already exists" (4xx) or a cloud redirect (307/308) aborted the whole re-registration, defeating the feature. → Reuse the existing redirect-tolerant helper; delete the duplicate.
- **Ran synchronously on the interactive hot path.** `load_resolved()` is called by UserPromptSubmit and other hooks; re-registration sat behind a 10s spin-lock with no health check, so a down/hung new target made every hook pay a multi-second login+dataset+register before failing, on every hook. → Gate on `server_health_ok(new_url)` first, add a short failure cooldown, and replace the spin-lock with a single non-blocking attempt (if another hook holds it, return immediately).
- **Login skipped TLS verification.** The login helper used `urlopen` without `_https_context()`, unlike every other HTTP call, breaking HTTPS/custom-CA endpoints. → Route all three login calls through `_https_context()`.
- **The idle-watcher could fight itself.** The idle-watcher daemon also calls `load_resolved()`; with its old env it could re-register back to the old URL and SIGTERM its own process. → Mark watcher-spawned processes with `COGNEE_IN_WATCHER=1` and skip re-registration when set. The watcher restart now also clears the exit-watcher pidfile and the idle stop-sentinel (otherwise the respawn is refused / exits at once) and closes the spawn log handle.
- **Out-of-scope code.** A best-effort old-target unregister (fragile `os.environ` swap, untested) and a dead `resolved["api_key"]` write were removed.
- **Duplication & lint.** The two watcher-spawn helpers are folded into one; the block is now `ruff`-clean (the original added 14 lint errors/file). The remaining login/parent-pid/watcher helpers are kept local — they can't be imported from `session-start.py` without a circular import, and refactoring that critical hook is out of scope for this issue.

## Commits

1. `feat(integrations): re-register agent session on mid-session URL change (#3544)` — original author commit, preserved.
2. `fix(integrations): send re-registration login over the shared TLS context`
3. `refactor(integrations): rework mid-session re-registration to reuse helpers and stay off the hot path`
4. `test(integrations): harden the mid-session switch test and add codex coverage`

## Verification

- `python3 integrations/claude-code/tests/test_mid_session_reregister.py` and `python3 integrations/codex/tests/test_mid_session_reregister.py` pass. The tests assert the connection lands on the **new** target (not the old), that a stale old-target key is never sent to the new server, and that an unreachable target is skipped; state is isolated per test and the environment is restored.
- `ruff format --check` + `ruff check` clean (line-length 100).
- No regressions in the plugins' other standalone tests. (`test_bridge_poll` / `test_improve_sync` fail identically on `main` — stale mocks that don't accept `context=` — and are unrelated to this change.)

## Out of scope

- Unregistering the old-target connection (left to the server's own agent-mode teardown).
- De-duplicating the login/parent-pid/watcher helpers shared with `session-start.py`.
- The unsupported case of pointing claude-code and codex at **different** servers simultaneously (contradicts the shared-local-server model; the shared readiness marker would ping-pong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)