### PR TITLE
fix(integrations): route fetchAPI success path through responseParser (SDK-242)

### DIFF
--- a/integrations/openclaw/__tests__/test_visualiseResponseParser.ts
+++ b/integrations/openclaw/__tests__/test_visualiseResponseParser.ts
@@ -1,0 +1,142 @@
+import { CogneeHttpClient } from "../src/client";
+
+// ---------------------------------------------------------------------------
+// fetchAPI success-path responseParser (gh #195 / SDK-242).
+//
+// fetchAPI accepts a responseParser so callers can read non-JSON bodies, but
+// the success path used to hardcode response.json() and ignore it — only the
+// 401-relogin path honored it. visualise() passes a text parser to read the
+// graph HTML the server returns, so every healthy 200 threw
+// "SyntaxError: Unexpected token < in JSON". These tests pin the success path
+// to the caller-supplied parser: they FAIL against the pre-fix client (json()
+// throws on the HTML body) and pass now.
+// ---------------------------------------------------------------------------
+
+let mockFetch: jest.Mock;
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  mockFetch = jest.fn();
+  (globalThis as unknown as { fetch: unknown }).fetch = mockFetch;
+});
+
+afterEach(() => {
+  (globalThis as unknown as { fetch: unknown }).fetch = originalFetch;
+  jest.restoreAllMocks();
+});
+
+const GRAPH_HTML = "<!doctype html><html><body><svg>graph</svg></body></html>";
+
+// A 200 Response whose body is HTML: text() returns it, json() throws exactly
+// as a real Response.json() does on a non-JSON body.
+function httpHtml(): Response {
+  return {
+    ok: true,
+    status: 200,
+    text: async () => GRAPH_HTML,
+    json: async () => {
+      throw new SyntaxError("Unexpected token < in JSON at position 0");
+    },
+  } as unknown as Response;
+}
+
+// apiKey is set so ensureAuth() short-circuits without a login round-trip.
+function makeClient(): CogneeHttpClient {
+  return new CogneeHttpClient("http://test", "key");
+}
+
+describe("fetchAPI success-path responseParser (gh #195)", () => {
+  it("routes the success path through the supplied responseParser instead of forcing JSON", async () => {
+    jest.useFakeTimers();
+    try {
+      const client = makeClient();
+      mockFetch.mockResolvedValue(httpHtml());
+
+      const body = await client.fetchAPI<string>(
+        "/api/v1/visualize?dataset_id=d",
+        { method: "GET" },
+        5_000,
+        async (r) => await r.text(),
+        0, // retries disabled: one fetch settles the call
+      );
+
+      expect(body).toBe(GRAPH_HTML);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("visualise() resolves to the raw graph HTML rather than throwing a JSON parse error", async () => {
+    jest.useFakeTimers();
+    try {
+      const client = makeClient();
+      mockFetch.mockResolvedValue(httpHtml());
+
+      await expect(client.visualise("dataset-1")).resolves.toBe(GRAPH_HTML);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error-path semantics: the success-path return is `await responseParser(...)`,
+// NOT a bare `return responseParser(...)`. The await keeps a parser/body-read
+// rejection inside fetchAPI's try, so the outer catch still clears the timer
+// and retries on an AbortError. A bare return would let that rejection escape
+// the loop — no retry — which this test pins. (It fails on the un-awaited form
+// and passes on the awaited one.)
+// ---------------------------------------------------------------------------
+
+describe("fetchAPI success-path keeps rejections inside the retry loop (gh #195)", () => {
+  it("retries when the body read aborts mid-stream instead of letting the AbortError escape", async () => {
+    jest.useFakeTimers();
+    try {
+      const client = makeClient();
+      let calls = 0;
+      mockFetch.mockImplementation(async () => {
+        calls += 1;
+        if (calls === 1) {
+          // attempt 0: headers arrive with 200, then the body read aborts
+          // (the per-request abort timer fired mid-stream).
+          return {
+            ok: true,
+            status: 200,
+            text: async () => {
+              throw new DOMException("The operation was aborted.", "AbortError");
+            },
+            json: async () => {
+              throw new DOMException("The operation was aborted.", "AbortError");
+            },
+          } as unknown as Response;
+        }
+        // attempt 1: succeeds.
+        return {
+          ok: true,
+          status: 200,
+          text: async () => GRAPH_HTML,
+          json: async () => ({}),
+        } as unknown as Response;
+      });
+
+      // retries=1: the attempt-0 body-read AbortError must be caught by fetchAPI
+      // and retried — only possible if the success-path return is awaited.
+      const result = client.fetchAPI<string>(
+        "/api/v1/visualize?dataset_id=d",
+        { method: "GET" },
+        5_000,
+        async (r) => await r.text(),
+        1,
+      );
+      const assertion = expect(result).resolves.toBe(GRAPH_HTML);
+      // advance past the retry backoff (RETRY_BASE_DELAY_MS = 3000ms on attempt 1).
+      await jest.advanceTimersByTimeAsync(3_000);
+      await assertion;
+
+      expect(calls).toBe(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/integrations/openclaw/src/client.ts
+++ b/integrations/openclaw/src/client.ts
@@ -169,7 +169,15 @@ export class CogneeHttpClient {
           const errorText = await response.text();
           throw new Error(`Cognee request failed (${response.status}): ${errorText}`);
         }
-        return (await response.json()) as T;
+        // Honor responseParser on the success path too — parity with the
+        // 401-retry path above, which already returns responseParser(...).
+        // The `await` is load-bearing: it keeps a parser/body-read rejection
+        // (a mid-read AbortError, or a parse error) inside this try, so the
+        // catch still clears the timer and retries on abort. Clearing the timer
+        // on the resolve path is #264/SDK-215's scope, not this change's.
+        // visualise() passes a text parser to read the graph HTML the server
+        // returns; forcing response.json() here threw on every 200. (gh #195)
+        return await responseParser(response);
       } catch (error) {
         clearTimeout(timer);
         const isTimeout =

--- a/integrations/opencode/src/client.ts
+++ b/integrations/opencode/src/client.ts
@@ -142,7 +142,12 @@ export class CogneeHttpClient {
           const errorText = await response.text();
           throw new Error(`Cognee request failed (${response.status}): ${errorText}`);
         }
-        return (await response.json()) as T;
+        // Honor responseParser on the success path — parity with the retry path
+        // and the openclaw client. The `await` is load-bearing: it keeps a
+        // parser/body-read rejection inside this try, so the catch still clears
+        // the timer and retries on abort. No opencode caller passes a custom
+        // parser today, but the shared transport must not silently force JSON. (gh #195)
+        return await responseParser(response);
       } catch (error) {
         clearTimeout(timer);
         const isTimeout =


### PR DESCRIPTION
## Summary

`CogneeHttpClient.fetchAPI` (openclaw + opencode) accepts a `responseParser` callback so callers can read non-JSON bodies, but **the success path hardcoded `response.json()` and ignored it** — only the 401-relogin path honored it. `visualise()` passes a text parser (`async (r) => await r.text()`) to read the graph **HTML** the server returns, so every healthy `200` threw `SyntaxError: Unexpected token < in JSON`. The `openclaw cognee visualise` command (`plugin.ts` → `console.log(await client.visualise(dsId))`) therefore never worked — it always fell into its catch and printed `Failed to visualise graph: Unexpected token < in JSON`, exit 1.

Fixes #195 (reported by @SaviPandey). Base `main` (this repo has no `dev`). Closes SDK-242.

## Root cause

An incomplete fix, not the original design. Commit `0b5b3d9` ("fix(openclaw): visualize endpoint typo + command output display", PR #43) introduced the `responseParser` parameter **with a default** (`= async (r) => (await r.json()) as T`), added `visualise()`'s text parser, and wired `responseParser` into the 401-retry path — but left the success-path `return (await response.json()) as T;` untouched. So the parameter is honored on the rare retry path and silently dropped on the happy path.

> Note: the issue's proposed fix (a `responseParser ? … : …` conditional, "because it has no default value") is stale — the default already exists since `0b5b3d9`. The correct fix is a direct substitution.

## What ships

Route the success path through `responseParser`, mirroring the 401-retry path which already does `return responseParser(retryResponse)`:

```diff
-        return (await response.json()) as T;
+        return await responseParser(response);
```

The `await` is **load-bearing**: it keeps a parser / body-read rejection (a mid-read `AbortError`, or a parse error) inside `fetchAPI`'s `try`, so the outer `catch` still clears the abort timer and retries on abort — preserving the pre-fix error/retry contract for **every** caller. A bare `return responseParser(response)` (no `await`) would let that rejection escape the loop, silently disabling the retry-on-abort and the error-path timer clear. This was verified with a Node probe and is pinned by a regression test (below).

- **openclaw** (`src/client.ts`) — the live bug; `visualise()` is a real caller.
- **opencode** (`src/client.ts`) — identical success-path hardcoding, currently **latent** (no opencode caller passes a custom parser and there is no opencode `visualise()`), fixed for parity so the shared transport is correct if such a caller is added.
- **Backward compatible** — the default parser is `response.json()`, so `await responseParser(response)` is byte-identical to `(await response.json())` for every caller that omits it.

## Scope note — `clearTimeout` stays with #264 ⚠️

This PR and **#264 (SDK-215)** edit the **same success-path line**. Agreed sequencing (Option A): **#195 lands first** with only the `responseParser` routing (no `clearTimeout` — that abort-timer-leak fix is #264's); then **#264 rebases** and its timer clear applies cleanly on top:

```ts
const data = await responseParser(response);
clearTimeout(timer);   // from #264
return data;
```

Do not merge #264 before this, or the change gets double-applied. (Four other open PRs — #183/#184/#123/#127 — touch the same region but are superseded and should be closed, not merged.)

## Tests

`openclaw/__tests__/test_visualiseResponseParser.ts` (3 tests):
1. the success path routes through the supplied parser (a text parser resolves to the HTML) — **fails pre-fix** (`json()` throws on the HTML body).
2. `visualise()` resolves to the raw graph HTML rather than throwing a JSON parse error.
3. a mid-body-read `AbortError` is **retried**, not escaped — **fails on a bare (un-awaited) return**, pinning the load-bearing `await`.

## Verification

Local, matching the `test-typescript` CI job (node 20):

- **openclaw** — `npx tsc --noEmit` clean; `npx jest` → **7 suites, 80 tests pass**. Tests 1 and 3 were confirmed to fail against the pre-fix and the bare-return forms respectively, and pass now, so they genuinely pin the behavior.
- **opencode** — `npx tsc --noEmit --skipLibCheck` clean.

`ruff` N/A (TypeScript). openclaw's `tsconfig` excludes `__tests__`, so CI builds only `src`; the tests are a local guard (CI runs `tsc` for openclaw, not jest).

Related: gh issue #195 (reporter @SaviPandey). Adjacent: PR #264 / SDK-215 (same lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
