### PR TITLE
feat(integrations): shared session-id sanitization conformance across integrations (SDK-216)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,39 @@ jobs:
         working-directory: integrations/${{ matrix.integration }}
         run: npx tsc --noEmit --skipLibCheck
 
+  test-conformance:
+    # Session-id sanitization conformance across integrations (see
+    # integrations/conformance/). The four sanitizers live in different trees and
+    # languages, so this cross-cutting job checks each against the shared case
+    # table. It covers what the per-manifest matrix above misses: the claude-code
+    # and codex plugin trees (no pyproject.toml -> no test-python job) and openclaw
+    # (test-typescript only type-checks). hermes-agent's copy already runs in test-python.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Check claude-code and codex sanitizers
+        run: |
+          python3 integrations/claude-code/tests/test_session_id_conformance.py
+          python3 integrations/codex/tests/test_session_id_conformance.py
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Check openclaw sanitizer
+        working-directory: integrations/openclaw
+        run: |
+          npm install
+          npm test -- __tests__/test_session_id_conformance.ts
+
   # ── Advisory Claude Code review — pulls the private skill from cognee-ci at runtime ──
   # Rubric + Slack map live in the private cognee-ci repo; this job carries no review logic.
   # Runs after the integration tests settle (skips tolerated; never on a test failure),

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -98,9 +98,12 @@ apply_cognee_env()
 
 
 def _sanitize_session_key(value: str) -> str:
+    # ASCII-only allowed set [A-Za-z0-9-_.], to stay identical across integrations
+    # (including the TypeScript openclaw one). `isascii()` guards against unicode
+    # letters/digits that `isalnum()` would otherwise keep.
     safe = []
     for ch in str(value or ""):
-        if ch.isalnum() or ch in ("-", "_", "."):
+        if (ch.isascii() and ch.isalnum()) or ch in ("-", "_", "."):
             safe.append(ch)
         else:
             safe.append("_")

--- a/integrations/claude-code/tests/test_session_id_conformance.py
+++ b/integrations/claude-code/tests/test_session_id_conformance.py
@@ -1,0 +1,45 @@
+"""Conformance test: claude-code session-id sanitization matches the shared spec.
+
+Loads the shared case table in integrations/conformance/session_id_cases.json
+(the same table the codex, hermes-agent and openclaw tests use) and checks the
+claude-code sanitizer against it. If any implementation drifts from the shared
+rule, its test fails.
+
+Run: python integrations/claude-code/tests/test_session_id_conformance.py (or via pytest).
+"""
+
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+
+def _load_cases():
+    root = next(p for p in pathlib.Path(__file__).resolve().parents if p.name == "integrations")
+    text = (root / "conformance" / "session_id_cases.json").read_text(encoding="utf-8")
+    return json.loads(text)
+
+
+def test_sanitizer_matches_shared_table():
+    mismatches = []
+    for case in _load_cases():
+        result = pc._sanitize_session_key(case["input"])
+        if result != case["expected"]:
+            mismatches.append(f"{case['input']!r} -> {result!r}, expected {case['expected']!r}")
+    assert not mismatches, "session-id sanitization drift:\n" + "\n".join(mismatches)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -99,9 +99,12 @@ apply_cognee_env()
 
 
 def _sanitize_session_key(value: str) -> str:
+    # ASCII-only allowed set [A-Za-z0-9-_.], to stay identical across integrations
+    # (including the TypeScript openclaw one). `isascii()` guards against unicode
+    # letters/digits that `isalnum()` would otherwise keep.
     safe = []
     for ch in str(value or ""):
-        if ch.isalnum() or ch in ("-", "_", "."):
+        if (ch.isascii() and ch.isalnum()) or ch in ("-", "_", "."):
             safe.append(ch)
         else:
             safe.append("_")

--- a/integrations/codex/plugins/cognee/tests/test_session_id_conformance.py
+++ b/integrations/codex/plugins/cognee/tests/test_session_id_conformance.py
@@ -1,0 +1,45 @@
+"""Conformance test: codex session-id sanitization matches the shared spec.
+
+Loads the shared case table in integrations/conformance/session_id_cases.json
+(the same table the claude-code, hermes-agent and openclaw tests use) and checks
+the codex sanitizer against it. If any implementation drifts from the shared
+rule, its test fails.
+
+Run: python integrations/codex/plugins/cognee/tests/test_session_id_conformance.py (or via pytest).
+"""
+
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+
+def _load_cases():
+    root = next(p for p in pathlib.Path(__file__).resolve().parents if p.name == "integrations")
+    text = (root / "conformance" / "session_id_cases.json").read_text(encoding="utf-8")
+    return json.loads(text)
+
+
+def test_sanitizer_matches_shared_table():
+    mismatches = []
+    for case in _load_cases():
+        result = pc._sanitize_session_key(case["input"])
+        if result != case["expected"]:
+            mismatches.append(f"{case['input']!r} -> {result!r}, expected {case['expected']!r}")
+    assert not mismatches, "session-id sanitization drift:\n" + "\n".join(mismatches)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/tests/test_session_id_conformance.py
+++ b/integrations/codex/tests/test_session_id_conformance.py
@@ -5,14 +5,16 @@ Loads the shared case table in integrations/conformance/session_id_cases.json
 the codex sanitizer against it. If any implementation drifts from the shared
 rule, its test fails.
 
-Run: python integrations/codex/plugins/cognee/tests/test_session_id_conformance.py (or via pytest).
+Run: python integrations/codex/tests/test_session_id_conformance.py (or via pytest).
 """
 
 import json
 import pathlib
 import sys
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+sys.path.insert(
+    0, str(pathlib.Path(__file__).resolve().parents[1] / "plugins" / "cognee" / "scripts")
+)
 
 import _plugin_common as pc  # noqa: E402
 

--- a/integrations/conformance/README.md
+++ b/integrations/conformance/README.md
@@ -14,7 +14,7 @@ list of `{ "input", "expected", "note" }` cases. Each integration has a small
 test that loads this file and checks its own sanitizer against it:
 
 - claude-code: `integrations/claude-code/tests/test_session_id_conformance.py`
-- codex: `integrations/codex/plugins/cognee/tests/test_session_id_conformance.py`
+- codex: `integrations/codex/tests/test_session_id_conformance.py`
 - hermes-agent: `integrations/hermes-agent/tests/test_session_id_conformance.py`
 - openclaw: `integrations/openclaw/__tests__/test_session_id_conformance.ts`
 

--- a/integrations/conformance/README.md
+++ b/integrations/conformance/README.md
@@ -19,7 +19,10 @@ test that loads this file and checks its own sanitizer against it:
 - openclaw: `integrations/openclaw/__tests__/test_session_id_conformance.ts`
 
 Because every test reads the same file, any implementation that drifts from the
-rule fails its test.
+rule fails its test. CI runs all four on every pull request: hermes-agent via
+the `test-python` job (it has a `pyproject.toml`), and claude-code, codex and
+openclaw via the dedicated `test-conformance` job in
+`.github/workflows/ci.yml`.
 
 ## Note on empty results
 

--- a/integrations/conformance/README.md
+++ b/integrations/conformance/README.md
@@ -1,0 +1,29 @@
+# Session id sanitization conformance
+
+Every Cognee integration turns a native session id into a Cognee session id with
+the same shape: `{agent}_{native_id}`. Before the native id is used, each
+integration runs it through a small sanitizer. The rule is:
+
+- Keep only the ASCII set `[A-Za-z0-9-_.]`.
+- Replace every other character with `_`.
+- Trim leading and trailing `.` and `_`.
+- Cap the length at 120 characters.
+
+`session_id_cases.json` is the single source of truth for that rule. It is a
+list of `{ "input", "expected", "note" }` cases. Each integration has a small
+test that loads this file and checks its own sanitizer against it:
+
+- claude-code: `integrations/claude-code/tests/test_session_id_conformance.py`
+- codex: `integrations/codex/plugins/cognee/tests/test_session_id_conformance.py`
+- hermes-agent: `integrations/hermes-agent/tests/test_session_id_conformance.py`
+- openclaw: `integrations/openclaw/__tests__/test_session_id_conformance.ts`
+
+Because every test reads the same file, any implementation that drifts from the
+rule fails its test.
+
+## Note on empty results
+
+The table only holds inputs whose sanitized output is not empty. hermes-agent
+returns `"session"` when the result would be empty, while the others return an
+empty string. That one case is left out on purpose so the shared table stays
+identical for all four integrations.

--- a/integrations/conformance/session_id_cases.json
+++ b/integrations/conformance/session_id_cases.json
@@ -1,0 +1,57 @@
+[
+  {
+    "input": "claude_session-01.log",
+    "expected": "claude_session-01.log",
+    "note": "allowed set passes through unchanged"
+  },
+  {
+    "input": "hello world",
+    "expected": "hello_world",
+    "note": "space becomes underscore"
+  },
+  {
+    "input": "a/b\\c:d",
+    "expected": "a_b_c_d",
+    "note": "path separators and colon become underscores"
+  },
+  {
+    "input": "__lead_and_trail__",
+    "expected": "lead_and_trail",
+    "note": "leading and trailing underscores are trimmed"
+  },
+  {
+    "input": "...dots...",
+    "expected": "dots",
+    "note": "leading and trailing dots are trimmed"
+  },
+  {
+    "input": "@@@leading",
+    "expected": "leading",
+    "note": "leading run of disallowed chars is trimmed after replacement"
+  },
+  {
+    "input": "naïve",
+    "expected": "na_ve",
+    "note": "unicode letter is not in the ASCII set, becomes underscore"
+  },
+  {
+    "input": "tab\tnl\n",
+    "expected": "tab_nl",
+    "note": "control chars become underscores, trailing one is trimmed"
+  },
+  {
+    "input": "3.14_pi",
+    "expected": "3.14_pi",
+    "note": "digits, dot and underscore are kept"
+  },
+  {
+    "input": "550e8400-e29b-41d4-a716-446655440000",
+    "expected": "550e8400-e29b-41d4-a716-446655440000",
+    "note": "a real UUID stays intact"
+  },
+  {
+    "input": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "expected": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "note": "length is capped at 120 characters"
+  }
+]

--- a/integrations/conformance/session_id_cases.json
+++ b/integrations/conformance/session_id_cases.json
@@ -53,5 +53,20 @@
     "input": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     "expected": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     "note": "length is capped at 120 characters"
+  },
+  {
+    "input": "a٣b",
+    "expected": "a_b",
+    "note": "non-ASCII unicode digit is rejected by the isascii guard, becomes underscore"
+  },
+  {
+    "input": "a😀b",
+    "expected": "a_b",
+    "note": "astral/emoji code point becomes a single underscore, pinning code-point iteration"
+  },
+  {
+    "input": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_bbbbbbbbbb",
+    "expected": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_",
+    "note": "trailing trim happens before the 120-char cap, so a boundary underscore is kept"
   }
 ]

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -82,9 +82,14 @@ def _has_cognee() -> bool:
 def _safe_session_component(value: str) -> str:
     # Sanitization kept consistent with the other integrations' session-id helpers
     # (claude-code/codex `_sanitize_session_key`, openclaw `sanitizeSessionKey`):
-    # keep alphanumerics plus `-` `_` `.`, replace others with `_`, trim `._` ends,
-    # cap length at 120.
-    safe = "".join(ch if ch.isalnum() or ch in ("-", "_", ".") else "_" for ch in value)
+    # keep the ASCII set [A-Za-z0-9-_.], replace others with `_`, trim `._` ends,
+    # cap length at 120. `isascii()` guards against unicode letters/digits that
+    # `isalnum()` would otherwise keep. The trailing `or "session"` fallback is
+    # intentional and hermes-specific, so empty-output cases are excluded from the
+    # shared conformance table.
+    safe = "".join(
+        ch if (ch.isascii() and ch.isalnum()) or ch in ("-", "_", ".") else "_" for ch in value
+    )
     return safe.strip("._")[:120] or "session"
 
 

--- a/integrations/hermes-agent/tests/test_session_id_conformance.py
+++ b/integrations/hermes-agent/tests/test_session_id_conformance.py
@@ -1,0 +1,31 @@
+"""Conformance test: hermes-agent session-id sanitization matches the shared spec.
+
+Loads the shared case table in integrations/conformance/session_id_cases.json
+(the same table the claude-code, codex and openclaw tests use) and checks the
+hermes-agent sanitizer against it. If any implementation drifts from the shared
+rule, its test fails.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _load_cases():
+    root = next(p for p in Path(__file__).resolve().parents if p.name == "integrations")
+    return json.loads((root / "conformance" / "session_id_cases.json").read_text(encoding="utf-8"))
+
+
+def test_sanitizer_matches_shared_table():
+    from cognee_integration_hermes.provider import _safe_session_component
+
+    mismatches = []
+    for case in _load_cases():
+        result = _safe_session_component(case["input"])
+        if result != case["expected"]:
+            mismatches.append(f"{case['input']!r} -> {result!r}, expected {case['expected']!r}")
+    assert not mismatches, "session-id sanitization drift:\n" + "\n".join(mismatches)

--- a/integrations/openclaw/__tests__/test_session_id_conformance.ts
+++ b/integrations/openclaw/__tests__/test_session_id_conformance.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { sanitizeSessionKey } from "../src/scope";
+
+type SanitizeCase = { input: string; expected: string; note: string };
+
+// The shared case table lives at integrations/conformance/session_id_cases.json.
+// The claude-code, codex and hermes-agent tests read the same file, so any
+// implementation that drifts from the shared rule fails its test.
+const casesPath = resolve(__dirname, "..", "..", "conformance", "session_id_cases.json");
+const cases: SanitizeCase[] = JSON.parse(readFileSync(casesPath, "utf-8"));
+
+describe("session-id sanitization conformance", () => {
+  it.each(cases)("$note", ({ input, expected }) => {
+    expect(sanitizeSessionKey(input)).toBe(expected);
+  });
+});

--- a/integrations/openclaw/src/scope.ts
+++ b/integrations/openclaw/src/scope.ts
@@ -127,7 +127,7 @@ export function normalizeAgentId(agentId: string | undefined, cfg: Required<Cogn
  * (`_sanitize_session_key`): keep alphanumerics plus `-` `_` `.`, replace anything
  * else with `_`, trim leading/trailing `.`/`_`, and cap length at 120.
  */
-function sanitizeSessionKey(value: string): string {
+export function sanitizeSessionKey(value: string): string {
   let safe = "";
   for (const ch of value) safe += /[A-Za-z0-9\-_.]/.test(ch) ? ch : "_";
   return safe.replace(/^[._]+/, "").replace(/[._]+$/, "").slice(0, 120);


### PR DESCRIPTION
Reworks community PR #174 by @zainAwan9175 for hackathon issue topoteretes/cognee#3548. The original commit is preserved as the base (authorship intact); maintainer improvements are layered on top as separate single-concern commits. Linear: SDK-216.

## Problem

Every integration turns a native id into a Cognee session id with the same shape, `{agent}_{native_id}`, running the native id through a small sanitizer first. Those sanitizers had drifted: the Python helpers (claude-code, codex, hermes-agent) used `isalnum()`, which keeps unicode letters/digits (`é`, `ñ`, `中`, `٣`), while the openclaw TypeScript helper used the ASCII regex `[A-Za-z0-9-_.]`. So the same native id produced a **different** Cognee session id depending on which tool handled it (`naïve` → `naïve` vs `na_ve`), breaking cross-tool memory scoping.

## Change (author)

- Align the three Python sanitizers to the ASCII allowlist: `(ch.isascii() and ch.isalnum())` is exactly the TS regex's `[A-Za-z0-9]`, so all four converge on one rule with a one-token change.
- Add `integrations/conformance/session_id_cases.json` as the single source of truth, plus a short README.
- Add one small conformance test per integration (claude-code, codex, hermes-agent, openclaw) that loads the shared table and checks its own sanitizer.

## Maintainer improvements (separate commits on top)

1. **fix(codex):** the conformance test was placed under a brand-new `integrations/codex/plugins/cognee/tests/`, but every other codex test lives in `integrations/codex/tests/` (and CI's `pytest tests/` only collects that dir). Moved it there and switched its `sys.path` to the established `parents[1]/"plugins"/"cognee"/"scripts"` idiom.
2. **test(conformance):** added three cases the table was missing — a non-ASCII unicode **digit** (`a٣b` → `a_b`, the exact input the `isascii()` guard rejects), an astral/emoji code point (`a😀b` → `a_b`, pinning code-point iteration across Python/TS), and a trim-before-cap boundary (`119×a + "_" + 10×b` → `119×a + "_"`, pinning trim-then-cap ordering). All pass identically across the four sanitizers.
3. **ci:** only hermes-agent's conformance test actually ran in CI (`test-python` is gated on a `pyproject.toml`, which the claude-code/codex plugin trees do not have by design; `test-typescript` only runs `tsc --noEmit`). Added a small cross-cutting `test-conformance` job that runs the claude-code + codex tests (stdlib-only `python3`) and the openclaw jest test, so every PR enforces the shared table for all four. No manifests were added to the plugin trees.

## Verification

All four suites pass locally: `python3` for claude-code + codex, `uv run pytest tests/` for hermes-agent, `npm test` (jest, 14 cases) for openclaw. `ruff format --check` + `ruff check` clean at line-length 100. The new `test-conformance` job's commands were validated locally, and the existing `test_session_id.py` still passes.

## Behavior note

Narrowing the Python sanitizers to ASCII means a non-ASCII `COGNEE_SESSION_ID` or `COGNEE_SESSION_PREFIX` normalizes to ASCII once at upgrade (`café_x` → `caf__x`). This is exactly the rule the issue mandates, and the affected population is small (host session ids are ASCII UUIDs).

Resolves topoteretes/cognee#3548.
