### PR TITLE
fix(codex): avoid remote lookups in persistence hooks

### DIFF
--- a/integrations/codex/plugins/cognee/scripts/store-to-session.py
+++ b/integrations/codex/plugins/cognee/scripts/store-to-session.py
@@ -113,14 +113,16 @@ def _infer_status(payload: dict) -> tuple[str, str]:
     return "success", ""
 
 
-def _load_session() -> tuple[str, str, str]:
-    """Load session_id, dataset, user_id from resolved cache with fallbacks."""
+def _load_session(config: dict, *, use_http: bool) -> tuple[str, str, str]:
+    """Load session metadata without network I/O in latency-sensitive HTTP hooks."""
+    if use_http:
+        return get_session_id(config), get_dataset(config), ""
+
     resolved = load_resolved()
     session_id = resolved.get("session_id", "")
     dataset = resolved.get("dataset", "")
     user_id = resolved.get("user_id", "")
     if not session_id or not dataset:
-        config = load_config()
         session_id = session_id or get_session_id(config)
         dataset = dataset or get_dataset(config)
     return session_id, dataset, user_id
@@ -155,14 +157,14 @@ async def _store_tool_call(payload: dict) -> None:
 
     return_value = _truncate_str(tool_output, _MAX_RETURN_BYTES)
 
-    session_id, dataset, user_id = _load_session()
+    config = load_config()
+    runtime = resolve_runtime_mode()
+    use_http = runtime["mode"] == "http"
+    session_id, dataset, user_id = _load_session(config, use_http=use_http)
     if not session_id:
         hook_log("no_session_id", {"tool": tool_name})
         return
 
-    config = load_config()
-    runtime = resolve_runtime_mode()
-    use_http = runtime["mode"] == "http"
     entry = {
         "type": "trace",
         "origin_function": tool_name,
@@ -259,14 +261,14 @@ async def _store_assistant_stop(payload: dict) -> None:
 
     msg = _truncate_str(msg, _MAX_ASSISTANT_BYTES)
 
-    session_id, dataset, user_id = _load_session()
+    config = load_config()
+    runtime = resolve_runtime_mode()
+    use_http = runtime["mode"] == "http"
+    session_id, dataset, user_id = _load_session(config, use_http=use_http)
     if not session_id:
         hook_log("no_session_id", {"event": "stop"})
         return
 
-    config = load_config()
-    runtime = resolve_runtime_mode()
-    use_http = runtime["mode"] == "http"
     pending = pop_pending_prompt(session_id, turn_id=str(payload.get("turn_id") or ""))
 
     # Codex intentionally differs from Claude here: store one paired

--- a/integrations/codex/tests/test_store_hook_runtime.py
+++ b/integrations/codex/tests/test_store_hook_runtime.py
@@ -1,0 +1,42 @@
+"""Regression tests for latency-sensitive Codex persistence hooks."""
+
+import asyncio
+import importlib.util
+import pathlib
+import sys
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "plugins" / "cognee" / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+_SPEC = importlib.util.spec_from_file_location("store_to_session", _SCRIPTS / "store-to-session.py")
+store = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(store)
+
+
+def test_http_stop_buffers_without_remote_session_lookup(monkeypatch):
+    buffered = []
+    monkeypatch.setattr(store, "load_config", lambda: {})
+    monkeypatch.setattr(store, "get_session_id", lambda _config: "session")
+    monkeypatch.setattr(store, "get_dataset", lambda _config: "dataset")
+    monkeypatch.setattr(
+        store,
+        "load_resolved",
+        lambda: (_ for _ in ()).throw(AssertionError("unexpected remote lookup")),
+    )
+    monkeypatch.setattr(
+        store, "resolve_runtime_mode", lambda: {"mode": "http", "base_url": "https://example"}
+    )
+    monkeypatch.setattr(
+        store,
+        "pop_pending_prompt",
+        lambda *_args, **_kwargs: {"prompt": "question", "context": ""},
+    )
+    monkeypatch.setattr(store, "server_ready_hint", lambda _url: False)
+    monkeypatch.setattr(store, "append_warmup_entry", lambda *args: buffered.append(args))
+    monkeypatch.setattr(store, "append_http_bridge_entry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(store, "bump_save_counter", lambda *args: None)
+    monkeypatch.setattr(store, "hook_log", lambda *args: None)
+
+    asyncio.run(store._store_assistant_stop({"assistant_message": "answer"}))
+
+    assert buffered[0][:2] == ("dataset", "session")


### PR DESCRIPTION
## Summary

- avoid remote runtime-state lookups in latency-sensitive Codex persistence hooks when using HTTP mode
- keep the existing resolved session and user lookup for local SDK mode
- add a regression test for the `Stop` hook's server-warming path

## Root cause

`store-to-session.py` called `load_resolved()` before every `PostToolUse` and `Stop` write. Despite its cache-oriented name, that function queries the Cognee connection and user endpoints with timeouts of up to 10 seconds each. A slow or unavailable backend could therefore consume Codex's entire 15-second hook budget before the response was buffered locally.

## Impact

HTTP-mode persistence hooks now derive the session ID and dataset from local configuration and can immediately buffer entries when the backend is unavailable. Local SDK mode retains the previous resolved-user behavior.

## Validation

- `uvx --with pytest --with pytest-asyncio pytest integrations/codex/tests/test_store_hook_runtime.py -q` — 1 passed
- `uvx ruff check integrations/codex/plugins/cognee/scripts/store-to-session.py integrations/codex/tests/test_store_hook_runtime.py` — passed
- independent correctness review — approved with no actionable issues

The complete Codex test directory reports 22 passed and 4 unrelated failures in `test_improve_sync.py`; those mocks do not accept the existing `context=` argument passed to `urlopen`.
