### PR TITLE
fix(integrations): stop the cognee-memory statusline crashing on Windows (SDK-253)

### DIFF
--- a/.github/workflows/plugin-windows-tests.yml
+++ b/.github/workflows/plugin-windows-tests.yml
@@ -2,8 +2,10 @@ name: Plugin Windows Tests
 
 # The claude-code and codex plugins ship platform-specific process helpers
 # (_proc.py: Windows liveness via OpenProcess/WaitForSingleObject, process
-# ancestry via CreateToolhelp32Snapshot). Those paths never run on the
-# ubuntu-only integration matrix, so exercise them on a real Windows runner.
+# ancestry via CreateToolhelp32Snapshot) and a status-line renderer whose stdio
+# encoding is Windows-sensitive (cp1252 cannot encode the health glyphs). Those
+# paths never run on the ubuntu-only integration matrix, so exercise them on a
+# real Windows runner.
 
 on:
   pull_request:
@@ -46,3 +48,9 @@ jobs:
 
       - name: codex process-helper tests
         run: python integrations/codex/tests/test_proc.py
+
+      - name: claude-code status-line renderer tests
+        run: python integrations/claude-code/tests/test_statusline_render.py
+
+      - name: codex status-line renderer tests
+        run: python integrations/codex/tests/test_statusline_render.py

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -158,6 +158,20 @@ def _evict_own_statusline() -> None:
 
 
 def main() -> None:
+    # Windows defaults stdio to the locale code page (e.g. cp1252), which cannot
+    # encode the status glyphs (●, ✕, ⬆) — the write raises UnicodeEncodeError,
+    # the renderer exits non-zero, and Claude Code drops the whole status line
+    # (cp1252 also fails to decode a non-ASCII cwd from the JSON context). Force
+    # UTF-8 on both streams: the context is UTF-8 and our output is UTF-8. Runtime
+    # reconfigure overrides the inherited encoding; best-effort, since a stream
+    # that can't be reconfigured (e.g. a captured stdout under test) is left as-is,
+    # matching this renderer's never-raise design.
+    for _stream in (sys.stdin, sys.stdout):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except Exception:
+            pass
+
     ctx = {}
     try:
         ctx = json.load(sys.stdin)  # consume stdin as required by Claude Code

--- a/integrations/claude-code/tests/test_statusline_render.py
+++ b/integrations/claude-code/tests/test_statusline_render.py
@@ -1,0 +1,90 @@
+"""Regression tests for the status-line renderer's stdio encoding.
+
+The renderer prints health glyphs (``●``/``✕``/``⬆``) to stdout. On Windows,
+stdout defaults to the locale code page (e.g. cp1252), which cannot encode
+those characters: the write raises ``UnicodeEncodeError``, the renderer exits
+non-zero, and Claude Code drops the whole status line (gh #272). ``main()``
+forces UTF-8 on stdio to prevent that.
+
+We reproduce the failure portably by launching the renderer as a subprocess
+with ``PYTHONIOENCODING=cp1252`` — the same narrow codec Windows uses by
+default — so the test is meaningful on any OS (the Windows CI runner exercises
+the real platform too). Run: `python integrations/claude-code/tests/test_statusline_render.py`
+(or via pytest).
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+_RENDERER = pathlib.Path(__file__).resolve().parents[1] / "scripts" / "cognee_statusline_render.py"
+_HEALTH_GLYPH = "●"  # ● — the U+25CF from the bug report; absent from cp1252
+
+
+def _run_under_encoding(io_encoding: str):
+    """Run the renderer with a forced stdio encoding and a fake, plugin-enabled
+    HOME, returning ``(returncode, stdout_bytes, stderr_text)``."""
+    with tempfile.TemporaryDirectory() as home:
+        home_path = pathlib.Path(home)
+        # server-ready.json makes the renderer emit the ● health prefix — the
+        # exact character that cannot be encoded under cp1252.
+        (home_path / ".cognee-plugin").mkdir(parents=True)
+        (home_path / ".cognee-plugin" / "server-ready.json").write_text("{}", encoding="utf-8")
+        # Enable the plugin in user settings so the renderer does not self-evict
+        # (which would render nothing and hide the encoding path under test).
+        claude_dir = home_path / ".claude"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "settings.json").write_text(
+            '{"enabledPlugins": {"cognee-memory@cognee": true}}', encoding="utf-8"
+        )
+
+        env = os.environ.copy()
+        env["HOME"] = home  # POSIX
+        env["USERPROFILE"] = home  # Windows: Path.home() prefers this
+        env["PYTHONIOENCODING"] = io_encoding
+        env["COGNEE_UPDATE_CHECK"] = "0"  # suppress the update segment
+        env.pop("COGNEE_BASE_URL", None)  # -> local mode
+        env.pop("COGNEE_PLUGIN_DATASET", None)  # -> default dataset
+
+        proc = subprocess.run(
+            [sys.executable, str(_RENDERER)],
+            input=b"{}",
+            capture_output=True,
+            env=env,
+        )
+        return proc.returncode, proc.stdout, proc.stderr.decode("utf-8", "replace")
+
+
+def _assert_renders_glyph(io_encoding: str):
+    code, out, err = _run_under_encoding(io_encoding)
+    assert code == 0, f"renderer exited {code} under {io_encoding}; stderr:\n{err}"
+    assert "Traceback" not in err, f"renderer raised under {io_encoding}:\n{err}"
+    text = out.decode("utf-8")  # renderer must emit UTF-8 regardless of the codepage
+    assert _HEALTH_GLYPH in text, f"health glyph missing under {io_encoding}: {text!r}"
+    assert "cognee:" in text, f"status body missing under {io_encoding}: {text!r}"
+
+
+def test_glyph_renders_under_legacy_codepage():
+    # The regression: on cp1252 the unpatched renderer crashes with
+    # UnicodeEncodeError on U+25CF and Claude Code drops the status line.
+    _assert_renders_glyph("cp1252")
+
+
+def test_glyph_renders_under_utf8():
+    # Sanity: the UTF-8 forcing must not disturb the normal (already-UTF-8) path.
+    _assert_renders_glyph("utf-8")
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
@@ -93,6 +93,20 @@ def render_status_for_host(host_id: str) -> str:
 
 
 def main() -> None:
+    # Windows defaults stdio to the locale code page (e.g. cp1252), which cannot
+    # encode the status glyphs (●, ✕, ⬆); writing one raises UnicodeEncodeError
+    # and exits non-zero. Force UTF-8 on both streams so this renderer stays
+    # crash-free when invoked directly via cognee-statusline.sh. Kept inside
+    # main() (not at module scope) because session-start.py and
+    # session-context-lookup.py import render_status_for_host — a module-level
+    # reconfigure would hijack the importer's stdout. Best-effort: a stream that
+    # can't be reconfigured (e.g. a captured stdout under test) is left as-is.
+    for _stream in (sys.stdin, sys.stdout):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except Exception:
+            pass
+
     try:
         json.load(sys.stdin)  # consume stdin as required by the host
     except Exception:

--- a/integrations/codex/tests/test_statusline_render.py
+++ b/integrations/codex/tests/test_statusline_render.py
@@ -1,0 +1,89 @@
+"""Regression tests for the status-line renderer's stdio encoding (Codex).
+
+The renderer prints health glyphs (``●``/``✕``/``⬆``) to stdout. On Windows,
+stdout defaults to the locale code page (e.g. cp1252), which cannot encode
+those characters: the write raises ``UnicodeEncodeError`` and the renderer
+exits non-zero (gh #272). ``main()`` forces UTF-8 on stdio to prevent that.
+
+Codex's live status path escapes the glyphs through ``json.dumps`` (ensure_ascii)
+and so does not crash, but ``cognee-statusline.sh`` invokes this renderer
+directly — this test guards that entrypoint. We reproduce the failure portably
+with ``PYTHONIOENCODING=cp1252`` (the codec Windows uses by default), so the
+test is meaningful on any OS. Run: `python integrations/codex/tests/test_statusline_render.py`
+(or via pytest).
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+_RENDERER = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "plugins"
+    / "cognee"
+    / "scripts"
+    / "cognee_statusline_render.py"
+)
+_HEALTH_GLYPH = "●"  # ● — the U+25CF from the bug report; absent from cp1252
+
+
+def _run_under_encoding(io_encoding: str):
+    """Run the renderer with a forced stdio encoding and a fake HOME holding the
+    server-ready marker, returning ``(returncode, stdout_bytes, stderr_text)``."""
+    with tempfile.TemporaryDirectory() as home:
+        home_path = pathlib.Path(home)
+        # server-ready.json makes the renderer emit the ● health prefix — the
+        # exact character that cannot be encoded under cp1252.
+        (home_path / ".cognee-plugin").mkdir(parents=True)
+        (home_path / ".cognee-plugin" / "server-ready.json").write_text("{}", encoding="utf-8")
+
+        env = os.environ.copy()
+        env["HOME"] = home  # POSIX
+        env["USERPROFILE"] = home  # Windows: Path.home() prefers this
+        env["PYTHONIOENCODING"] = io_encoding
+        env["COGNEE_UPDATE_CHECK"] = "0"  # suppress the update segment
+        env.pop("COGNEE_BASE_URL", None)  # -> local mode
+        env.pop("COGNEE_PLUGIN_DATASET", None)  # -> default dataset
+
+        proc = subprocess.run(
+            [sys.executable, str(_RENDERER)],
+            input=b"{}",
+            capture_output=True,
+            env=env,
+        )
+        return proc.returncode, proc.stdout, proc.stderr.decode("utf-8", "replace")
+
+
+def _assert_renders_glyph(io_encoding: str):
+    code, out, err = _run_under_encoding(io_encoding)
+    assert code == 0, f"renderer exited {code} under {io_encoding}; stderr:\n{err}"
+    assert "Traceback" not in err, f"renderer raised under {io_encoding}:\n{err}"
+    text = out.decode("utf-8")  # renderer must emit UTF-8 regardless of the codepage
+    assert _HEALTH_GLYPH in text, f"health glyph missing under {io_encoding}: {text!r}"
+    assert "cognee:" in text, f"status body missing under {io_encoding}: {text!r}"
+
+
+def test_glyph_renders_under_legacy_codepage():
+    # The regression: on cp1252 the unpatched renderer crashes with
+    # UnicodeEncodeError on U+25CF.
+    _assert_renders_glyph("cp1252")
+
+
+def test_glyph_renders_under_utf8():
+    # Sanity: the UTF-8 forcing must not disturb the normal (already-UTF-8) path.
+    _assert_renders_glyph("utf-8")
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Summary

Closes #272. Linear: SDK-253.

The Claude Code plugin status line renders once and then disappears on Windows. On Windows, Python defaults stdout to the locale code page (e.g. `cp1252`), which cannot encode the status-line health glyphs `●` (U+25CF), `✕` (U+2715) or `⬆` (U+2B06). `cognee_statusline_render.py` writes them straight to stdout, so the write raises `UnicodeEncodeError`, the renderer exits non-zero, and Claude Code drops the whole status line. The same `cp1252` default also fails to decode a non-ASCII `cwd` from the JSON context piped on stdin.

## What changed

**1. `fix: force UTF-8 stdio in the status-line renderer (claude-code + codex)`**

- At the top of `main()` in both renderers, reconfigure **stdin and stdout** to UTF-8 (`_stream.reconfigure(encoding="utf-8")`), best-effort so a stream that can't be reconfigured (e.g. a captured stdout under test) is left as-is — matching the renderer's never-raise design.
- A runtime `reconfigure()` overrides the inherited code page regardless of how the interpreter was launched (unlike `-X utf8` / UTF-8 mode, which `PYTHONIOENCODING` can beat).
- Kept **inside `main()`, not at module scope**, because codex's `session-start.py` and `session-context-lookup.py` `import cognee_statusline_render` for `render_status_for_host`; a module-level reconfigure would hijack the importer's stdout. (codex's live status path emits glyphs via `print(json.dumps(...))`, where `ensure_ascii=True` escapes them to ASCII and is already crash-free — the renderer is fixed anyway for parity and to harden its direct `cognee-statusline.sh` entrypoint.)

**2. Regression coverage on the Windows CI**

- New `test_statusline_render.py` in both trees launches the renderer as a subprocess under `PYTHONIOENCODING=cp1252` (the codec Windows uses by default) with a fake, plugin-enabled HOME that forces the `●` prefix, and asserts exit 0 + UTF-8-decodable output containing the glyph. Reproduces the crash portably on any OS and fails on the unpatched renderer. Dual-mode (pytest + built-in runner), like `test_proc.py`.
- Wired both into `.github/workflows/plugin-windows-tests.yml` — the only CI that runs these suites (claude-code/codex have no `pyproject.toml`, so they're absent from the `ci.yml` matrix; that gap is why CI didn't catch this).

## Notes

- The reporter's second item — a `/#` typo on `cognee-statusline.sh` line 7 — is **already fixed on `main`**: the comment header was rewritten since the reporter's 0.2.0 baseline, and no `/#` remains in either tree. No change needed.
- No `plugin.json` / `marketplace.json` / CHANGELOG bump — consistent with #266 (SDK-238), the analogous Windows fix for these plugins; versions are batched at release.

## Verification

- Unpatched renderer: exits 1 with `UnicodeEncodeError: '●'` under `cp1252`. Patched: exits 0 and emits `● cognee: agent_sessions · local`.
- Full claude-code + codex suites green except the two pre-existing `context=`-kwarg failures (`test_bridge_poll`, `test_improve_sync`) that fail on `main` independently and are untouched here.
- `ruff format --check` + `ruff check` clean over `integrations/` at line-length 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
