### PR TITLE
fix(integrations): make the cognee-memory exit-watcher fire on Windows (SDK-238)

### DIFF
--- a/.github/workflows/plugin-windows-tests.yml
+++ b/.github/workflows/plugin-windows-tests.yml
@@ -1,0 +1,38 @@
+name: Plugin Windows Tests
+
+# The claude-code and codex plugins ship platform-specific process helpers
+# (_proc.py: Windows liveness via OpenProcess/WaitForSingleObject, process
+# ancestry via CreateToolhelp32Snapshot). Those paths never run on the
+# ubuntu-only integration matrix, so exercise them on a real Windows runner.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'integrations/claude-code/**'
+      - 'integrations/codex/**'
+      - '.github/workflows/plugin-windows-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'integrations/claude-code/**'
+      - 'integrations/codex/**'
+      - '.github/workflows/plugin-windows-tests.yml'
+
+jobs:
+  test-plugins-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: claude-code process-helper tests
+        run: python integrations/claude-code/tests/test_proc.py
+
+      - name: codex process-helper tests
+        run: python integrations/codex/tests/test_proc.py

--- a/.github/workflows/plugin-windows-tests.yml
+++ b/.github/workflows/plugin-windows-tests.yml
@@ -23,8 +23,18 @@ jobs:
   test-plugins-windows:
     runs-on: windows-latest
     steps:
+      # The repo has deeply-nested committed artifacts (n8n_workflows LanceDB
+      # files) whose paths exceed Windows' MAX_PATH; sparse-checkout the plugin
+      # trees this job needs and allow long paths so checkout cannot break.
+      - name: Allow long paths for checkout
+        run: git config --global core.longpaths true
+
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            integrations/claude-code
+            integrations/codex
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -20,6 +20,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+import _proc
+
 _PLUGIN_DIR = Path.home() / ".cognee-plugin" / "claude-code"
 _SHARED_PLUGIN_ROOT = Path.home() / ".cognee-plugin"
 _HOOK_LOG = _PLUGIN_DIR / "hook.log"
@@ -913,13 +915,7 @@ def sync_lock(owner: str):
                 pid = 0
             pid_alive = False
             if pid > 0:
-                try:
-                    os.kill(pid, 0)
-                    pid_alive = True
-                except PermissionError:
-                    pid_alive = True
-                except OSError:
-                    pid_alive = False
+                pid_alive = _proc.pid_alive(pid)
             if not pid_alive or now - created_at > SYNC_LOCK_STALE_SECONDS:
                 try:
                     _SYNC_LOCK.unlink()

--- a/integrations/claude-code/scripts/_proc.py
+++ b/integrations/claude-code/scripts/_proc.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Cross-platform process helpers for the cognee-memory plugin scripts.
+
+Kept stdlib-only so the detached watchers can import it without pulling in the
+rest of the plugin. The plugin decides a session has ended by polling the host
+(Claude/Codex) PID; the POSIX ``os.kill(pid, 0)`` liveness probe is unsupported
+on Windows, where signal 0 raises ``OSError`` (``WinError 87``), so the check
+needs a native Windows path.
+"""
+
+import os
+import sys
+
+_IS_WINDOWS = sys.platform == "win32"
+
+
+def pid_alive(pid: int) -> bool:
+    """Return ``True`` if a process with ``pid`` is currently running.
+
+    Non-destructive on every platform: it never signals or terminates the
+    target. PIDs <= 1 (unknown / init / kernel) are reported not-alive so the
+    watchers never bind to them.
+    """
+    if pid <= 1:
+        return False
+    if _IS_WINDOWS:
+        return _pid_alive_windows(pid)
+    return _pid_alive_posix(pid)
+
+
+def _pid_alive_posix(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists, owned by another user — still alive from our point of view.
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _pid_alive_windows(pid: int) -> bool:
+    # ``os.kill(pid, 0)`` raises WinError 87 here (signal 0 is unsupported), so
+    # probe via a process handle instead. OpenProcess fails with
+    # ERROR_ACCESS_DENIED for a live process we may not synchronise on (e.g. a
+    # system process); an open handle is non-signalled (WAIT_TIMEOUT) while an
+    # exited process signals immediately.
+    import ctypes
+    from ctypes import wintypes
+
+    SYNCHRONIZE = 0x00100000
+    WAIT_TIMEOUT = 0x00000102
+    ERROR_ACCESS_DENIED = 5
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+
+    handle = kernel32.OpenProcess(SYNCHRONIZE, False, pid)
+    if not handle:
+        return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+    try:
+        return kernel32.WaitForSingleObject(handle, 0) == WAIT_TIMEOUT
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def find_host_ancestor_windows(start_pid: int, host_stem: str) -> int:
+    """Nearest ancestor of ``start_pid`` whose executable base name is ``host_stem``
+    (e.g. "claude" / "codex"), found by walking the Windows process tree.
+
+    Returns ``start_pid`` unchanged when the process table cannot be read or no
+    matching ancestor is found, so the caller keeps its existing fallback. Used
+    where POSIX shells out to ``ps``, which does not exist on Windows.
+    """
+    return _walk_ancestors(_process_table_windows(), start_pid, host_stem)
+
+
+def _matches_host_exe(exe: str, host_stem: str) -> bool:
+    base = os.path.splitext(exe)[0].casefold()
+    stem = host_stem.casefold()
+    return base == stem or base.startswith(stem + "-")
+
+
+def _walk_ancestors(table: dict[int, tuple[int, str]], start_pid: int, host_stem: str) -> int:
+    pid = start_pid
+    seen: set[int] = set()
+    while pid > 1 and pid not in seen:
+        seen.add(pid)
+        ppid, exe = table.get(pid, (0, ""))
+        if exe and _matches_host_exe(exe, host_stem):
+            return pid
+        pid = ppid
+    return start_pid
+
+
+def _process_table_windows() -> dict[int, tuple[int, str]]:
+    """``{pid: (ppid, exe_basename)}`` for every process via Toolhelp; ``{}`` on failure."""
+    import ctypes
+    from ctypes import wintypes
+
+    TH32CS_SNAPPROCESS = 0x00000002
+    INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+    MAX_PATH = 260
+
+    class PROCESSENTRY32W(ctypes.Structure):
+        # ``th32DefaultHeapID`` is a pointer-sized ULONG_PTR: it must stay
+        # pointer-wide so the fields after it keep the right offsets on 64-bit.
+        _fields_ = (
+            ("dwSize", wintypes.DWORD),
+            ("cntUsage", wintypes.DWORD),
+            ("th32ProcessID", wintypes.DWORD),
+            ("th32DefaultHeapID", ctypes.c_void_p),
+            ("th32ModuleID", wintypes.DWORD),
+            ("cntThreads", wintypes.DWORD),
+            ("th32ParentProcessID", wintypes.DWORD),
+            ("pcPriClassBase", ctypes.c_long),
+            ("dwFlags", wintypes.DWORD),
+            ("szExeFile", ctypes.c_wchar * MAX_PATH),
+        )
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+    kernel32.CreateToolhelp32Snapshot.argtypes = (wintypes.DWORD, wintypes.DWORD)
+    kernel32.Process32FirstW.argtypes = (wintypes.HANDLE, ctypes.POINTER(PROCESSENTRY32W))
+    kernel32.Process32NextW.argtypes = (wintypes.HANDLE, ctypes.POINTER(PROCESSENTRY32W))
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+
+    snapshot = kernel32.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+    if not snapshot or snapshot == INVALID_HANDLE_VALUE:
+        return {}
+
+    table: dict[int, tuple[int, str]] = {}
+    try:
+        entry = PROCESSENTRY32W()
+        entry.dwSize = ctypes.sizeof(PROCESSENTRY32W)
+        ok = kernel32.Process32FirstW(snapshot, ctypes.byref(entry))
+        while ok:
+            table[int(entry.th32ProcessID)] = (int(entry.th32ParentProcessID), entry.szExeFile)
+            ok = kernel32.Process32NextW(snapshot, ctypes.byref(entry))
+    finally:
+        kernel32.CloseHandle(snapshot)
+    return table

--- a/integrations/claude-code/scripts/_proc.py
+++ b/integrations/claude-code/scripts/_proc.py
@@ -36,7 +36,9 @@ def _pid_alive_posix(pid: int) -> bool:
     except PermissionError:
         # Exists, owned by another user — still alive from our point of view.
         return True
-    except OSError:
+    except Exception:
+        # Any other failure (e.g. an out-of-range PID from a corrupt pidfile)
+        # counts as not-alive — a liveness probe must never raise into a hook.
         return False
     return True
 

--- a/integrations/claude-code/scripts/_proc.py
+++ b/integrations/claude-code/scripts/_proc.py
@@ -44,6 +44,10 @@ def _pid_alive_posix(pid: int) -> bool:
 
 
 def _pid_alive_windows(pid: int) -> bool:
+    if pid > 0xFFFFFFFF:
+        # A Windows PID is a DWORD; a larger value (e.g. from a corrupt pidfile)
+        # is not a real process and would otherwise truncate into DWORD range.
+        return False
     # ``os.kill(pid, 0)`` raises WinError 87 here (signal 0 is unsupported), so
     # probe via a process handle instead. OpenProcess fails with
     # ERROR_ACCESS_DENIED for a live process we may not synchronise on (e.g. a

--- a/integrations/claude-code/scripts/exit-watcher.py
+++ b/integrations/claude-code/scripts/exit-watcher.py
@@ -14,6 +14,9 @@ import sys
 import time
 from pathlib import Path
 
+sys.path.insert(0, os.path.dirname(__file__))
+from _proc import pid_alive as _pid_alive
+
 _PLUGIN_DIR = Path.home() / ".cognee-plugin" / "claude-code"
 _EXIT_WATCHERS_DIR = _PLUGIN_DIR / "exit-watchers"
 _PIDFILE = _PLUGIN_DIR / "exit-watcher.pid"
@@ -34,21 +37,6 @@ def _log(event: str, **detail) -> None:
             fh.write(json.dumps(line, default=str) + "\n")
     except Exception:
         pass
-
-
-def _pid_alive(pid: int) -> bool:
-    if pid <= 1:
-        return False
-    try:
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except Exception as exc:
-        _log("pid_alive_check_failed", parent_pid=pid, error=str(exc)[:200])
-        return False
 
 
 def _owns_pidfile(pidfile: Path) -> bool:

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -46,6 +46,7 @@ from _plugin_common import (
     set_session_key,
     touch_activity,
 )
+from _proc import find_host_ancestor_windows
 from _proc import pid_alive as _pid_alive
 from config import (
     _cloud_http_request,
@@ -668,6 +669,8 @@ def _spawn_idle_watcher(
 def _find_claude_parent_pid() -> int:
     """Find the nearest live Claude ancestor, skipping hook shells."""
     fallback = os.getppid()
+    if sys.platform == "win32":
+        return find_host_ancestor_windows(fallback, "claude")
     try:
         raw = subprocess.check_output(
             ["ps", "-axo", "pid=,ppid=,command="],

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -46,6 +46,7 @@ from _plugin_common import (
     set_session_key,
     touch_activity,
 )
+from _proc import pid_alive as _pid_alive
 from config import (
     _cloud_http_request,
     _user_id_via_api,
@@ -458,20 +459,6 @@ def _ensure_local_server_running(
                 hook_log("server_bootstrap_lock_release_failed", {"error": str(exc)[:200]})
 
 
-def _pid_alive(pid: int) -> bool:
-    if pid <= 1:
-        return False
-    try:
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except Exception:
-        return False
-
-
 def _normalize_service_url(service_url: str) -> str:
     return str(service_url or "").strip().rstrip("/")
 
@@ -609,10 +596,9 @@ def _watcher_alive() -> bool:
         return False
     try:
         pid = int(_WATCHER_PID.read_text(encoding="utf-8").strip())
-        os.kill(pid, 0)
-        return True
     except Exception:
         return False
+    return _pid_alive(pid)
 
 
 def _spawn_idle_watcher(
@@ -731,19 +717,6 @@ def _spawn_exit_watcher(
     service_url: str = "",
 ) -> None:
     """Launch a detached watcher that syncs only after Claude exits."""
-
-    def _pid_alive(pid: int) -> bool:
-        if pid <= 1:
-            return False
-        try:
-            os.kill(pid, 0)
-            return True
-        except ProcessLookupError:
-            return False
-        except PermissionError:
-            return True
-        except Exception:
-            return False
 
     # Cleanup stale watcher pidfiles so the directory does not grow forever.
     try:

--- a/integrations/claude-code/scripts/store-user-prompt.py
+++ b/integrations/claude-code/scripts/store-user-prompt.py
@@ -33,6 +33,7 @@ from _plugin_common import (
     set_session_key,
     touch_activity,
 )
+from _proc import pid_alive
 from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
 
 MAX_TEXT = 4000
@@ -59,11 +60,10 @@ def _watcher_alive() -> bool:
         return False
     try:
         pid = int(_WATCHER_PID.read_text(encoding="utf-8").strip())
-        os.kill(pid, 0)
-        return True
     except Exception as exc:
         hook_log("prompt_watcher_alive_check_failed", {"error": str(exc)[:200]})
         return False
+    return pid_alive(pid)
 
 
 def _ensure_idle_watcher(session_id: str, dataset: str, user_id: str, config: dict) -> None:

--- a/integrations/claude-code/tests/test_proc.py
+++ b/integrations/claude-code/tests/test_proc.py
@@ -32,6 +32,12 @@ def test_pid_alive_false_for_reaped_child():
     assert _proc.pid_alive(proc.pid) is False
 
 
+def test_pid_alive_false_for_out_of_range_pid():
+    # A corrupt pidfile can yield an int too large for the OS; the probe must
+    # report not-alive, never raise into a hook.
+    assert _proc.pid_alive(2**63) is False
+
+
 def test_matches_host_exe():
     assert _proc._matches_host_exe("claude.exe", "claude") is True
     assert _proc._matches_host_exe("Claude.EXE", "claude") is True

--- a/integrations/claude-code/tests/test_proc.py
+++ b/integrations/claude-code/tests/test_proc.py
@@ -1,0 +1,76 @@
+"""Unit tests for the cross-platform process helpers (_proc.py).
+
+The Windows liveness path uses Win32 APIs and only runs on Windows; here we
+exercise the POSIX liveness probe and the reserved-PID guard that every
+platform shares. Run: `python integrations/claude-code/tests/test_proc.py`
+(or via pytest).
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _proc  # noqa: E402
+
+
+def test_pid_alive_true_for_current_process():
+    assert _proc.pid_alive(os.getpid()) is True
+
+
+def test_pid_alive_false_for_reserved_pids():
+    assert _proc.pid_alive(0) is False
+    assert _proc.pid_alive(1) is False
+    assert _proc.pid_alive(-5) is False
+
+
+def test_pid_alive_false_for_reaped_child():
+    proc = subprocess.Popen([sys.executable, "-c", ""])
+    proc.wait()
+    assert _proc.pid_alive(proc.pid) is False
+
+
+def test_matches_host_exe():
+    assert _proc._matches_host_exe("claude.exe", "claude") is True
+    assert _proc._matches_host_exe("Claude.EXE", "claude") is True
+    assert _proc._matches_host_exe("claude", "claude") is True
+    assert _proc._matches_host_exe("claude-nightly.exe", "claude") is True
+    assert _proc._matches_host_exe("codex.exe", "codex") is True
+    assert _proc._matches_host_exe("claudex.exe", "claude") is False
+    assert _proc._matches_host_exe("code.exe", "claude") is False
+    assert _proc._matches_host_exe("", "claude") is False
+
+
+def test_walk_ancestors_finds_host():
+    # 400 (python hook) -> 300 (cmd) -> 200 (claude.exe) -> 100 (explorer) -> 1
+    table = {
+        400: (300, "python.exe"),
+        300: (200, "cmd.exe"),
+        200: (100, "claude.exe"),
+        100: (1, "explorer.exe"),
+    }
+    assert _proc._walk_ancestors(table, 400, "claude") == 200
+
+
+def test_walk_ancestors_returns_start_when_absent():
+    table = {400: (300, "python.exe"), 300: (1, "cmd.exe")}
+    assert _proc._walk_ancestors(table, 400, "claude") == 400
+
+
+def test_walk_ancestors_survives_cycle():
+    assert _proc._walk_ancestors({5: (5, "a.exe")}, 5, "claude") == 5
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print("PASS", name)
+            except AssertionError as e:
+                failures += 1
+                print("FAIL", name, e)
+    sys.exit(1 if failures else 0)

--- a/integrations/claude-code/tests/test_proc.py
+++ b/integrations/claude-code/tests/test_proc.py
@@ -69,6 +69,22 @@ def test_walk_ancestors_survives_cycle():
     assert _proc._walk_ancestors({5: (5, "a.exe")}, 5, "claude") == 5
 
 
+def test_process_table_and_ancestry_on_windows():
+    # _process_table_windows() uses Win32 (Toolhelp); on POSIX the pure
+    # _walk_ancestors / _matches_host_exe tests above cover the walk logic.
+    if sys.platform != "win32":
+        return
+    table = _proc._process_table_windows()
+    assert isinstance(table, dict) and table  # Toolhelp snapshot succeeded
+    me = os.getpid()
+    assert me in table  # this process is present, with (ppid, exe basename)
+    _ppid, exe = table[me]
+    stem = os.path.splitext(exe)[0]
+    assert stem
+    # the ancestry walk resolves this process by its own executable base name
+    assert _proc.find_host_ancestor_windows(me, stem) == me
+
+
 if __name__ == "__main__":
     failures = 0
     for name, fn in sorted(globals().items()):

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -20,6 +20,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+import _proc
+
 _PLUGIN_DIR = Path.home() / ".cognee-plugin" / "codex"
 _SHARED_PLUGIN_ROOT = Path.home() / ".cognee-plugin"
 _HOOK_LOG = _PLUGIN_DIR / "hook.log"
@@ -911,13 +913,7 @@ def sync_lock(owner: str):
                 pid = 0
             pid_alive = False
             if pid > 0:
-                try:
-                    os.kill(pid, 0)
-                    pid_alive = True
-                except PermissionError:
-                    pid_alive = True
-                except OSError:
-                    pid_alive = False
+                pid_alive = _proc.pid_alive(pid)
             if not pid_alive or now - created_at > SYNC_LOCK_STALE_SECONDS:
                 try:
                     _SYNC_LOCK.unlink()

--- a/integrations/codex/plugins/cognee/scripts/_proc.py
+++ b/integrations/codex/plugins/cognee/scripts/_proc.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Cross-platform process helpers for the cognee-memory plugin scripts.
+
+Kept stdlib-only so the detached watchers can import it without pulling in the
+rest of the plugin. The plugin decides a session has ended by polling the host
+(Claude/Codex) PID; the POSIX ``os.kill(pid, 0)`` liveness probe is unsupported
+on Windows, where signal 0 raises ``OSError`` (``WinError 87``), so the check
+needs a native Windows path.
+"""
+
+import os
+import sys
+
+_IS_WINDOWS = sys.platform == "win32"
+
+
+def pid_alive(pid: int) -> bool:
+    """Return ``True`` if a process with ``pid`` is currently running.
+
+    Non-destructive on every platform: it never signals or terminates the
+    target. PIDs <= 1 (unknown / init / kernel) are reported not-alive so the
+    watchers never bind to them.
+    """
+    if pid <= 1:
+        return False
+    if _IS_WINDOWS:
+        return _pid_alive_windows(pid)
+    return _pid_alive_posix(pid)
+
+
+def _pid_alive_posix(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists, owned by another user — still alive from our point of view.
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _pid_alive_windows(pid: int) -> bool:
+    # ``os.kill(pid, 0)`` raises WinError 87 here (signal 0 is unsupported), so
+    # probe via a process handle instead. OpenProcess fails with
+    # ERROR_ACCESS_DENIED for a live process we may not synchronise on (e.g. a
+    # system process); an open handle is non-signalled (WAIT_TIMEOUT) while an
+    # exited process signals immediately.
+    import ctypes
+    from ctypes import wintypes
+
+    SYNCHRONIZE = 0x00100000
+    WAIT_TIMEOUT = 0x00000102
+    ERROR_ACCESS_DENIED = 5
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+
+    handle = kernel32.OpenProcess(SYNCHRONIZE, False, pid)
+    if not handle:
+        return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+    try:
+        return kernel32.WaitForSingleObject(handle, 0) == WAIT_TIMEOUT
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def find_host_ancestor_windows(start_pid: int, host_stem: str) -> int:
+    """Nearest ancestor of ``start_pid`` whose executable base name is ``host_stem``
+    (e.g. "claude" / "codex"), found by walking the Windows process tree.
+
+    Returns ``start_pid`` unchanged when the process table cannot be read or no
+    matching ancestor is found, so the caller keeps its existing fallback. Used
+    where POSIX shells out to ``ps``, which does not exist on Windows.
+    """
+    return _walk_ancestors(_process_table_windows(), start_pid, host_stem)
+
+
+def _matches_host_exe(exe: str, host_stem: str) -> bool:
+    base = os.path.splitext(exe)[0].casefold()
+    stem = host_stem.casefold()
+    return base == stem or base.startswith(stem + "-")
+
+
+def _walk_ancestors(table: dict[int, tuple[int, str]], start_pid: int, host_stem: str) -> int:
+    pid = start_pid
+    seen: set[int] = set()
+    while pid > 1 and pid not in seen:
+        seen.add(pid)
+        ppid, exe = table.get(pid, (0, ""))
+        if exe and _matches_host_exe(exe, host_stem):
+            return pid
+        pid = ppid
+    return start_pid
+
+
+def _process_table_windows() -> dict[int, tuple[int, str]]:
+    """``{pid: (ppid, exe_basename)}`` for every process via Toolhelp; ``{}`` on failure."""
+    import ctypes
+    from ctypes import wintypes
+
+    TH32CS_SNAPPROCESS = 0x00000002
+    INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+    MAX_PATH = 260
+
+    class PROCESSENTRY32W(ctypes.Structure):
+        # ``th32DefaultHeapID`` is a pointer-sized ULONG_PTR: it must stay
+        # pointer-wide so the fields after it keep the right offsets on 64-bit.
+        _fields_ = (
+            ("dwSize", wintypes.DWORD),
+            ("cntUsage", wintypes.DWORD),
+            ("th32ProcessID", wintypes.DWORD),
+            ("th32DefaultHeapID", ctypes.c_void_p),
+            ("th32ModuleID", wintypes.DWORD),
+            ("cntThreads", wintypes.DWORD),
+            ("th32ParentProcessID", wintypes.DWORD),
+            ("pcPriClassBase", ctypes.c_long),
+            ("dwFlags", wintypes.DWORD),
+            ("szExeFile", ctypes.c_wchar * MAX_PATH),
+        )
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+    kernel32.CreateToolhelp32Snapshot.argtypes = (wintypes.DWORD, wintypes.DWORD)
+    kernel32.Process32FirstW.argtypes = (wintypes.HANDLE, ctypes.POINTER(PROCESSENTRY32W))
+    kernel32.Process32NextW.argtypes = (wintypes.HANDLE, ctypes.POINTER(PROCESSENTRY32W))
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+
+    snapshot = kernel32.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+    if not snapshot or snapshot == INVALID_HANDLE_VALUE:
+        return {}
+
+    table: dict[int, tuple[int, str]] = {}
+    try:
+        entry = PROCESSENTRY32W()
+        entry.dwSize = ctypes.sizeof(PROCESSENTRY32W)
+        ok = kernel32.Process32FirstW(snapshot, ctypes.byref(entry))
+        while ok:
+            table[int(entry.th32ProcessID)] = (int(entry.th32ParentProcessID), entry.szExeFile)
+            ok = kernel32.Process32NextW(snapshot, ctypes.byref(entry))
+    finally:
+        kernel32.CloseHandle(snapshot)
+    return table

--- a/integrations/codex/plugins/cognee/scripts/_proc.py
+++ b/integrations/codex/plugins/cognee/scripts/_proc.py
@@ -36,7 +36,9 @@ def _pid_alive_posix(pid: int) -> bool:
     except PermissionError:
         # Exists, owned by another user — still alive from our point of view.
         return True
-    except OSError:
+    except Exception:
+        # Any other failure (e.g. an out-of-range PID from a corrupt pidfile)
+        # counts as not-alive — a liveness probe must never raise into a hook.
         return False
     return True
 

--- a/integrations/codex/plugins/cognee/scripts/_proc.py
+++ b/integrations/codex/plugins/cognee/scripts/_proc.py
@@ -44,6 +44,10 @@ def _pid_alive_posix(pid: int) -> bool:
 
 
 def _pid_alive_windows(pid: int) -> bool:
+    if pid > 0xFFFFFFFF:
+        # A Windows PID is a DWORD; a larger value (e.g. from a corrupt pidfile)
+        # is not a real process and would otherwise truncate into DWORD range.
+        return False
     # ``os.kill(pid, 0)`` raises WinError 87 here (signal 0 is unsupported), so
     # probe via a process handle instead. OpenProcess fails with
     # ERROR_ACCESS_DENIED for a live process we may not synchronise on (e.g. a

--- a/integrations/codex/plugins/cognee/scripts/exit-watcher.py
+++ b/integrations/codex/plugins/cognee/scripts/exit-watcher.py
@@ -14,6 +14,9 @@ import sys
 import time
 from pathlib import Path
 
+sys.path.insert(0, os.path.dirname(__file__))
+from _proc import pid_alive as _pid_alive
+
 _PLUGIN_DIR = Path.home() / ".cognee-plugin" / "codex"
 _EXIT_WATCHERS_DIR = _PLUGIN_DIR / "exit-watchers"
 _PIDFILE = _PLUGIN_DIR / "exit-watcher.pid"
@@ -34,21 +37,6 @@ def _log(event: str, **detail) -> None:
             fh.write(json.dumps(line, default=str) + "\n")
     except Exception:
         pass
-
-
-def _pid_alive(pid: int) -> bool:
-    if pid <= 1:
-        return False
-    try:
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except Exception as exc:
-        _log("pid_alive_check_failed", parent_pid=pid, error=str(exc)[:200])
-        return False
 
 
 def _owns_pidfile(pidfile: Path) -> bool:

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -44,6 +44,7 @@ from _plugin_common import (
     set_session_key,
     touch_activity,
 )
+from _proc import find_host_ancestor_windows
 from _proc import pid_alive as _pid_alive
 from cognee_statusline_render import render_status_for_host
 from config import (
@@ -668,6 +669,8 @@ def _spawn_idle_watcher(
 def _find_codex_parent_pid() -> int:
     """Find the nearest live Codex ancestor, skipping hook shells."""
     fallback = os.getppid()
+    if sys.platform == "win32":
+        return find_host_ancestor_windows(fallback, "codex")
     try:
         raw = subprocess.check_output(
             ["ps", "-axo", "pid=,ppid=,command="],

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -44,6 +44,7 @@ from _plugin_common import (
     set_session_key,
     touch_activity,
 )
+from _proc import pid_alive as _pid_alive
 from cognee_statusline_render import render_status_for_host
 from config import (
     _cloud_http_request,
@@ -458,20 +459,6 @@ def _ensure_local_server_running(
                 hook_log("server_bootstrap_lock_release_failed", {"error": str(exc)[:200]})
 
 
-def _pid_alive(pid: int) -> bool:
-    if pid <= 1:
-        return False
-    try:
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except Exception:
-        return False
-
-
 def _normalize_service_url(service_url: str) -> str:
     return str(service_url or "").strip().rstrip("/")
 
@@ -609,10 +596,9 @@ def _watcher_alive() -> bool:
         return False
     try:
         pid = int(_WATCHER_PID.read_text(encoding="utf-8").strip())
-        os.kill(pid, 0)
-        return True
     except Exception:
         return False
+    return _pid_alive(pid)
 
 
 def _spawn_idle_watcher(
@@ -731,19 +717,6 @@ def _spawn_exit_watcher(
     service_url: str = "",
 ) -> None:
     """Launch a detached watcher that syncs only after Codex exits."""
-
-    def _pid_alive(pid: int) -> bool:
-        if pid <= 1:
-            return False
-        try:
-            os.kill(pid, 0)
-            return True
-        except ProcessLookupError:
-            return False
-        except PermissionError:
-            return True
-        except Exception:
-            return False
 
     # Cleanup stale watcher pidfiles so the directory does not grow forever.
     try:

--- a/integrations/codex/plugins/cognee/scripts/store-user-prompt.py
+++ b/integrations/codex/plugins/cognee/scripts/store-user-prompt.py
@@ -33,6 +33,7 @@ from _plugin_common import (
     set_session_key,
     touch_activity,
 )
+from _proc import pid_alive
 from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
 
 MAX_TEXT = 4000
@@ -59,11 +60,10 @@ def _watcher_alive() -> bool:
         return False
     try:
         pid = int(_WATCHER_PID.read_text(encoding="utf-8").strip())
-        os.kill(pid, 0)
-        return True
     except Exception as exc:
         hook_log("prompt_watcher_alive_check_failed", {"error": str(exc)[:200]})
         return False
+    return pid_alive(pid)
 
 
 def _ensure_idle_watcher(session_id: str, dataset: str, user_id: str, config: dict) -> None:

--- a/integrations/codex/tests/test_proc.py
+++ b/integrations/codex/tests/test_proc.py
@@ -71,6 +71,22 @@ def test_walk_ancestors_survives_cycle():
     assert _proc._walk_ancestors({5: (5, "a.exe")}, 5, "codex") == 5
 
 
+def test_process_table_and_ancestry_on_windows():
+    # _process_table_windows() uses Win32 (Toolhelp); on POSIX the pure
+    # _walk_ancestors / _matches_host_exe tests above cover the walk logic.
+    if sys.platform != "win32":
+        return
+    table = _proc._process_table_windows()
+    assert isinstance(table, dict) and table  # Toolhelp snapshot succeeded
+    me = os.getpid()
+    assert me in table  # this process is present, with (ppid, exe basename)
+    _ppid, exe = table[me]
+    stem = os.path.splitext(exe)[0]
+    assert stem
+    # the ancestry walk resolves this process by its own executable base name
+    assert _proc.find_host_ancestor_windows(me, stem) == me
+
+
 if __name__ == "__main__":
     failures = 0
     for name, fn in sorted(globals().items()):

--- a/integrations/codex/tests/test_proc.py
+++ b/integrations/codex/tests/test_proc.py
@@ -34,6 +34,12 @@ def test_pid_alive_false_for_reaped_child():
     assert _proc.pid_alive(proc.pid) is False
 
 
+def test_pid_alive_false_for_out_of_range_pid():
+    # A corrupt pidfile can yield an int too large for the OS; the probe must
+    # report not-alive, never raise into a hook.
+    assert _proc.pid_alive(2**63) is False
+
+
 def test_matches_host_exe():
     assert _proc._matches_host_exe("codex.exe", "codex") is True
     assert _proc._matches_host_exe("Codex.EXE", "codex") is True

--- a/integrations/codex/tests/test_proc.py
+++ b/integrations/codex/tests/test_proc.py
@@ -1,0 +1,78 @@
+"""Unit tests for the cross-platform process helpers (_proc.py).
+
+The Windows liveness path uses Win32 APIs and only runs on Windows; here we
+exercise the POSIX liveness probe and the reserved-PID guard that every
+platform shares. Run: `python integrations/codex/tests/test_proc.py`
+(or via pytest).
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+
+sys.path.insert(
+    0, str(pathlib.Path(__file__).resolve().parents[1] / "plugins" / "cognee" / "scripts")
+)
+
+import _proc  # noqa: E402
+
+
+def test_pid_alive_true_for_current_process():
+    assert _proc.pid_alive(os.getpid()) is True
+
+
+def test_pid_alive_false_for_reserved_pids():
+    assert _proc.pid_alive(0) is False
+    assert _proc.pid_alive(1) is False
+    assert _proc.pid_alive(-5) is False
+
+
+def test_pid_alive_false_for_reaped_child():
+    proc = subprocess.Popen([sys.executable, "-c", ""])
+    proc.wait()
+    assert _proc.pid_alive(proc.pid) is False
+
+
+def test_matches_host_exe():
+    assert _proc._matches_host_exe("codex.exe", "codex") is True
+    assert _proc._matches_host_exe("Codex.EXE", "codex") is True
+    assert _proc._matches_host_exe("codex", "codex") is True
+    assert _proc._matches_host_exe("codex-nightly.exe", "codex") is True
+    assert _proc._matches_host_exe("claude.exe", "claude") is True
+    assert _proc._matches_host_exe("codexy.exe", "codex") is False
+    assert _proc._matches_host_exe("code.exe", "codex") is False
+    assert _proc._matches_host_exe("", "codex") is False
+
+
+def test_walk_ancestors_finds_host():
+    # 400 (python hook) -> 300 (sh) -> 200 (codex.exe) -> 100 (explorer) -> 1
+    table = {
+        400: (300, "python.exe"),
+        300: (200, "sh.exe"),
+        200: (100, "codex.exe"),
+        100: (1, "explorer.exe"),
+    }
+    assert _proc._walk_ancestors(table, 400, "codex") == 200
+
+
+def test_walk_ancestors_returns_start_when_absent():
+    table = {400: (300, "python.exe"), 300: (1, "sh.exe")}
+    assert _proc._walk_ancestors(table, 400, "codex") == 400
+
+
+def test_walk_ancestors_survives_cycle():
+    assert _proc._walk_ancestors({5: (5, "a.exe")}, 5, "codex") == 5
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print("PASS", name)
+            except AssertionError as e:
+                failures += 1
+                print("FAIL", name, e)
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Summary

Closes #258. Linear: SDK-238.

On Windows the `cognee-memory` plugin's exit-watcher never functions: its process-liveness check `os.kill(pid, 0)` raises `OSError [WinError 87]` on every call, because Windows' `os.kill` does not support signal `0`. `_pid_alive()` therefore always returns `False`, the watch loop exits immediately, and the "final" end-of-session graph sync is spawned at **session start** on an empty transcript instead of at session end. Downstream, every Cognee Cloud session sits at **RUNNING** → **ABANDONED** (0% success in the Sessions view) and the deep end-of-session consolidation never runs — only the shallow incremental Stop-hook sync does.

The same `os.kill(pid, 0)` liveness idiom is duplicated across the plugin, so it breaks identically at every call site, in **both** the `claude-code` and `codex` plugin trees.

## What changed

**1. `fix(integrations): make the exit-watcher process-liveness check work on Windows`**

- New stdlib-only `_proc.py` (one per tree) with a single cross-platform `pid_alive(pid)`:
  - **POSIX** — `os.kill(pid, 0)` with the existing `ProcessLookupError` / `PermissionError` semantics (byte-identical behaviour).
  - **Windows** — `OpenProcess(SYNCHRONIZE)` + `WaitForSingleObject`; a live process' handle is non-signalled (`WAIT_TIMEOUT`), and `ERROR_ACCESS_DENIED` means it exists but we may not synchronise on it (e.g. a system process). Never destructive — it never terminates the probed process.
- Every liveness call site now delegates to `_proc.pid_alive`: `exit-watcher.py`, `session-start.py` (×3), `store-user-prompt.py`, and `_plugin_common.sync_lock`. This removes five duplicated `_pid_alive` copies per tree rather than patching one.
- `os.kill(pid, SIGTERM)` termination sites are deliberately left untouched — `TerminateProcess` already works cross-platform; only signal `0` is unsupported on Windows.

**2. `fix(integrations): resolve the host PID natively on Windows instead of ps`** — the report's "secondary / related" item

- `_find_{claude,codex}_parent_pid()` shells out to `ps`, which does not exist on Windows, so it always logged `find_*_parent_failed` and fell back to `os.getppid()`. Added a Windows-native ancestry walk via `CreateToolhelp32Snapshot` (`_proc.find_host_ancestor_windows`), wired in additively (a single guarded early-return; the POSIX `ps` path is byte-identical). If the process table cannot be read or no host ancestor is found it returns `os.getppid()`, so behaviour is never worse than before.

**3. `fix(integrations): treat any liveness-probe failure as not-alive`** — post-review hardening

- The pre-refactor per-file `_pid_alive` helpers caught `except Exception` (any `os.kill` failure → not-alive); the new `_pid_alive_posix` had narrowed that to `except OSError`, so an out-of-range PID (e.g. a corrupt watcher pidfile) would raise `OverflowError` out of `_watcher_alive` and crash the hook. Restored the catch-all so the probe never raises into a hook, with a regression test (`pid_alive(2**63) → False`).

**4. `fix(integrations): reject out-of-range PIDs in the Windows liveness probe`**

- A Windows PID is a `DWORD`; ctypes *truncates* an out-of-range int into the `DWORD` arg rather than raising, so an absurd value could truncate into a real PID and report a false positive. Guard it before `OpenProcess` — any PID outside `DWORD` range → not-alive.

**5. `test(integrations): exercise the Windows process helpers on a windows-latest CI job`**

- The integration matrix is ubuntu-only and skips these trees (no `pyproject.toml`), so the Win32 paths had **zero** runtime coverage. Added a path-gated `windows-latest` job (`.github/workflows/plugin-windows-tests.yml`) that runs both `test_proc.py` suites, plus a Windows-only test driving the Toolhelp snapshot + ancestry walk against the current process. The existing liveness tests already exercise `_pid_alive_windows` when run on Windows.

## Scope & compatibility

- `integrations/claude-code/` and `integrations/codex/` only (mirror plugin trees).
- Fully backward-compatible on POSIX: the POSIX branch is byte-identical to the previous inline checks; no neighbouring logic or comments were changed.

## Verification

- New `test_proc.py` in both trees — POSIX liveness (current process alive; reserved / reaped PIDs dead) and the platform-independent ancestry helpers (exe-name matching, ancestor walk, cycle-safety). Green via the built-in runner.
- Full `claude-code` + `codex` suites green except two pre-existing failures (`test_bridge_poll`, `test_improve_sync`) that fail on `main` independently of this change (their test doubles predate a `context=` kwarg on `urlopen`) — untouched here.
- `ruff format --check` + `ruff check` clean over `integrations/` at line-length 100.
- **Windows CI:** a new path-gated `windows-latest` job runs both `test_proc.py` suites on a real Windows runner, so `_pid_alive_windows` (`OpenProcess`/`WaitForSingleObject`) and `_process_table_windows` (`CreateToolhelp32Snapshot`) are now exercised in CI — these paths had no runtime coverage before. Matches the approach verified on Windows 11 in the report.

## Out of scope / follow-ups

- **openclaw** (`integrations/openclaw/src/server.ts`) embeds a Python daemon as string literals that carries the *identical* `os.kill(pid, 0)` liveness idiom — it has the same Windows failure and warrants its own fix in that (TypeScript) integration. Not touched here to keep this PR scoped to #258.
- **Windows QA:** the `_proc` primitives are now unit-tested on `windows-latest` in CI. A full end-to-end smoke test on a real Windows host remains worthwhile to confirm the whole exit-watcher lifecycle — that it binds to the live host PID, the end-of-session sync fires on exit, and the host process is named `claude*` / `codex*` so the native ancestry walk engages (otherwise it safely falls back to `os.getppid()`).

Base branch `main` (this repo has no `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
