### PR TITLE
fix(openclaw): clear abort timer on fetchAPI success path (SDK-215)

### DIFF
--- a/integrations/openclaw/__tests__/test_transportTimer.ts
+++ b/integrations/openclaw/__tests__/test_transportTimer.ts
@@ -1,0 +1,65 @@
+import { CogneeHttpClient } from "../src/client";
+
+// ---------------------------------------------------------------------------
+// Transport abort-timer hygiene.
+//
+// fetchAPI arms a per-request abort timer (setTimeout -> controller.abort()) to
+// bound each call. On the success path the timer must be cleared: a leaked,
+// still-armed timer keeps the Node event loop alive and delays process exit up
+// to timeoutMs. Only the error and 401-relogin paths cleared it before; this
+// pins the success path too.
+// ---------------------------------------------------------------------------
+
+let mockFetch: jest.Mock;
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  mockFetch = jest.fn();
+  (globalThis as unknown as { fetch: unknown }).fetch = mockFetch;
+});
+
+afterEach(() => {
+  (globalThis as unknown as { fetch: unknown }).fetch = originalFetch;
+  jest.restoreAllMocks();
+});
+
+// A minimal 2xx Response stand-in: fetchAPI only reads ok/status and .json().
+function httpOk(body: unknown = {}): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+// apiKey is set so ensureAuth() short-circuits without a login round-trip.
+function makeClient(): CogneeHttpClient {
+  return new CogneeHttpClient("http://test", "key");
+}
+
+describe("fetchAPI abort timer", () => {
+  it("clears the per-request timeout on the success path", async () => {
+    jest.useFakeTimers();
+    try {
+      const client = makeClient();
+      let signal: AbortSignal | undefined;
+      mockFetch.mockImplementation((_url: string, init: RequestInit) => {
+        signal = init.signal as AbortSignal;
+        return Promise.resolve(httpOk({ ok: true }));
+      });
+
+      // retries disabled so a single fetch settles the call.
+      await client.fetchAPI("/api/v1/x", { method: "GET" }, 5_000, undefined, 0);
+
+      // Timer was cleared: nothing left pending, and advancing well past the
+      // timeout never aborts the already-settled request.
+      expect(jest.getTimerCount()).toBe(0);
+      jest.advanceTimersByTime(60_000);
+      expect(signal?.aborted).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/integrations/openclaw/src/client.ts
+++ b/integrations/openclaw/src/client.ts
@@ -169,15 +169,15 @@ export class CogneeHttpClient {
           const errorText = await response.text();
           throw new Error(`Cognee request failed (${response.status}): ${errorText}`);
         }
-        // Honor responseParser on the success path too — parity with the
-        // 401-retry path above, which already returns responseParser(...).
-        // The `await` is load-bearing: it keeps a parser/body-read rejection
-        // (a mid-read AbortError, or a parse error) inside this try, so the
-        // catch still clears the timer and retries on abort. Clearing the timer
-        // on the resolve path is #264/SDK-215's scope, not this change's.
-        // visualise() passes a text parser to read the graph HTML the server
-        // returns; forcing response.json() here threw on every 200. (gh #195)
-        return await responseParser(response);
+        // Honor responseParser on the success path (gh #195, SDK-242) — the
+        // `await` is load-bearing: it keeps a parser/body-read rejection (a
+        // mid-read AbortError, or a parse error) inside this try so the catch
+        // still clears the timer and retries on abort. Then clear the abort
+        // timer on the resolve path too, so a leaked, still-armed timer doesn't
+        // hold the Node event loop open until timeoutMs (SDK-215).
+        const data = await responseParser(response);
+        clearTimeout(timer);
+        return data;
       } catch (error) {
         clearTimeout(timer);
         const isTimeout =


### PR DESCRIPTION
## Summary

Rework of community hackathon PR #184 (by @alishair7071) for gh issue [topoteretes/cognee#3545](https://github.com/topoteretes/cognee/issues/3545) — *"OpenClaw: circuit breaker + per-op timeouts in the TS client"*.

**The feature the issue asked for already shipped on `main`** in `4a8e99f` — a file-backed `RecallBreaker` (`src/breaker.ts`) shared with the claude-code/codex plugins, plus configurable `recallTimeoutMs` / `recallBudgetMs` / `recallBreakerThreshold` / `recallBreakerCooldownMs`. That satisfies every acceptance criterion in gh #3545, so PR #184's second, in-memory, all-ops breaker is redundant and is **not** re-introduced. Exactly one change in #184 is genuinely new and worth keeping — this PR salvages it.

## What ships

A single fix: **`CogneeHttpClient.fetchAPI` clears its per-request abort timer on the success path.**

`fetchAPI` arms `setTimeout(() => controller.abort(), timeoutMs)` to bound each request, but the resolve path returned the parsed body without clearing it — only the error and 401-relogin paths did. A still-armed, ref'd timer keeps the Node event loop alive, delaying process exit up to `timeoutMs` (60s default, 300s ingestion) after the last successful request.

Rebased onto current `main`, which now includes #267 (SDK-242) routing the success path through `responseParser`, so the salvage lands as:

```ts
const data = await responseParser(response);
clearTimeout(timer);   // ← this PR
return data;
```

Plus a focused regression test (`__tests__/test_transportTimer.ts`) that fails on the pre-fix code (leaked pending timer / late abort) and passes now.

## Commit shape

Rebased onto `origin/main`. #264's original history added an in-memory breaker (the two `@alishair7071` commits) and then reverted it (maintainer `chore`) — those three net to **zero** (the breaker they added is superseded by `main`'s `4a8e99f`, and the chore returned the tree to `main`), so the rebase drops them and keeps the **single salvage commit**. @alishair7071 is credited via the `Co-authored-by` trailer on that commit (the timer fix originated in #184); PR #184 is closed with thanks.

## Verification

Local, matching the `test-typescript` CI job (node 20):

- `npx tsc --noEmit` — clean (0 errors).
- `npx jest` — **8 suites, 81 tests pass**, including `test_transportTimer` (timer cleared on success) and, from `main`, `test_visualiseResponseParser` (SDK-242) — the two compose cleanly on the shared success-path line.

Net vs `main`: `client.ts` success path (the timer clear) + one new 65-line test. No new config, no second breaker.

Closes SDK-215. Related: gh #3545, community PR #184; adjacent #267 / SDK-242 (same line, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
