### PR TITLE
fix(codex): emit valid UserPromptSubmit hook output

### DIFF
--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -404,10 +404,10 @@ async def _run(prompt: str) -> dict | None:
     # terminal (mirrors the claude-code integration); hosts that render
     # additionalContext directly will still show the full block.
     output = {
+        "systemMessage": header,
         "hookSpecificOutput": {
             "hookEventName": "UserPromptSubmit",
             "additionalContext": full_context,
-            "systemMessage": header,
         }
     }
     return output
@@ -443,9 +443,13 @@ def main():
             output = asyncio.run(_run(prompt))
     except Exception as exc:
         hook_log("context_lookup_exception", {"error": str(exc)[:200]})
-    if output:
-        print(json.dumps(output))
+    return output
 
 
 if __name__ == "__main__":
-    main()
+    print(json.dumps(main() or {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": "",
+        }
+    }))

--- a/integrations/codex/plugins/cognee/scripts/store-user-prompt.py
+++ b/integrations/codex/plugins/cognee/scripts/store-user-prompt.py
@@ -190,3 +190,9 @@ def main():
 
 if __name__ == "__main__":
     main()
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": "",
+        }
+    }))

--- a/integrations/codex/tests/test_user_prompt_hooks.py
+++ b/integrations/codex/tests/test_user_prompt_hooks.py
@@ -1,0 +1,59 @@
+"""Contract tests for Codex UserPromptSubmit hook output."""
+
+import asyncio
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_SCRIPTS = _ROOT / "plugins" / "cognee" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+
+def _load_script(name):
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_"), _SCRIPTS / name)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_context_output_uses_codex_schema(tmp_path, monkeypatch):
+    module = _load_script("session-context-lookup.py")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(module, "load_config", lambda: {})
+    monkeypatch.setattr(module, "resolve_runtime_mode", lambda: {"mode": "http", "base_url": ""})
+    monkeypatch.setattr(module, "server_ready_hint", lambda _url: True)
+    monkeypatch.setattr(module, "get_session_key", lambda: "session")
+    monkeypatch.setattr(
+        module,
+        "read_and_reset_save_counter",
+        lambda _session: {"prompt": 0, "trace": 0, "answer": 0},
+    )
+    monkeypatch.setattr(module, "recall_via_http", lambda *args, **kwargs: [])
+    monkeypatch.setattr(module, "render_status_for_host", lambda _session: "Cognee")
+
+    output = asyncio.run(module._run("remember this"))
+
+    assert output["systemMessage"].startswith("Cognee")
+    assert "systemMessage" not in output["hookSpecificOutput"]
+    assert output["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+
+
+def test_noop_hooks_emit_valid_user_prompt_submit_json(tmp_path):
+    payload = json.dumps({"session_id": "test", "prompt": "no"})
+    for script in ("session-context-lookup.py", "store-user-prompt.py"):
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPTS / script)],
+            input=payload,
+            text=True,
+            capture_output=True,
+            check=True,
+            env={"HOME": str(tmp_path), "PATH": str(pathlib.Path(sys.executable).parent)},
+        )
+        output = json.loads(result.stdout)
+        assert output["hookSpecificOutput"] == {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": "",
+        }


### PR DESCRIPTION
## Summary

- emit a valid `UserPromptSubmit` response when Cognee has no context to return
- place `systemMessage` at the top level of the Codex hook response
- add contract tests for both Codex user-prompt hooks

## Root cause

The Codex integration could either write nothing to stdout or put `systemMessage` inside `hookSpecificOutput`. Codex validates each `UserPromptSubmit` command against its event-specific JSON schema, so both cases surfaced as `hook returned invalid user prompt submit JSON output`.

## Impact

Cognee recall and prompt persistence now complete without emitting hook failures, including early-return and no-op paths.

## Validation

- `uvx --with pytest --with pytest-asyncio pytest integrations/codex/tests/test_user_prompt_hooks.py -q` — 2 passed
- `uvx ruff check integrations/codex/plugins/cognee/scripts/session-context-lookup.py integrations/codex/plugins/cognee/scripts/store-user-prompt.py integrations/codex/tests/test_user_prompt_hooks.py` — passed
- live `codex exec` validation — all three configured `UserPromptSubmit` hooks completed

The complete Codex test directory currently reports 23 passed and 4 unrelated failures in `test_improve_sync.py`; those mocks do not accept the existing `context=` argument passed to `urlopen`.
