### PR TITLE
docs(hermes): clarify unpublished PyPI package

### DIFF
--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -19,9 +19,11 @@ Python package with the `hermes_agent.plugins` entry point.
 
 ## Install For Local Hermes Development
 
-From this repository:
+From a fresh checkout of this repository:
 
 ```bash
+git clone https://github.com/topoteretes/cognee-integrations.git
+cd cognee-integrations
 mkdir -p ~/.hermes/plugins/cognee
 cp -R integrations/hermes-agent/. ~/.hermes/plugins/cognee/
 hermes memory setup
@@ -29,14 +31,12 @@ hermes memory setup
 
 Select `cognee` in the memory provider picker.
 
-## Install From Pip
+## PyPI Availability
 
-```bash
-pip install cognee-integration-hermes-agent
-hermes memory setup
-```
+`cognee-integration-hermes-agent` is not currently published on PyPI. Use the
+local installation steps above until a release is available.
 
-The package exposes:
+The project is prepared for future package distribution and exposes:
 
 ```toml
 [project.entry-points."hermes_agent.plugins"]
@@ -146,4 +146,3 @@ uv sync --dev
 uv run pytest -q
 uv run ruff check .
 ```
-


### PR DESCRIPTION
## Summary

- remove the unusable PyPI installation command for the unpublished Hermes package
- make the supported local installation path self-contained with clone and checkout steps
- retain the entry-point details for future package distribution

Fixes topoteretes/cognee#4181

## Testing

- `uv sync --locked --dev`
- `uv run pytest tests/ -v` — 26 passed, 2 skipped
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — 11 files already formatted
- `git diff --check` — passed
