### PR TITLE
fix(openclaw-skills): call fetchAPI instead of the missing fetchJson (SDK-244)

### DIFF
--- a/integrations/openclaw-skills/index.ts
+++ b/integrations/openclaw-skills/index.ts
@@ -215,7 +215,7 @@ class CogneeSkillsClient {
   }
 
   async ingest(skillsFolder: string, datasetName: string): Promise<void> {
-    await this.http.fetchJson("/api/v1/skills/ingest", {
+    await this.http.fetchAPI("/api/v1/skills/ingest", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ skills_folder: skillsFolder, dataset_name: datasetName }),
@@ -223,7 +223,7 @@ class CogneeSkillsClient {
   }
 
   async upsert(skillsFolder: string, datasetName: string): Promise<unknown> {
-    return this.http.fetchJson("/api/v1/skills/upsert", {
+    return this.http.fetchAPI("/api/v1/skills/upsert", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ skills_folder: skillsFolder, dataset_name: datasetName }),
@@ -231,12 +231,12 @@ class CogneeSkillsClient {
   }
 
   async list(): Promise<SkillSummary[]> {
-    return this.http.fetchJson<SkillSummary[]>("/api/v1/skills", { method: "GET" });
+    return this.http.fetchAPI<SkillSummary[]>("/api/v1/skills", { method: "GET" });
   }
 
   async load(skillId: string): Promise<SkillDetail | null> {
     try {
-      return await this.http.fetchJson<SkillDetail>(`/api/v1/skills/${encodeURIComponent(skillId)}`, { method: "GET" });
+      return await this.http.fetchAPI<SkillDetail>(`/api/v1/skills/${encodeURIComponent(skillId)}`, { method: "GET" });
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       if (msg.includes("404")) return null;
@@ -255,7 +255,7 @@ class CogneeSkillsClient {
     amendifyScoreThreshold?: number;
     sessionId?: string;
   }): Promise<ExecuteResult> {
-    return this.http.fetchJson<ExecuteResult>("/api/v1/skills/execute", {
+    return this.http.fetchAPI<ExecuteResult>("/api/v1/skills/execute", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -282,7 +282,7 @@ class CogneeSkillsClient {
     errorMessage?: string;
     latencyMs?: number;
   }): Promise<unknown> {
-    return this.http.fetchJson("/api/v1/skills/observe", {
+    return this.http.fetchAPI("/api/v1/skills/observe", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -299,7 +299,7 @@ class CogneeSkillsClient {
   }
 
   async inspect(skillId: string, minRuns = 1, scoreThreshold = 0.5): Promise<InspectionResult | null> {
-    const result = await this.http.fetchJson<InspectionResult | { result: null; message: string }>("/api/v1/skills/inspect", {
+    const result = await this.http.fetchAPI<InspectionResult | { result: null; message: string }>("/api/v1/skills/inspect", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ skill_id: skillId, min_runs: minRuns, score_threshold: scoreThreshold }),
@@ -309,7 +309,7 @@ class CogneeSkillsClient {
   }
 
   async previewAmendify(skillId: string, inspectionId?: string, minRuns = 1, scoreThreshold = 0.5): Promise<AmendmentPreview | null> {
-    const result = await this.http.fetchJson<AmendmentPreview | { result: null; message: string }>("/api/v1/skills/preview-amendify", {
+    const result = await this.http.fetchAPI<AmendmentPreview | { result: null; message: string }>("/api/v1/skills/preview-amendify", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ skill_id: skillId, inspection_id: inspectionId || null, min_runs: minRuns, score_threshold: scoreThreshold }),
@@ -319,7 +319,7 @@ class CogneeSkillsClient {
   }
 
   async amendify(amendmentId: string): Promise<unknown> {
-    return this.http.fetchJson("/api/v1/skills/amendify", {
+    return this.http.fetchAPI("/api/v1/skills/amendify", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ amendment_id: amendmentId }),
@@ -327,7 +327,7 @@ class CogneeSkillsClient {
   }
 
   async rollback(amendmentId: string): Promise<{ success: boolean }> {
-    return this.http.fetchJson<{ success: boolean }>("/api/v1/skills/rollback-amendify", {
+    return this.http.fetchAPI<{ success: boolean }>("/api/v1/skills/rollback-amendify", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ amendment_id: amendmentId }),
@@ -335,7 +335,7 @@ class CogneeSkillsClient {
   }
 
   async evaluateAmendify(amendmentId: string): Promise<{ pre_avg: number; post_avg: number; improvement: number; recommendation: string }> {
-    return this.http.fetchJson("/api/v1/skills/evaluate-amendify", {
+    return this.http.fetchAPI("/api/v1/skills/evaluate-amendify", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ amendment_id: amendmentId }),
@@ -343,7 +343,7 @@ class CogneeSkillsClient {
   }
 
   async autoAmendify(skillId: string, minRuns = 3, scoreThreshold = 0.5): Promise<unknown | null> {
-    const result = await this.http.fetchJson<unknown>("/api/v1/skills/auto-amendify", {
+    const result = await this.http.fetchAPI<unknown>("/api/v1/skills/auto-amendify", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ skill_id: skillId, min_runs: minRuns, score_threshold: scoreThreshold }),

--- a/integrations/openclaw-skills/package.json
+++ b/integrations/openclaw-skills/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "openclaw": ">=2026.2.3-1",
-    "@cognee/cognee-openclaw": ">=2026.3.0"
+    "@cognee/cognee-openclaw": ">=2026.4.13"
   },
   "devDependencies": {
     "@cognee/cognee-openclaw": "file:../openclaw",


### PR DESCRIPTION
## Summary

`integrations/openclaw-skills/index.ts` called `this.http.fetchJson(...)` at 12 sites, but the shared `CogneeHttpClient` renamed that method to `fetchAPI`. The rename shipped in `@cognee/cognee-openclaw` **2026.4.13** (versions 2026.3.0–2026.4.12 exposed `fetchJson`), and skills' call sites were never updated. So the current shared client no longer defines `fetchJson`: every skills operation (ingest, upsert, list, load, execute, observe, inspect, amendify, …) threw `TypeError: this.http.fetchJson is not a function` at runtime, and the package failed to typecheck on `main` (12× `TS2339: Property 'fetchJson' does not exist on type 'CogneeHttpClient'`).

This renames the 12 call sites to `fetchAPI`, the client's current method. `fetchAPI` has the identical signature `(path, init, timeoutMs?, responseParser?, retries?)` and already returns parsed JSON, so it's a byte-equivalent substitution with no behavior change.

It also raises the `@cognee/cognee-openclaw` peer floor from `>=2026.3.0` to `>=2026.4.13` — the first published openclaw that exposes `fetchAPI` — so a standalone install can't resolve a `fetchJson`-only client (2026.3.0–2026.4.12) and hit the symmetric `fetchAPI is not a function` crash.

Fixes #194. Tracked in SDK-244.

## Why rename the callers instead of adding a `fetchJson` alias

The alternative (attempted in #216) re-adds a `fetchJson` alias delegating to `fetchAPI`. Renaming the callers is cleaner here:

- `fetchAPI` is the client's current single public name; the alias would be a second name for the same method.
- Touches only the broken integration, so CI runs the `openclaw-skills` job and verifies the fix at the crash site.
- No dead `fetchJson` added to `opencode` (which has no caller for it).
- With the peer floor at `>=2026.4.13`, every openclaw the skills plugin can resolve already exposes `fetchAPI` — no client-side shim or openclaw re-release required.

## Supersedes #216

Thanks to @SaviPandey for the precise bug report and @Gautam5514 for the fix attempt in #216. This PR takes the caller-rename approach; #216 is closed with a pointer here.

## Verification

- `npx tsc --noEmit --skipLibCheck` in `openclaw-skills` (against a freshly built `openclaw`): **passes** (0 errors). On `main` it fails with the 12 `TS2339` errors.
- `npx tsc --noEmit --skipLibCheck` in `openclaw`: passes (unchanged).
- The published `@cognee/cognee-openclaw@2026.4.13` tarball exposes `fetchAPI`, the 6-arg constructor, and the public `ingestionTimeoutMs` field skills uses — confirming the peer floor is both necessary (2026.4.12 exposes `fetchJson` only) and sufficient.
- Mirrors the `test-typescript` CI job (node 20), which builds `openclaw` then typechecks `openclaw-skills`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
