### PR TITLE
feat(doctor): add a cognee doctor diagnostic command for claude-code & codex (SDK-298)

### DIFF
--- a/integrations/claude-code/scripts/cognee-doctor.sh
+++ b/integrations/claude-code/scripts/cognee-doctor.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Cognee Doctor — diagnostics for the Claude Code plugin.
+#
+# Usage:
+#   cognee-doctor.sh            # human-readable output
+#   cognee-doctor.sh --json     # JSON output
+
+set -euo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+exec python3 "${SELF_DIR}/doctor.py" "$@"

--- a/integrations/claude-code/scripts/doctor.py
+++ b/integrations/claude-code/scripts/doctor.py
@@ -26,6 +26,7 @@ _SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parent)
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
+
 def _resolve_local_cognee_version() -> str:
     """Cognee version installed in the plugin's managed venv.
 
@@ -143,7 +144,6 @@ def _resolve_server_version(health_body: dict | None) -> str:
     return "Unknown"
 
 
-
 def _resolve_circuit_breaker() -> str:
     """Return a human description of the circuit breaker state."""
     from _cognee_client import breaker_open
@@ -191,6 +191,7 @@ def collect_report() -> dict:
         "circuit_breaker": circuit_breaker,
     }
 
+
 _DISPLAY_ORDER = [
     ("Mode", "mode"),
     ("Server URL", "server_url"),
@@ -203,6 +204,7 @@ _DISPLAY_ORDER = [
     ("Embedding Dims", "embedding_dimensions"),
     ("Circuit Breaker", "circuit_breaker"),
 ]
+
 
 def _format_value(key: str, value) -> str:
     """Format a single report value for human display."""

--- a/integrations/claude-code/scripts/doctor.py
+++ b/integrations/claude-code/scripts/doctor.py
@@ -114,9 +114,13 @@ def _check_health(server_url: str, timeout: float = 5.0) -> dict:
     base = server_url.rstrip("/") if server_url else ""
     if not base:
         return {"reachable": False, "latency_ms": None, "raw_body": None}
+    from _plugin_common import _https_context
+
     try:
         t0 = time.monotonic()
-        with urllib.request.urlopen(f"{base}/health", timeout=timeout) as resp:
+        with urllib.request.urlopen(
+            f"{base}/health", timeout=timeout, context=_https_context()
+        ) as resp:
             latency = (time.monotonic() - t0) * 1000  # ms
             body_text = resp.read().decode("utf-8", errors="replace")
             try:

--- a/integrations/claude-code/scripts/doctor.py
+++ b/integrations/claude-code/scripts/doctor.py
@@ -20,14 +20,10 @@ import time
 import urllib.error
 import urllib.request
 
-# Ensure the scripts directory is on sys.path so sibling modules resolve.
+#Ensure the scripts directory is on sys.path so sibling modules resolve.
 _SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parent)
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
-
-# ---------------------------------------------------------------------------
-# Plugin-version resolution
-# ---------------------------------------------------------------------------
 
 _INVENTORY_SLUG = "claude-code"
 
@@ -71,29 +67,28 @@ def _parse_inventory_version(path: pathlib.Path, slug: str) -> str:
     return "Unknown"
 
 
-# ---------------------------------------------------------------------------
-# Mode resolution
-# ---------------------------------------------------------------------------
-
-
 def _resolve_mode() -> str:
-    """Return the resolved operating mode: Cloud, Local, or Server."""
-    from config import is_cloud_mode, is_local_mode, load_config
+    """Return the resolved operating mode: Local, Local Managed, or Cloud.
+
+    - No base_url configured → Local
+    - base_url pointing to localhost / 127.0.0.1 / ::1 → Local Managed
+    - Remote base_url → Cloud
+    """
+    import urllib.parse
+
+    from config import load_config
 
     cfg = load_config()
-    if is_cloud_mode(cfg):
-        return "Cloud"
-    if is_local_mode(cfg):
+    base_url = str(cfg.get("base_url") or "").strip()
+
+    if not base_url:
         return "Local"
-    # A base_url without an LLM key is the legacy "server" mode.
-    if cfg.get("base_url"):
-        return "Server"
-    return "Local"
 
+    hostname = urllib.parse.urlparse(base_url).hostname or ""
+    if hostname in ("localhost", "127.0.0.1", "::1"):
+        return "Local Managed"
 
-# ---------------------------------------------------------------------------
-# Server URL resolution
-# ---------------------------------------------------------------------------
+    return "Cloud"
 
 
 def _resolve_server_url() -> tuple:
@@ -110,10 +105,6 @@ def _resolve_server_url() -> tuple:
     return display, url
 
 
-# ---------------------------------------------------------------------------
-# API-key source resolution
-# ---------------------------------------------------------------------------
-
 _KEY_SOURCE_LABELS = {
     "env_api_key": "ENV",
     "cache_single_key": "Config",
@@ -127,11 +118,6 @@ def _resolve_api_key_source() -> str:
 
     _key, source = _api_key_with_source()
     return _KEY_SOURCE_LABELS.get(source, source)
-
-
-# ---------------------------------------------------------------------------
-# Health check (reachability + latency)
-# ---------------------------------------------------------------------------
 
 
 def _check_health(server_url: str, timeout: float = 5.0) -> dict:
@@ -159,11 +145,6 @@ def _check_health(server_url: str, timeout: float = 5.0) -> dict:
         return {"reachable": False, "latency_ms": None, "raw_body": None}
 
 
-# ---------------------------------------------------------------------------
-# Server version
-# ---------------------------------------------------------------------------
-
-
 def _resolve_server_version(health_body: dict | None) -> str:
     """Extract a server version from the health response, if present."""
     if isinstance(health_body, dict):
@@ -172,10 +153,6 @@ def _resolve_server_version(health_body: dict | None) -> str:
             return str(version).strip()
     return "Unknown"
 
-
-# ---------------------------------------------------------------------------
-# Circuit breaker state
-# ---------------------------------------------------------------------------
 
 
 def _resolve_circuit_breaker() -> str:
@@ -186,11 +163,6 @@ def _resolve_circuit_breaker() -> str:
     if is_open:
         return f"Open (retry in ~{retry}s)"
     return "Closed"
-
-
-# ---------------------------------------------------------------------------
-# Assemble the full report
-# ---------------------------------------------------------------------------
 
 
 def collect_report() -> dict:
@@ -216,11 +188,6 @@ def collect_report() -> dict:
         "circuit_breaker": circuit_breaker,
     }
 
-
-# ---------------------------------------------------------------------------
-# Output formatters
-# ---------------------------------------------------------------------------
-
 _DISPLAY_ORDER = [
     ("Mode", "mode"),
     ("Server URL", "server_url"),
@@ -233,7 +200,6 @@ _DISPLAY_ORDER = [
     ("Embedding Dims", "embedding_dimensions"),
     ("Circuit Breaker", "circuit_breaker"),
 ]
-
 
 def _format_value(key: str, value) -> str:
     """Format a single report value for human display."""
@@ -263,11 +229,6 @@ def format_human(report: dict) -> str:
 def format_json(report: dict) -> str:
     """Render the report as pretty-printed JSON."""
     return json.dumps(report, indent=2)
-
-
-# ---------------------------------------------------------------------------
-# CLI entry point
-# ---------------------------------------------------------------------------
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/integrations/claude-code/scripts/doctor.py
+++ b/integrations/claude-code/scripts/doctor.py
@@ -15,6 +15,7 @@ resources, writes files, or mutates state.
 import json
 import os
 import pathlib
+import subprocess
 import sys
 import time
 import urllib.error
@@ -25,43 +26,27 @@ _SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parent)
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
-_INVENTORY_SLUG = "claude-code"
+def _resolve_local_cognee_version() -> str:
+    """Cognee version installed in the plugin's managed venv.
 
-
-def _resolve_plugin_version() -> str:
-    """Read the plugin version from inventory.yml.
-
-    Walks up from the scripts directory looking for inventory.yml,
-    then extracts the current_version for the claude-code slug.
-    Falls back to "Unknown" if the file is missing or unparseable.
+    The plugin installs cognee into ~/.cognee-plugin/venv at session start;
+    probe that interpreter directly. Returns "Not installed" when the venv is
+    absent and "Unknown" if the probe fails.
     """
-    search = pathlib.Path(__file__).resolve().parent
-    for _ in range(10):
-        candidate = search / "inventory.yml"
-        if candidate.exists():
-            return _parse_inventory_version(candidate, _INVENTORY_SLUG)
-        if search.parent == search:
-            break
-        search = search.parent
-    return "Unknown"
+    from _plugin_common import _VENV_PYTHON
 
-
-def _parse_inventory_version(path: pathlib.Path, slug: str) -> str:
-    """Extract current_version for *slug* from a YAML inventory file.
-
-    Uses a simple line-scanner instead of importing PyYAML (which may
-    not be installed in the host interpreter).
-    """
+    if not _VENV_PYTHON.exists():
+        return "Not installed"
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-        found_slug = False
-        for line in lines:
-            stripped = line.strip()
-            if stripped.startswith("- slug:"):
-                found_slug = stripped.split(":", 1)[1].strip().strip('"').strip("'") == slug
-            elif found_slug and stripped.startswith("current_version:"):
-                raw = stripped.split(":", 1)[1].strip().strip('"').strip("'")
-                return raw or "Unknown"
+        probe = "import importlib.metadata as m; print(m.version('cognee'))"
+        out = subprocess.run(
+            [str(_VENV_PYTHON), "-c", probe],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            return out.stdout.strip()
     except Exception:
         pass
     return "Unknown"
@@ -184,8 +169,8 @@ def collect_report() -> dict:
     display_url, raw_url = _resolve_server_url()
     api_key_source = _resolve_api_key_source()
     health = _check_health(raw_url)
-    server_version = _resolve_server_version(health["raw_body"])
-    plugin_version = _resolve_plugin_version()
+    cognee_server = _resolve_server_version(health["raw_body"])
+    cognee_local = _resolve_local_cognee_version()
     circuit_breaker = _resolve_circuit_breaker()
     embedding_model, embedding_dimensions = _resolve_embedding()
 
@@ -195,8 +180,8 @@ def collect_report() -> dict:
         "api_key_source": api_key_source,
         "reachable": health["reachable"],
         "latency_ms": health["latency_ms"],
-        "plugin_version": plugin_version,
-        "server_version": server_version,
+        "cognee_local": cognee_local,
+        "cognee_server": cognee_server,
         "embedding_model": embedding_model,
         "embedding_dimensions": embedding_dimensions,
         "circuit_breaker": circuit_breaker,
@@ -208,8 +193,8 @@ _DISPLAY_ORDER = [
     ("API Key Source", "api_key_source"),
     ("Reachable", "reachable"),
     ("Latency", "latency_ms"),
-    ("Plugin Version", "plugin_version"),
-    ("Server Version", "server_version"),
+    ("Cognee (local)", "cognee_local"),
+    ("Cognee (server)", "cognee_server"),
     ("Embedding Model", "embedding_model"),
     ("Embedding Dims", "embedding_dimensions"),
     ("Circuit Breaker", "circuit_breaker"),

--- a/integrations/claude-code/scripts/doctor.py
+++ b/integrations/claude-code/scripts/doctor.py
@@ -20,7 +20,7 @@ import time
 import urllib.error
 import urllib.request
 
-#Ensure the scripts directory is on sys.path so sibling modules resolve.
+# Ensure the scripts directory is on sys.path so sibling modules resolve.
 _SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parent)
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
@@ -165,6 +165,19 @@ def _resolve_circuit_breaker() -> str:
     return "Closed"
 
 
+def _resolve_embedding() -> tuple[str, str]:
+    """Embedding model + dimensions from the environment cognee reads.
+
+    cognee resolves embeddings from EMBEDDING_MODEL / EMBEDDING_DIMENSIONS; no
+    HTTP endpoint exposes them, so we surface what the local environment sets
+    (the values that govern local mode). "Default" means unset — cognee falls
+    back to its built-in default.
+    """
+    model = (os.environ.get("EMBEDDING_MODEL") or "").strip() or "Default"
+    dims = (os.environ.get("EMBEDDING_DIMENSIONS") or "").strip() or "Default"
+    return model, dims
+
+
 def collect_report() -> dict:
     """Gather all diagnostic fields into an ordered dict."""
     mode = _resolve_mode()
@@ -174,6 +187,7 @@ def collect_report() -> dict:
     server_version = _resolve_server_version(health["raw_body"])
     plugin_version = _resolve_plugin_version()
     circuit_breaker = _resolve_circuit_breaker()
+    embedding_model, embedding_dimensions = _resolve_embedding()
 
     return {
         "mode": mode,
@@ -183,8 +197,8 @@ def collect_report() -> dict:
         "latency_ms": health["latency_ms"],
         "plugin_version": plugin_version,
         "server_version": server_version,
-        "embedding_model": "Unknown",
-        "embedding_dimensions": "Unknown",
+        "embedding_model": embedding_model,
+        "embedding_dimensions": embedding_dimensions,
         "circuit_breaker": circuit_breaker,
     }
 

--- a/integrations/claude-code/scripts/doctor.py
+++ b/integrations/claude-code/scripts/doctor.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Cognee Doctor — unified diagnostics for the Claude Code plugin.
+
+Read-only command that aggregates configuration, connectivity, and
+circuit-breaker state into a single diagnostic report.
+
+Usage:
+    python doctor.py           # human-readable table
+    python doctor.py --json    # machine-readable JSON
+
+Never modifies configuration, initialises databases, registers
+resources, writes files, or mutates state.
+"""
+
+import json
+import os
+import pathlib
+import sys
+import time
+import urllib.error
+import urllib.request
+
+# Ensure the scripts directory is on sys.path so sibling modules resolve.
+_SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+# ---------------------------------------------------------------------------
+# Plugin-version resolution
+# ---------------------------------------------------------------------------
+
+_INVENTORY_SLUG = "claude-code"
+
+
+def _resolve_plugin_version() -> str:
+    """Read the plugin version from inventory.yml.
+
+    Walks up from the scripts directory looking for inventory.yml,
+    then extracts the current_version for the claude-code slug.
+    Falls back to "Unknown" if the file is missing or unparseable.
+    """
+    search = pathlib.Path(__file__).resolve().parent
+    for _ in range(10):
+        candidate = search / "inventory.yml"
+        if candidate.exists():
+            return _parse_inventory_version(candidate, _INVENTORY_SLUG)
+        if search.parent == search:
+            break
+        search = search.parent
+    return "Unknown"
+
+
+def _parse_inventory_version(path: pathlib.Path, slug: str) -> str:
+    """Extract current_version for *slug* from a YAML inventory file.
+
+    Uses a simple line-scanner instead of importing PyYAML (which may
+    not be installed in the host interpreter).
+    """
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+        found_slug = False
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("- slug:"):
+                found_slug = stripped.split(":", 1)[1].strip().strip('"').strip("'") == slug
+            elif found_slug and stripped.startswith("current_version:"):
+                raw = stripped.split(":", 1)[1].strip().strip('"').strip("'")
+                return raw or "Unknown"
+    except Exception:
+        pass
+    return "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# Mode resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_mode() -> str:
+    """Return the resolved operating mode: Cloud, Local, or Server."""
+    from config import is_cloud_mode, is_local_mode, load_config
+
+    cfg = load_config()
+    if is_cloud_mode(cfg):
+        return "Cloud"
+    if is_local_mode(cfg):
+        return "Local"
+    # A base_url without an LLM key is the legacy "server" mode.
+    if cfg.get("base_url"):
+        return "Server"
+    return "Local"
+
+
+# ---------------------------------------------------------------------------
+# Server URL resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_server_url() -> tuple:
+    """Return (display_url, raw_url).
+
+    In local mode the display value is "-" (no remote server), but the
+    raw_url is still resolved so the health-check can probe localhost.
+    """
+    from _plugin_common import _local_api_url_with_source
+
+    url, _source = _local_api_url_with_source()
+    mode = _resolve_mode()
+    display = "-" if mode == "Local" else url
+    return display, url
+
+
+# ---------------------------------------------------------------------------
+# API-key source resolution
+# ---------------------------------------------------------------------------
+
+_KEY_SOURCE_LABELS = {
+    "env_api_key": "ENV",
+    "cache_single_key": "Config",
+    "missing": "Default",
+}
+
+
+def _resolve_api_key_source() -> str:
+    """Return a human-friendly label for where the API key came from."""
+    from _plugin_common import _api_key_with_source
+
+    _key, source = _api_key_with_source()
+    return _KEY_SOURCE_LABELS.get(source, source)
+
+
+# ---------------------------------------------------------------------------
+# Health check (reachability + latency)
+# ---------------------------------------------------------------------------
+
+
+def _check_health(server_url: str, timeout: float = 5.0) -> dict:
+    """Probe GET /health and return reachability + latency.
+
+    Returns a dict with keys: reachable (bool), latency_ms (float|None),
+    and raw_body (dict|None) for downstream consumers.
+    """
+    base = server_url.rstrip("/") if server_url else ""
+    if not base:
+        return {"reachable": False, "latency_ms": None, "raw_body": None}
+    try:
+        t0 = time.monotonic()
+        with urllib.request.urlopen(f"{base}/health", timeout=timeout) as resp:
+            latency = (time.monotonic() - t0) * 1000  # ms
+            body_text = resp.read().decode("utf-8", errors="replace")
+            try:
+                body = json.loads(body_text)
+            except (json.JSONDecodeError, ValueError):
+                body = None
+            if resp.status == 200:
+                return {"reachable": True, "latency_ms": round(latency, 1), "raw_body": body}
+        return {"reachable": False, "latency_ms": None, "raw_body": None}
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return {"reachable": False, "latency_ms": None, "raw_body": None}
+
+
+# ---------------------------------------------------------------------------
+# Server version
+# ---------------------------------------------------------------------------
+
+
+def _resolve_server_version(health_body: dict | None) -> str:
+    """Extract a server version from the health response, if present."""
+    if isinstance(health_body, dict):
+        version = health_body.get("version")
+        if version and str(version).strip():
+            return str(version).strip()
+    return "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker state
+# ---------------------------------------------------------------------------
+
+
+def _resolve_circuit_breaker() -> str:
+    """Return a human description of the circuit breaker state."""
+    from _cognee_client import breaker_open
+
+    is_open, retry = breaker_open()
+    if is_open:
+        return f"Open (retry in ~{retry}s)"
+    return "Closed"
+
+
+# ---------------------------------------------------------------------------
+# Assemble the full report
+# ---------------------------------------------------------------------------
+
+
+def collect_report() -> dict:
+    """Gather all diagnostic fields into an ordered dict."""
+    mode = _resolve_mode()
+    display_url, raw_url = _resolve_server_url()
+    api_key_source = _resolve_api_key_source()
+    health = _check_health(raw_url)
+    server_version = _resolve_server_version(health["raw_body"])
+    plugin_version = _resolve_plugin_version()
+    circuit_breaker = _resolve_circuit_breaker()
+
+    return {
+        "mode": mode,
+        "server_url": display_url if display_url != "-" else None,
+        "api_key_source": api_key_source,
+        "reachable": health["reachable"],
+        "latency_ms": health["latency_ms"],
+        "plugin_version": plugin_version,
+        "server_version": server_version,
+        "embedding_model": "Unknown",
+        "embedding_dimensions": "Unknown",
+        "circuit_breaker": circuit_breaker,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+_DISPLAY_ORDER = [
+    ("Mode", "mode"),
+    ("Server URL", "server_url"),
+    ("API Key Source", "api_key_source"),
+    ("Reachable", "reachable"),
+    ("Latency", "latency_ms"),
+    ("Plugin Version", "plugin_version"),
+    ("Server Version", "server_version"),
+    ("Embedding Model", "embedding_model"),
+    ("Embedding Dims", "embedding_dimensions"),
+    ("Circuit Breaker", "circuit_breaker"),
+]
+
+
+def _format_value(key: str, value) -> str:
+    """Format a single report value for human display."""
+    if key == "server_url":
+        return str(value) if value else "-"
+    if key == "reachable":
+        return "Yes" if value else "No"
+    if key == "latency_ms":
+        if value is None:
+            return "N/A"
+        return f"{value} ms"
+    if value is None:
+        return "N/A"
+    return str(value)
+
+
+def format_human(report: dict) -> str:
+    """Render the report as a human-readable table."""
+    lines = ["", "Cognee Doctor", ""]
+    for label, key in _DISPLAY_ORDER:
+        value = _format_value(key, report.get(key))
+        lines.append(f"{label + ':':<21}{value}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_json(report: dict) -> str:
+    """Render the report as pretty-printed JSON."""
+    return json.dumps(report, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = argv if argv is not None else sys.argv[1:]
+    use_json = "--json" in args
+
+    report = collect_report()
+
+    if use_json:
+        print(format_json(report))
+    else:
+        print(format_human(report))
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/claude-code/tests/test_doctor.py
+++ b/integrations/claude-code/tests/test_doctor.py
@@ -1,0 +1,298 @@
+"""Unit tests for the Cognee Doctor command (Claude Code plugin).
+
+Tests verify behaviour with mocked HTTP and filesystem state, covering:
+  - local vs server mode resolution
+  - reachable vs unreachable health endpoint
+  - env vs config API key source
+  - breaker state reporting
+  - JSON output format
+
+Run:
+    pytest integrations/claude-code/tests/test_doctor.py
+    python integrations/claude-code/tests/test_doctor.py   # standalone
+"""
+
+import io
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import textwrap
+import urllib.error
+
+# Put the scripts dir on sys.path so doctor.py and its siblings resolve.
+_SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parents[1] / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+# Isolate the circuit-breaker state dir before importing _cognee_client.
+_TMP = tempfile.mkdtemp(prefix="cognee-doctor-test-")
+os.environ["COGNEE_PLUGIN_STATE_DIR"] = _TMP
+
+import doctor  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset_env(*keys):
+    """Remove env vars that affect config resolution."""
+    for key in keys:
+        os.environ.pop(key, None)
+
+
+def _reset_breaker():
+    p = pathlib.Path(_TMP) / "recall-breaker.json"
+    if p.exists():
+        p.unlink()
+
+
+class _FakeResponse:
+    """Minimal stand-in for urllib.request.urlopen response."""
+
+    def __init__(self, status=200, body=b"{}"):
+        self.status = status
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Mode resolution
+# ---------------------------------------------------------------------------
+
+
+def test_local_mode_when_no_base_url():
+    _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "COGNEE_API_KEY", "LLM_API_KEY")
+    mode = doctor._resolve_mode()
+    # Without a base_url or llm_api_key, resolves to Local.
+    assert mode == "Local", f"expected Local, got {mode}"
+
+
+def test_server_mode_with_base_url():
+    os.environ["COGNEE_BASE_URL"] = "http://test-server:8011"
+    try:
+        mode = doctor._resolve_mode()
+        assert mode in ("Cloud", "Server"), f"expected Cloud or Server, got {mode}"
+    finally:
+        _reset_env("COGNEE_BASE_URL")
+
+
+# ---------------------------------------------------------------------------
+# Server URL display
+# ---------------------------------------------------------------------------
+
+
+def test_server_url_dash_in_local_mode():
+    _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "LLM_API_KEY")
+    display, _raw = doctor._resolve_server_url()
+    assert display == "-", f"expected '-', got {display}"
+
+
+def test_server_url_shown_in_server_mode():
+    os.environ["COGNEE_BASE_URL"] = "http://custom:9999"
+    try:
+        display, raw = doctor._resolve_server_url()
+        assert "custom:9999" in raw
+    finally:
+        _reset_env("COGNEE_BASE_URL")
+
+
+# ---------------------------------------------------------------------------
+# API key source
+# ---------------------------------------------------------------------------
+
+
+def test_api_key_source_env():
+    os.environ["COGNEE_API_KEY"] = "test-key-from-env"
+    try:
+        source = doctor._resolve_api_key_source()
+        assert source == "ENV", f"expected ENV, got {source}"
+    finally:
+        _reset_env("COGNEE_API_KEY")
+
+
+def test_api_key_source_config(tmp_path):
+    _reset_env("COGNEE_API_KEY")
+    # Temporarily swap the cache path to a temp file with a cached key.
+    import _plugin_common
+
+    original = _plugin_common._API_KEY_CACHE
+    cache_file = tmp_path / "api_key.json"
+    cache_file.write_text(json.dumps({"api_key": "cached-key", "base_url": ""}))
+    _plugin_common._API_KEY_CACHE = cache_file
+    try:
+        source = doctor._resolve_api_key_source()
+        assert source == "Config", f"expected Config, got {source}"
+    finally:
+        _plugin_common._API_KEY_CACHE = original
+
+
+# ---------------------------------------------------------------------------
+# Health check
+# ---------------------------------------------------------------------------
+
+
+def test_health_reachable(monkeypatch):
+    body = json.dumps({"status": "ok"}).encode()
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *a, **k: _FakeResponse(200, body),
+    )
+    result = doctor._check_health("http://fake:8011")
+    assert result["reachable"] is True
+    assert result["latency_ms"] is not None and result["latency_ms"] >= 0
+
+
+def test_health_unreachable(monkeypatch):
+    def _raise(*a, **k):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", _raise)
+    result = doctor._check_health("http://fake:8011")
+    assert result["reachable"] is False
+    assert result["latency_ms"] is None
+
+
+# ---------------------------------------------------------------------------
+# Server version
+# ---------------------------------------------------------------------------
+
+
+def test_server_version_unknown_when_not_in_body():
+    assert doctor._resolve_server_version({"status": "ok"}) == "Unknown"
+    assert doctor._resolve_server_version(None) == "Unknown"
+
+
+def test_server_version_extracted_when_present():
+    assert doctor._resolve_server_version({"version": "1.2.3"}) == "1.2.3"
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker
+# ---------------------------------------------------------------------------
+
+
+def test_breaker_closed():
+    _reset_breaker()
+    state = doctor._resolve_circuit_breaker()
+    assert state == "Closed", f"expected Closed, got {state}"
+
+
+def test_breaker_open():
+    import time as _time
+
+    breaker_path = pathlib.Path(_TMP) / "recall-breaker.json"
+    breaker_path.write_text(
+        json.dumps({"failures": 10, "cooldown_until": _time.time() + 60}),
+        encoding="utf-8",
+    )
+    state = doctor._resolve_circuit_breaker()
+    assert state.startswith("Open"), f"expected Open..., got {state}"
+    _reset_breaker()
+
+
+# ---------------------------------------------------------------------------
+# Plugin version (inventory lookup)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_inventory_version(tmp_path):
+    inventory = tmp_path / "inventory.yml"
+    inventory.write_text(
+        textwrap.dedent("""\
+        integrations:
+          - slug: claude-code
+            current_version: "0.1.0"
+          - slug: codex
+            current_version: "1.0.3-local"
+        """),
+        encoding="utf-8",
+    )
+    assert doctor._parse_inventory_version(inventory, "claude-code") == "0.1.0"
+    assert doctor._parse_inventory_version(inventory, "codex") == "1.0.3-local"
+    assert doctor._parse_inventory_version(inventory, "nonexistent") == "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# JSON output
+# ---------------------------------------------------------------------------
+
+
+def test_json_output(monkeypatch):
+    body = json.dumps({"status": "ok"}).encode()
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *a, **k: _FakeResponse(200, body),
+    )
+    _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "LLM_API_KEY")
+    _reset_breaker()
+
+    report = doctor.collect_report()
+    output = doctor.format_json(report)
+    parsed = json.loads(output)
+
+    expected_keys = {
+        "mode", "server_url", "api_key_source", "reachable", "latency_ms",
+        "plugin_version", "server_version", "embedding_model",
+        "embedding_dimensions", "circuit_breaker",
+    }
+    assert expected_keys == set(parsed.keys()), f"missing keys: {expected_keys - set(parsed.keys())}"
+
+
+# ---------------------------------------------------------------------------
+# Human-readable output
+# ---------------------------------------------------------------------------
+
+
+def test_human_output_contains_header():
+    _reset_breaker()
+    report = doctor.collect_report()
+    text = doctor.format_human(report)
+    assert "Cognee Doctor" in text
+    assert "Mode:" in text
+    assert "Circuit Breaker:" in text
+
+
+# ---------------------------------------------------------------------------
+# Standalone runner
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    # Lightweight standalone runner (no pytest dependency required).
+    failures = 0
+    skipped = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+
+        import inspect
+
+        sig = inspect.signature(fn)
+        params = list(sig.parameters.keys())
+
+        # Skip tests that require pytest fixtures when running standalone.
+        if "monkeypatch" in params or "tmp_path" in params:
+            skipped += 1
+            print(f"SKIP {name} (requires pytest fixtures)")
+            continue
+
+        try:
+            fn()
+            print(f"PASS {name}")
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL {name}: {e}")
+    if skipped:
+        print(f"\n{skipped} test(s) skipped (run with pytest for full coverage)")
+    sys.exit(1 if failures else 0)

--- a/integrations/claude-code/tests/test_doctor.py
+++ b/integrations/claude-code/tests/test_doctor.py
@@ -21,21 +21,14 @@ import tempfile
 import textwrap
 import urllib.error
 
-# Put the scripts dir on sys.path so doctor.py and its siblings resolve.
 _SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parents[1] / "scripts")
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
-# Isolate the circuit-breaker state dir before importing _cognee_client.
 _TMP = tempfile.mkdtemp(prefix="cognee-doctor-test-")
 os.environ["COGNEE_PLUGIN_STATE_DIR"] = _TMP
 
-import doctor  # noqa: E402
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+import doctor  # pyrefly: ignore [missing-import]
 
 
 def _reset_env(*keys):
@@ -67,31 +60,50 @@ class _FakeResponse:
         pass
 
 
-# ---------------------------------------------------------------------------
-# Mode resolution
-# ---------------------------------------------------------------------------
-
 
 def test_local_mode_when_no_base_url():
     _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "COGNEE_API_KEY", "LLM_API_KEY")
     mode = doctor._resolve_mode()
-    # Without a base_url or llm_api_key, resolves to Local.
     assert mode == "Local", f"expected Local, got {mode}"
 
 
-def test_server_mode_with_base_url():
-    os.environ["COGNEE_BASE_URL"] = "http://test-server:8011"
+def test_managed_mode_with_localhost():
+    os.environ["COGNEE_BASE_URL"] = "http://localhost:8011"
     try:
         mode = doctor._resolve_mode()
-        assert mode in ("Cloud", "Server"), f"expected Cloud or Server, got {mode}"
+        assert mode == "Local Managed", f"expected Local Managed, got {mode}"
     finally:
         _reset_env("COGNEE_BASE_URL")
 
 
-# ---------------------------------------------------------------------------
-# Server URL display
-# ---------------------------------------------------------------------------
+def test_managed_mode_with_127():
+    os.environ["COGNEE_BASE_URL"] = "http://127.0.0.1:8000"
+    try:
+        mode = doctor._resolve_mode()
+        assert mode == "Local Managed", f"expected Local Managed, got {mode}"
+    finally:
+        _reset_env("COGNEE_BASE_URL")
 
+
+def test_managed_mode_with_ipv6_loopback():
+    os.environ["COGNEE_BASE_URL"] = "http://[::1]:8000"
+    try:
+        mode = doctor._resolve_mode()
+        assert mode == "Local Managed", f"expected Local Managed, got {mode}"
+    finally:
+        _reset_env("COGNEE_BASE_URL")
+
+
+def test_cloud_mode_with_remote_url():
+    os.environ["COGNEE_BASE_URL"] = "https://company.cognee.ai"
+    try:
+        mode = doctor._resolve_mode()
+        assert mode == "Cloud", f"expected Cloud, got {mode}"
+    finally:
+        _reset_env("COGNEE_BASE_URL")
+
+
+# Server URL display
 
 def test_server_url_dash_in_local_mode():
     _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "LLM_API_KEY")
@@ -108,10 +120,7 @@ def test_server_url_shown_in_server_mode():
         _reset_env("COGNEE_BASE_URL")
 
 
-# ---------------------------------------------------------------------------
 # API key source
-# ---------------------------------------------------------------------------
-
 
 def test_api_key_source_env():
     os.environ["COGNEE_API_KEY"] = "test-key-from-env"
@@ -125,7 +134,8 @@ def test_api_key_source_env():
 def test_api_key_source_config(tmp_path):
     _reset_env("COGNEE_API_KEY")
     # Temporarily swap the cache path to a temp file with a cached key.
-    import _plugin_common
+    # pyrefly: ignore [missing-import]
+    import _plugin_common 
 
     original = _plugin_common._API_KEY_CACHE
     cache_file = tmp_path / "api_key.json"
@@ -138,10 +148,7 @@ def test_api_key_source_config(tmp_path):
         _plugin_common._API_KEY_CACHE = original
 
 
-# ---------------------------------------------------------------------------
 # Health check
-# ---------------------------------------------------------------------------
-
 
 def test_health_reachable(monkeypatch):
     body = json.dumps({"status": "ok"}).encode()
@@ -164,10 +171,7 @@ def test_health_unreachable(monkeypatch):
     assert result["latency_ms"] is None
 
 
-# ---------------------------------------------------------------------------
 # Server version
-# ---------------------------------------------------------------------------
-
 
 def test_server_version_unknown_when_not_in_body():
     assert doctor._resolve_server_version({"status": "ok"}) == "Unknown"
@@ -178,10 +182,7 @@ def test_server_version_extracted_when_present():
     assert doctor._resolve_server_version({"version": "1.2.3"}) == "1.2.3"
 
 
-# ---------------------------------------------------------------------------
 # Circuit breaker
-# ---------------------------------------------------------------------------
-
 
 def test_breaker_closed():
     _reset_breaker()
@@ -202,10 +203,7 @@ def test_breaker_open():
     _reset_breaker()
 
 
-# ---------------------------------------------------------------------------
 # Plugin version (inventory lookup)
-# ---------------------------------------------------------------------------
-
 
 def test_parse_inventory_version(tmp_path):
     inventory = tmp_path / "inventory.yml"
@@ -224,10 +222,7 @@ def test_parse_inventory_version(tmp_path):
     assert doctor._parse_inventory_version(inventory, "nonexistent") == "Unknown"
 
 
-# ---------------------------------------------------------------------------
 # JSON output
-# ---------------------------------------------------------------------------
-
 
 def test_json_output(monkeypatch):
     body = json.dumps({"status": "ok"}).encode()
@@ -250,11 +245,6 @@ def test_json_output(monkeypatch):
     assert expected_keys == set(parsed.keys()), f"missing keys: {expected_keys - set(parsed.keys())}"
 
 
-# ---------------------------------------------------------------------------
-# Human-readable output
-# ---------------------------------------------------------------------------
-
-
 def test_human_output_contains_header():
     _reset_breaker()
     report = doctor.collect_report()
@@ -264,12 +254,7 @@ def test_human_output_contains_header():
     assert "Circuit Breaker:" in text
 
 
-# ---------------------------------------------------------------------------
-# Standalone runner
-# ---------------------------------------------------------------------------
-
 if __name__ == "__main__":
-    # Lightweight standalone runner (no pytest dependency required).
     failures = 0
     skipped = 0
     for name, fn in sorted(globals().items()):

--- a/integrations/claude-code/tests/test_doctor.py
+++ b/integrations/claude-code/tests/test_doctor.py
@@ -4,21 +4,19 @@ Tests verify behaviour with mocked HTTP and filesystem state, covering:
   - local vs server mode resolution
   - reachable vs unreachable health endpoint
   - env vs config API key source
+  - local (venv) / server cognee version + embedding fields
   - breaker state reporting
   - JSON output format
 
-Run:
-    pytest integrations/claude-code/tests/test_doctor.py
-    python integrations/claude-code/tests/test_doctor.py   # standalone
+Every test runs under plain `python3 tests/test_doctor.py` (no pytest
+fixtures) as well as under `pytest`, matching the sibling test convention.
 """
 
-import io
 import json
 import os
 import pathlib
 import sys
 import tempfile
-import textwrap
 import urllib.error
 
 _SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parents[1] / "scripts")
@@ -28,7 +26,8 @@ if _SCRIPTS_DIR not in sys.path:
 _TMP = tempfile.mkdtemp(prefix="cognee-doctor-test-")
 os.environ["COGNEE_PLUGIN_STATE_DIR"] = _TMP
 
-import doctor  # pyrefly: ignore [missing-import]
+import _plugin_common  # noqa: E402
+import doctor  # noqa: E402
 
 
 def _reset_env(*keys):
@@ -44,7 +43,7 @@ def _reset_breaker():
 
 
 class _FakeResponse:
-    """Minimal stand-in for urllib.request.urlopen response."""
+    """Minimal stand-in for a urllib.request.urlopen response."""
 
     def __init__(self, status=200, body=b"{}"):
         self.status = status
@@ -60,18 +59,42 @@ class _FakeResponse:
         pass
 
 
+class _patch_urlopen:
+    """Context manager that swaps urllib.request.urlopen for a stub."""
+
+    def __init__(self, response=None, error=None):
+        self._response = response
+        self._error = error
+
+    def __enter__(self):
+        import urllib.request
+
+        self._mod = urllib.request
+        self._orig = urllib.request.urlopen
+
+        def _fake(*a, **k):
+            if self._error is not None:
+                raise self._error
+            return self._response
+
+        urllib.request.urlopen = _fake
+
+    def __exit__(self, *a):
+        self._mod.urlopen = self._orig
+
+
+# Mode resolution
+
 
 def test_local_mode_when_no_base_url():
     _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "COGNEE_API_KEY", "LLM_API_KEY")
-    mode = doctor._resolve_mode()
-    assert mode == "Local", f"expected Local, got {mode}"
+    assert doctor._resolve_mode() == "Local"
 
 
 def test_managed_mode_with_localhost():
     os.environ["COGNEE_BASE_URL"] = "http://localhost:8011"
     try:
-        mode = doctor._resolve_mode()
-        assert mode == "Local Managed", f"expected Local Managed, got {mode}"
+        assert doctor._resolve_mode() == "Local Managed"
     finally:
         _reset_env("COGNEE_BASE_URL")
 
@@ -79,8 +102,7 @@ def test_managed_mode_with_localhost():
 def test_managed_mode_with_127():
     os.environ["COGNEE_BASE_URL"] = "http://127.0.0.1:8000"
     try:
-        mode = doctor._resolve_mode()
-        assert mode == "Local Managed", f"expected Local Managed, got {mode}"
+        assert doctor._resolve_mode() == "Local Managed"
     finally:
         _reset_env("COGNEE_BASE_URL")
 
@@ -88,8 +110,7 @@ def test_managed_mode_with_127():
 def test_managed_mode_with_ipv6_loopback():
     os.environ["COGNEE_BASE_URL"] = "http://[::1]:8000"
     try:
-        mode = doctor._resolve_mode()
-        assert mode == "Local Managed", f"expected Local Managed, got {mode}"
+        assert doctor._resolve_mode() == "Local Managed"
     finally:
         _reset_env("COGNEE_BASE_URL")
 
@@ -97,24 +118,24 @@ def test_managed_mode_with_ipv6_loopback():
 def test_cloud_mode_with_remote_url():
     os.environ["COGNEE_BASE_URL"] = "https://company.cognee.ai"
     try:
-        mode = doctor._resolve_mode()
-        assert mode == "Cloud", f"expected Cloud, got {mode}"
+        assert doctor._resolve_mode() == "Cloud"
     finally:
         _reset_env("COGNEE_BASE_URL")
 
 
 # Server URL display
 
+
 def test_server_url_dash_in_local_mode():
     _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "LLM_API_KEY")
     display, _raw = doctor._resolve_server_url()
-    assert display == "-", f"expected '-', got {display}"
+    assert display == "-"
 
 
 def test_server_url_shown_in_server_mode():
     os.environ["COGNEE_BASE_URL"] = "http://custom:9999"
     try:
-        display, raw = doctor._resolve_server_url()
+        _display, raw = doctor._resolve_server_url()
         assert "custom:9999" in raw
     finally:
         _reset_env("COGNEE_BASE_URL")
@@ -122,59 +143,52 @@ def test_server_url_shown_in_server_mode():
 
 # API key source
 
+
 def test_api_key_source_env():
     os.environ["COGNEE_API_KEY"] = "test-key-from-env"
     try:
-        source = doctor._resolve_api_key_source()
-        assert source == "ENV", f"expected ENV, got {source}"
+        assert doctor._resolve_api_key_source() == "ENV"
     finally:
         _reset_env("COGNEE_API_KEY")
 
 
-def test_api_key_source_config(tmp_path):
-    _reset_env("COGNEE_API_KEY")
-    # Temporarily swap the cache path to a temp file with a cached key.
-    # pyrefly: ignore [missing-import]
-    import _plugin_common 
-
+def test_api_key_source_config():
+    # No env key; a cached key file should resolve to "Config".
+    _reset_env("COGNEE_API_KEY", "COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL")
     original = _plugin_common._API_KEY_CACHE
-    cache_file = tmp_path / "api_key.json"
+    cache_file = pathlib.Path(_TMP) / "api_key.json"
     cache_file.write_text(json.dumps({"api_key": "cached-key", "base_url": ""}))
     _plugin_common._API_KEY_CACHE = cache_file
     try:
-        source = doctor._resolve_api_key_source()
-        assert source == "Config", f"expected Config, got {source}"
+        assert doctor._resolve_api_key_source() == "Config"
     finally:
         _plugin_common._API_KEY_CACHE = original
+        _reset_env("COGNEE_API_KEY")
 
 
 # Health check
 
-def test_health_reachable(monkeypatch):
-    body = json.dumps({"status": "ok"}).encode()
-    monkeypatch.setattr(
-        "urllib.request.urlopen",
-        lambda *a, **k: _FakeResponse(200, body),
-    )
-    result = doctor._check_health("http://fake:8011")
+
+def test_health_reachable():
+    body = json.dumps({"status": "ready"}).encode()
+    with _patch_urlopen(response=_FakeResponse(200, body)):
+        result = doctor._check_health("http://fake:8011")
     assert result["reachable"] is True
     assert result["latency_ms"] is not None and result["latency_ms"] >= 0
 
 
-def test_health_unreachable(monkeypatch):
-    def _raise(*a, **k):
-        raise urllib.error.URLError("connection refused")
-
-    monkeypatch.setattr("urllib.request.urlopen", _raise)
-    result = doctor._check_health("http://fake:8011")
+def test_health_unreachable():
+    with _patch_urlopen(error=urllib.error.URLError("connection refused")):
+        result = doctor._check_health("http://fake:8011")
     assert result["reachable"] is False
     assert result["latency_ms"] is None
 
 
-# Server version
+# Cognee versions
+
 
 def test_server_version_unknown_when_not_in_body():
-    assert doctor._resolve_server_version({"status": "ok"}) == "Unknown"
+    assert doctor._resolve_server_version({"status": "ready"}) == "Unknown"
     assert doctor._resolve_server_version(None) == "Unknown"
 
 
@@ -182,12 +196,38 @@ def test_server_version_extracted_when_present():
     assert doctor._resolve_server_version({"version": "1.2.3"}) == "1.2.3"
 
 
+def test_local_cognee_not_installed_when_venv_absent():
+    original = _plugin_common._VENV_PYTHON
+    _plugin_common._VENV_PYTHON = pathlib.Path(_TMP) / "no-such-venv" / "python"
+    try:
+        assert doctor._resolve_local_cognee_version() == "Not installed"
+    finally:
+        _plugin_common._VENV_PYTHON = original
+
+
+# Embedding
+
+
+def test_embedding_default_when_unset():
+    _reset_env("EMBEDDING_MODEL", "EMBEDDING_DIMENSIONS")
+    assert doctor._resolve_embedding() == ("Default", "Default")
+
+
+def test_embedding_from_env():
+    os.environ["EMBEDDING_MODEL"] = "openai/text-embedding-3-large"
+    os.environ["EMBEDDING_DIMENSIONS"] = "3072"
+    try:
+        assert doctor._resolve_embedding() == ("openai/text-embedding-3-large", "3072")
+    finally:
+        _reset_env("EMBEDDING_MODEL", "EMBEDDING_DIMENSIONS")
+
+
 # Circuit breaker
+
 
 def test_breaker_closed():
     _reset_breaker()
-    state = doctor._resolve_circuit_breaker()
-    assert state == "Closed", f"expected Closed, got {state}"
+    assert doctor._resolve_circuit_breaker() == "Closed"
 
 
 def test_breaker_open():
@@ -198,51 +238,35 @@ def test_breaker_open():
         json.dumps({"failures": 10, "cooldown_until": _time.time() + 60}),
         encoding="utf-8",
     )
-    state = doctor._resolve_circuit_breaker()
-    assert state.startswith("Open"), f"expected Open..., got {state}"
-    _reset_breaker()
+    try:
+        assert doctor._resolve_circuit_breaker().startswith("Open")
+    finally:
+        _reset_breaker()
 
 
-# Plugin version (inventory lookup)
-
-def test_parse_inventory_version(tmp_path):
-    inventory = tmp_path / "inventory.yml"
-    inventory.write_text(
-        textwrap.dedent("""\
-        integrations:
-          - slug: claude-code
-            current_version: "0.1.0"
-          - slug: codex
-            current_version: "1.0.3-local"
-        """),
-        encoding="utf-8",
-    )
-    assert doctor._parse_inventory_version(inventory, "claude-code") == "0.1.0"
-    assert doctor._parse_inventory_version(inventory, "codex") == "1.0.3-local"
-    assert doctor._parse_inventory_version(inventory, "nonexistent") == "Unknown"
+# Output
 
 
-# JSON output
-
-def test_json_output(monkeypatch):
-    body = json.dumps({"status": "ok"}).encode()
-    monkeypatch.setattr(
-        "urllib.request.urlopen",
-        lambda *a, **k: _FakeResponse(200, body),
-    )
+def test_json_output():
     _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "LLM_API_KEY")
     _reset_breaker()
-
-    report = doctor.collect_report()
-    output = doctor.format_json(report)
-    parsed = json.loads(output)
-
-    expected_keys = {
-        "mode", "server_url", "api_key_source", "reachable", "latency_ms",
-        "plugin_version", "server_version", "embedding_model",
-        "embedding_dimensions", "circuit_breaker",
+    body = json.dumps({"status": "ready"}).encode()
+    with _patch_urlopen(response=_FakeResponse(200, body)):
+        report = doctor.collect_report()
+    parsed = json.loads(doctor.format_json(report))
+    expected = {
+        "mode",
+        "server_url",
+        "api_key_source",
+        "reachable",
+        "latency_ms",
+        "cognee_local",
+        "cognee_server",
+        "embedding_model",
+        "embedding_dimensions",
+        "circuit_breaker",
     }
-    assert expected_keys == set(parsed.keys()), f"missing keys: {expected_keys - set(parsed.keys())}"
+    assert expected == set(parsed.keys()), f"keys mismatch: {expected ^ set(parsed.keys())}"
 
 
 def test_human_output_contains_header():
@@ -251,33 +275,19 @@ def test_human_output_contains_header():
     text = doctor.format_human(report)
     assert "Cognee Doctor" in text
     assert "Mode:" in text
+    assert "Cognee (local):" in text
     assert "Circuit Breaker:" in text
 
 
 if __name__ == "__main__":
     failures = 0
-    skipped = 0
-    for name, fn in sorted(globals().items()):
-        if not name.startswith("test_") or not callable(fn):
+    for _name, _fn in sorted(globals().items()):
+        if not _name.startswith("test_") or not callable(_fn):
             continue
-
-        import inspect
-
-        sig = inspect.signature(fn)
-        params = list(sig.parameters.keys())
-
-        # Skip tests that require pytest fixtures when running standalone.
-        if "monkeypatch" in params or "tmp_path" in params:
-            skipped += 1
-            print(f"SKIP {name} (requires pytest fixtures)")
-            continue
-
         try:
-            fn()
-            print(f"PASS {name}")
+            _fn()
+            print(f"PASS {_name}")
         except AssertionError as e:
             failures += 1
-            print(f"FAIL {name}: {e}")
-    if skipped:
-        print(f"\n{skipped} test(s) skipped (run with pytest for full coverage)")
+            print(f"FAIL {_name}: {e}")
     sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/scripts/cognee-cli.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-cli.sh
@@ -10,4 +10,11 @@ else
   exit 64
 fi
 
+# Doctor subcommand: delegate to the plugin's doctor.py
+if [[ "${1:-}" == "doctor" ]]; then
+  shift
+  SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+  exec python3 "${SELF_DIR}/doctor.py" "$@"
+fi
+
 exec uv run cognee-cli "$@"

--- a/integrations/codex/plugins/cognee/scripts/cognee-cli.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-cli.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Doctor subcommand: a self-contained, read-only diagnostic that does not need
+# the Cognee repo, so dispatch it before the repo-root gate below (you often
+# run the doctor from wherever you are when something looks off).
+if [[ "${1:-}" == "doctor" ]]; then
+  shift
+  SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+  exec python3 "${SELF_DIR}/doctor.py" "$@"
+fi
+
 if [[ -n "${COGNEE_REPO_ROOT:-}" ]]; then
   cd "$COGNEE_REPO_ROOT"
 elif [[ -f pyproject.toml ]] && grep -q '^name = "cognee"$' pyproject.toml; then
@@ -8,13 +17,6 @@ elif [[ -f pyproject.toml ]] && grep -q '^name = "cognee"$' pyproject.toml; then
 else
   echo "Run this from the Cognee repository root or set COGNEE_REPO_ROOT." >&2
   exit 64
-fi
-
-# Doctor subcommand: delegate to the plugin's doctor.py
-if [[ "${1:-}" == "doctor" ]]; then
-  shift
-  SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
-  exec python3 "${SELF_DIR}/doctor.py" "$@"
 fi
 
 exec uv run cognee-cli "$@"

--- a/integrations/codex/plugins/cognee/scripts/cognee-cli.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-cli.sh
@@ -14,7 +14,7 @@ fi
 if [[ "${1:-}" == "doctor" ]]; then
   shift
   SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
-  exec python "${SELF_DIR}/doctor.py" "$@"
+  exec python3 "${SELF_DIR}/doctor.py" "$@"
 fi
 
 exec uv run cognee-cli "$@"

--- a/integrations/codex/plugins/cognee/scripts/cognee-cli.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-cli.sh
@@ -14,7 +14,7 @@ fi
 if [[ "${1:-}" == "doctor" ]]; then
   shift
   SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
-  exec python3 "${SELF_DIR}/doctor.py" "$@"
+  exec python "${SELF_DIR}/doctor.py" "$@"
 fi
 
 exec uv run cognee-cli "$@"

--- a/integrations/codex/plugins/cognee/scripts/doctor.py
+++ b/integrations/codex/plugins/cognee/scripts/doctor.py
@@ -15,6 +15,7 @@ resources, writes files, or mutates state.
 import json
 import os
 import pathlib
+import subprocess
 import sys
 import time
 import urllib.error
@@ -26,42 +27,27 @@ if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
 
-_INVENTORY_SLUG = "codex"
+def _resolve_local_cognee_version() -> str:
+    """Cognee version installed in the plugin's managed venv.
 
-def _resolve_plugin_version() -> str:
-    """Read the plugin version from inventory.yml.
-
-    Walks up from the scripts directory looking for inventory.yml,
-    then extracts the current_version for the codex slug.
-    Falls back to "Unknown" if the file is missing or unparseable.
+    The plugin installs cognee into ~/.cognee-plugin/venv at session start;
+    probe that interpreter directly. Returns "Not installed" when the venv is
+    absent and "Unknown" if the probe fails.
     """
-    search = pathlib.Path(__file__).resolve().parent
-    for _ in range(10):
-        candidate = search / "inventory.yml"
-        if candidate.exists():
-            return _parse_inventory_version(candidate, _INVENTORY_SLUG)
-        if search.parent == search:
-            break
-        search = search.parent
-    return "Unknown"
+    from _plugin_common import _VENV_PYTHON
 
-
-def _parse_inventory_version(path: pathlib.Path, slug: str) -> str:
-    """Extract current_version for *slug* from a YAML inventory file.
-
-    Uses a simple line-scanner instead of importing PyYAML (which may
-    not be installed in the host interpreter).
-    """
+    if not _VENV_PYTHON.exists():
+        return "Not installed"
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-        found_slug = False
-        for line in lines:
-            stripped = line.strip()
-            if stripped.startswith("- slug:"):
-                found_slug = stripped.split(":", 1)[1].strip().strip('"').strip("'") == slug
-            elif found_slug and stripped.startswith("current_version:"):
-                raw = stripped.split(":", 1)[1].strip().strip('"').strip("'")
-                return raw or "Unknown"
+        probe = "import importlib.metadata as m; print(m.version('cognee'))"
+        out = subprocess.run(
+            [str(_VENV_PYTHON), "-c", probe],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            return out.stdout.strip()
     except Exception:
         pass
     return "Unknown"
@@ -202,8 +188,8 @@ def collect_report() -> dict:
     display_url, raw_url = _resolve_server_url()
     api_key_source = _resolve_api_key_source()
     health = _check_health(raw_url)
-    server_version = _resolve_server_version(health["raw_body"])
-    plugin_version = _resolve_plugin_version()
+    cognee_server = _resolve_server_version(health["raw_body"])
+    cognee_local = _resolve_local_cognee_version()
     circuit_breaker = _resolve_circuit_breaker()
     embedding_model, embedding_dimensions = _resolve_embedding()
 
@@ -213,8 +199,8 @@ def collect_report() -> dict:
         "api_key_source": api_key_source,
         "reachable": health["reachable"],
         "latency_ms": health["latency_ms"],
-        "plugin_version": plugin_version,
-        "server_version": server_version,
+        "cognee_local": cognee_local,
+        "cognee_server": cognee_server,
         "embedding_model": embedding_model,
         "embedding_dimensions": embedding_dimensions,
         "circuit_breaker": circuit_breaker,
@@ -227,8 +213,8 @@ _DISPLAY_ORDER = [
     ("API Key Source", "api_key_source"),
     ("Reachable", "reachable"),
     ("Latency", "latency_ms"),
-    ("Plugin Version", "plugin_version"),
-    ("Server Version", "server_version"),
+    ("Cognee (local)", "cognee_local"),
+    ("Cognee (server)", "cognee_server"),
     ("Embedding Model", "embedding_model"),
     ("Embedding Dims", "embedding_dimensions"),
     ("Circuit Breaker", "circuit_breaker"),

--- a/integrations/codex/plugins/cognee/scripts/doctor.py
+++ b/integrations/codex/plugins/cognee/scripts/doctor.py
@@ -183,6 +183,18 @@ def _resolve_circuit_breaker() -> str:
     return "Closed"
 
 
+def _resolve_embedding() -> tuple[str, str]:
+    """Embedding model + dimensions from the environment cognee reads.
+
+    cognee resolves embeddings from EMBEDDING_MODEL / EMBEDDING_DIMENSIONS; no
+    HTTP endpoint exposes them, so we surface what the local environment sets
+    (the values that govern local mode). "Default" means unset — cognee falls
+    back to its built-in default.
+    """
+    model = (os.environ.get("EMBEDDING_MODEL") or "").strip() or "Default"
+    dims = (os.environ.get("EMBEDDING_DIMENSIONS") or "").strip() or "Default"
+    return model, dims
+
 
 def collect_report() -> dict:
     """Gather all diagnostic fields into an ordered dict."""
@@ -193,6 +205,7 @@ def collect_report() -> dict:
     server_version = _resolve_server_version(health["raw_body"])
     plugin_version = _resolve_plugin_version()
     circuit_breaker = _resolve_circuit_breaker()
+    embedding_model, embedding_dimensions = _resolve_embedding()
 
     return {
         "mode": mode,
@@ -202,8 +215,8 @@ def collect_report() -> dict:
         "latency_ms": health["latency_ms"],
         "plugin_version": plugin_version,
         "server_version": server_version,
-        "embedding_model": "Unknown",
-        "embedding_dimensions": "Unknown",
+        "embedding_model": embedding_model,
+        "embedding_dimensions": embedding_dimensions,
         "circuit_breaker": circuit_breaker,
     }
 

--- a/integrations/codex/plugins/cognee/scripts/doctor.py
+++ b/integrations/codex/plugins/cognee/scripts/doctor.py
@@ -25,12 +25,8 @@ _SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parent)
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
-# ---------------------------------------------------------------------------
-# Plugin-version resolution
-# ---------------------------------------------------------------------------
 
 _INVENTORY_SLUG = "codex"
-
 
 def _resolve_plugin_version() -> str:
     """Read the plugin version from inventory.yml.
@@ -71,28 +67,29 @@ def _parse_inventory_version(path: pathlib.Path, slug: str) -> str:
     return "Unknown"
 
 
-# ---------------------------------------------------------------------------
-# Mode resolution
-# ---------------------------------------------------------------------------
-
-
 def _resolve_mode() -> str:
-    """Return the resolved operating mode: Cloud, Local, or Server."""
-    from config import is_cloud_mode, is_local_mode, load_config
+    """Return the resolved operating mode: Local, Local Managed, or Cloud.
+
+    - No base_url configured → Local
+    - base_url pointing to localhost / 127.0.0.1 / ::1 → Local Managed
+    - Remote base_url → Cloud
+    """
+    import urllib.parse
+
+    from config import load_config
 
     cfg = load_config()
-    if is_cloud_mode(cfg):
-        return "Cloud"
-    if is_local_mode(cfg):
+    base_url = str(cfg.get("base_url") or "").strip()
+
+    if not base_url:
         return "Local"
-    if cfg.get("base_url"):
-        return "Server"
-    return "Local"
 
+    hostname = urllib.parse.urlparse(base_url).hostname or ""
+    if hostname in ("localhost", "127.0.0.1", "::1"):
+        return "Local Managed"
 
-# ---------------------------------------------------------------------------
-# Server URL resolution
-# ---------------------------------------------------------------------------
+    return "Cloud"
+
 
 _DEFAULT_LOCAL_SERVICE_URL = "http://localhost:8011"
 
@@ -114,10 +111,6 @@ def _resolve_server_url() -> tuple:
     display = "-" if mode == "Local" else raw_url
     return display, raw_url
 
-
-# ---------------------------------------------------------------------------
-# API-key source resolution
-# ---------------------------------------------------------------------------
 
 _SHARED_PLUGIN_ROOT = pathlib.Path.home() / ".cognee-plugin"
 _API_KEY_CACHE = _SHARED_PLUGIN_ROOT / "api_key.json"
@@ -145,11 +138,6 @@ def _resolve_api_key_source() -> str:
     return "Default"
 
 
-# ---------------------------------------------------------------------------
-# Health check (reachability + latency)
-# ---------------------------------------------------------------------------
-
-
 def _check_health(server_url: str, timeout: float = 5.0) -> dict:
     """Probe GET /health and return reachability + latency.
 
@@ -175,10 +163,6 @@ def _check_health(server_url: str, timeout: float = 5.0) -> dict:
         return {"reachable": False, "latency_ms": None, "raw_body": None}
 
 
-# ---------------------------------------------------------------------------
-# Server version
-# ---------------------------------------------------------------------------
-
 
 def _resolve_server_version(health_body: dict | None) -> str:
     """Extract a server version from the health response, if present."""
@@ -187,11 +171,6 @@ def _resolve_server_version(health_body: dict | None) -> str:
         if version and str(version).strip():
             return str(version).strip()
     return "Unknown"
-
-
-# ---------------------------------------------------------------------------
-# Circuit breaker state
-# ---------------------------------------------------------------------------
 
 
 def _resolve_circuit_breaker() -> str:
@@ -203,10 +182,6 @@ def _resolve_circuit_breaker() -> str:
         return f"Open (retry in ~{retry}s)"
     return "Closed"
 
-
-# ---------------------------------------------------------------------------
-# Assemble the full report
-# ---------------------------------------------------------------------------
 
 
 def collect_report() -> dict:
@@ -232,10 +207,6 @@ def collect_report() -> dict:
         "circuit_breaker": circuit_breaker,
     }
 
-
-# ---------------------------------------------------------------------------
-# Output formatters
-# ---------------------------------------------------------------------------
 
 _DISPLAY_ORDER = [
     ("Mode", "mode"),
@@ -280,10 +251,6 @@ def format_json(report: dict) -> str:
     """Render the report as pretty-printed JSON."""
     return json.dumps(report, indent=2)
 
-
-# ---------------------------------------------------------------------------
-# CLI entry point
-# ---------------------------------------------------------------------------
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/integrations/codex/plugins/cognee/scripts/doctor.py
+++ b/integrations/codex/plugins/cognee/scripts/doctor.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Cognee Doctor — unified diagnostics for the Codex plugin.
+
+Read-only command that aggregates configuration, connectivity, and
+circuit-breaker state into a single diagnostic report.
+
+Usage:
+    python doctor.py           # human-readable table
+    python doctor.py --json    # machine-readable JSON
+
+Never modifies configuration, initialises databases, registers
+resources, writes files, or mutates state.
+"""
+
+import json
+import os
+import pathlib
+import sys
+import time
+import urllib.error
+import urllib.request
+
+# Ensure the scripts directory is on sys.path so sibling modules resolve.
+_SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+# ---------------------------------------------------------------------------
+# Plugin-version resolution
+# ---------------------------------------------------------------------------
+
+_INVENTORY_SLUG = "codex"
+
+
+def _resolve_plugin_version() -> str:
+    """Read the plugin version from inventory.yml.
+
+    Walks up from the scripts directory looking for inventory.yml,
+    then extracts the current_version for the codex slug.
+    Falls back to "Unknown" if the file is missing or unparseable.
+    """
+    search = pathlib.Path(__file__).resolve().parent
+    for _ in range(10):
+        candidate = search / "inventory.yml"
+        if candidate.exists():
+            return _parse_inventory_version(candidate, _INVENTORY_SLUG)
+        if search.parent == search:
+            break
+        search = search.parent
+    return "Unknown"
+
+
+def _parse_inventory_version(path: pathlib.Path, slug: str) -> str:
+    """Extract current_version for *slug* from a YAML inventory file.
+
+    Uses a simple line-scanner instead of importing PyYAML (which may
+    not be installed in the host interpreter).
+    """
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+        found_slug = False
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("- slug:"):
+                found_slug = stripped.split(":", 1)[1].strip().strip('"').strip("'") == slug
+            elif found_slug and stripped.startswith("current_version:"):
+                raw = stripped.split(":", 1)[1].strip().strip('"').strip("'")
+                return raw or "Unknown"
+    except Exception:
+        pass
+    return "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# Mode resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_mode() -> str:
+    """Return the resolved operating mode: Cloud, Local, or Server."""
+    from config import is_cloud_mode, is_local_mode, load_config
+
+    cfg = load_config()
+    if is_cloud_mode(cfg):
+        return "Cloud"
+    if is_local_mode(cfg):
+        return "Local"
+    if cfg.get("base_url"):
+        return "Server"
+    return "Local"
+
+
+# ---------------------------------------------------------------------------
+# Server URL resolution
+# ---------------------------------------------------------------------------
+
+_DEFAULT_LOCAL_SERVICE_URL = "http://localhost:8011"
+
+
+def _resolve_server_url() -> tuple:
+    """Return (display_url, raw_url).
+
+    Codex's _plugin_common does not expose _local_api_url_with_source,
+    so we inline the same resolution logic here (env → default).
+    In local mode the display value is "-".
+    """
+    raw_url = (
+        os.environ.get("COGNEE_LOCAL_API_URL")
+        or os.environ.get("COGNEE_BASE_URL")
+        or ""
+    ).strip() or _DEFAULT_LOCAL_SERVICE_URL
+
+    mode = _resolve_mode()
+    display = "-" if mode == "Local" else raw_url
+    return display, raw_url
+
+
+# ---------------------------------------------------------------------------
+# API-key source resolution
+# ---------------------------------------------------------------------------
+
+_SHARED_PLUGIN_ROOT = pathlib.Path.home() / ".cognee-plugin"
+_API_KEY_CACHE = _SHARED_PLUGIN_ROOT / "api_key.json"
+
+
+def _resolve_api_key_source() -> str:
+    """Return a human-friendly label for where the API key came from.
+
+    Codex's _plugin_common._api_key does not return the source, so we
+    inline the same precedence logic here without modifying the module.
+    """
+    env_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
+    if env_key:
+        return "ENV"
+
+    # Check the single cached key file.
+    try:
+        if _API_KEY_CACHE.exists():
+            data = json.loads(_API_KEY_CACHE.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and (data.get("api_key") or "").strip():
+                return "Config"
+    except Exception:
+        pass
+
+    return "Default"
+
+
+# ---------------------------------------------------------------------------
+# Health check (reachability + latency)
+# ---------------------------------------------------------------------------
+
+
+def _check_health(server_url: str, timeout: float = 5.0) -> dict:
+    """Probe GET /health and return reachability + latency.
+
+    Returns a dict with keys: reachable (bool), latency_ms (float|None),
+    and raw_body (dict|None) for downstream consumers.
+    """
+    base = server_url.rstrip("/") if server_url else ""
+    if not base:
+        return {"reachable": False, "latency_ms": None, "raw_body": None}
+    try:
+        t0 = time.monotonic()
+        with urllib.request.urlopen(f"{base}/health", timeout=timeout) as resp:
+            latency = (time.monotonic() - t0) * 1000  # ms
+            body_text = resp.read().decode("utf-8", errors="replace")
+            try:
+                body = json.loads(body_text)
+            except (json.JSONDecodeError, ValueError):
+                body = None
+            if resp.status == 200:
+                return {"reachable": True, "latency_ms": round(latency, 1), "raw_body": body}
+        return {"reachable": False, "latency_ms": None, "raw_body": None}
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return {"reachable": False, "latency_ms": None, "raw_body": None}
+
+
+# ---------------------------------------------------------------------------
+# Server version
+# ---------------------------------------------------------------------------
+
+
+def _resolve_server_version(health_body: dict | None) -> str:
+    """Extract a server version from the health response, if present."""
+    if isinstance(health_body, dict):
+        version = health_body.get("version")
+        if version and str(version).strip():
+            return str(version).strip()
+    return "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker state
+# ---------------------------------------------------------------------------
+
+
+def _resolve_circuit_breaker() -> str:
+    """Return a human description of the circuit breaker state."""
+    from _cognee_client import breaker_open
+
+    is_open, retry = breaker_open()
+    if is_open:
+        return f"Open (retry in ~{retry}s)"
+    return "Closed"
+
+
+# ---------------------------------------------------------------------------
+# Assemble the full report
+# ---------------------------------------------------------------------------
+
+
+def collect_report() -> dict:
+    """Gather all diagnostic fields into an ordered dict."""
+    mode = _resolve_mode()
+    display_url, raw_url = _resolve_server_url()
+    api_key_source = _resolve_api_key_source()
+    health = _check_health(raw_url)
+    server_version = _resolve_server_version(health["raw_body"])
+    plugin_version = _resolve_plugin_version()
+    circuit_breaker = _resolve_circuit_breaker()
+
+    return {
+        "mode": mode,
+        "server_url": display_url if display_url != "-" else None,
+        "api_key_source": api_key_source,
+        "reachable": health["reachable"],
+        "latency_ms": health["latency_ms"],
+        "plugin_version": plugin_version,
+        "server_version": server_version,
+        "embedding_model": "Unknown",
+        "embedding_dimensions": "Unknown",
+        "circuit_breaker": circuit_breaker,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+_DISPLAY_ORDER = [
+    ("Mode", "mode"),
+    ("Server URL", "server_url"),
+    ("API Key Source", "api_key_source"),
+    ("Reachable", "reachable"),
+    ("Latency", "latency_ms"),
+    ("Plugin Version", "plugin_version"),
+    ("Server Version", "server_version"),
+    ("Embedding Model", "embedding_model"),
+    ("Embedding Dims", "embedding_dimensions"),
+    ("Circuit Breaker", "circuit_breaker"),
+]
+
+
+def _format_value(key: str, value) -> str:
+    """Format a single report value for human display."""
+    if key == "server_url":
+        return str(value) if value else "-"
+    if key == "reachable":
+        return "Yes" if value else "No"
+    if key == "latency_ms":
+        if value is None:
+            return "N/A"
+        return f"{value} ms"
+    if value is None:
+        return "N/A"
+    return str(value)
+
+
+def format_human(report: dict) -> str:
+    """Render the report as a human-readable table."""
+    lines = ["", "Cognee Doctor", ""]
+    for label, key in _DISPLAY_ORDER:
+        value = _format_value(key, report.get(key))
+        lines.append(f"{label + ':':<21}{value}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_json(report: dict) -> str:
+    """Render the report as pretty-printed JSON."""
+    return json.dumps(report, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = argv if argv is not None else sys.argv[1:]
+    use_json = "--json" in args
+
+    report = collect_report()
+
+    if use_json:
+        print(format_json(report))
+    else:
+        print(format_human(report))
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/codex/plugins/cognee/scripts/doctor.py
+++ b/integrations/codex/plugins/cognee/scripts/doctor.py
@@ -133,9 +133,13 @@ def _check_health(server_url: str, timeout: float = 5.0) -> dict:
     base = server_url.rstrip("/") if server_url else ""
     if not base:
         return {"reachable": False, "latency_ms": None, "raw_body": None}
+    from _plugin_common import _https_context
+
     try:
         t0 = time.monotonic()
-        with urllib.request.urlopen(f"{base}/health", timeout=timeout) as resp:
+        with urllib.request.urlopen(
+            f"{base}/health", timeout=timeout, context=_https_context()
+        ) as resp:
             latency = (time.monotonic() - t0) * 1000  # ms
             body_text = resp.read().decode("utf-8", errors="replace")
             try:

--- a/integrations/codex/plugins/cognee/scripts/doctor.py
+++ b/integrations/codex/plugins/cognee/scripts/doctor.py
@@ -88,9 +88,7 @@ def _resolve_server_url() -> tuple:
     In local mode the display value is "-".
     """
     raw_url = (
-        os.environ.get("COGNEE_LOCAL_API_URL")
-        or os.environ.get("COGNEE_BASE_URL")
-        or ""
+        os.environ.get("COGNEE_LOCAL_API_URL") or os.environ.get("COGNEE_BASE_URL") or ""
     ).strip() or _DEFAULT_LOCAL_SERVICE_URL
 
     mode = _resolve_mode()
@@ -151,7 +149,6 @@ def _check_health(server_url: str, timeout: float = 5.0) -> dict:
         return {"reachable": False, "latency_ms": None, "raw_body": None}
     except (urllib.error.URLError, TimeoutError, OSError):
         return {"reachable": False, "latency_ms": None, "raw_body": None}
-
 
 
 def _resolve_server_version(health_body: dict | None) -> str:
@@ -253,7 +250,6 @@ def format_human(report: dict) -> str:
 def format_json(report: dict) -> str:
     """Render the report as pretty-printed JSON."""
     return json.dumps(report, indent=2)
-
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/integrations/codex/plugins/cognee/tests/test_doctor.py
+++ b/integrations/codex/plugins/cognee/tests/test_doctor.py
@@ -1,0 +1,293 @@
+"""Unit tests for the Cognee Doctor command (Codex plugin).
+
+Tests verify behaviour with mocked HTTP and filesystem state, covering:
+  - local vs server mode resolution
+  - reachable vs unreachable health endpoint
+  - env vs config API key source
+  - breaker state reporting
+  - JSON output format
+
+Run:
+    pytest integrations/codex/plugins/cognee/tests/test_doctor.py
+    python integrations/codex/plugins/cognee/tests/test_doctor.py   # standalone
+"""
+
+import io
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import textwrap
+import urllib.error
+
+# Put the scripts dir on sys.path so doctor.py and its siblings resolve.
+_SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parents[1] / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+# Isolate the circuit-breaker state dir before importing _cognee_client.
+_TMP = tempfile.mkdtemp(prefix="cognee-doctor-codex-test-")
+os.environ["COGNEE_PLUGIN_STATE_DIR"] = _TMP
+
+import doctor  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset_env(*keys):
+    """Remove env vars that affect config resolution."""
+    for key in keys:
+        os.environ.pop(key, None)
+
+
+def _reset_breaker():
+    p = pathlib.Path(_TMP) / "recall-breaker.json"
+    if p.exists():
+        p.unlink()
+
+
+class _FakeResponse:
+    """Minimal stand-in for urllib.request.urlopen response."""
+
+    def __init__(self, status=200, body=b"{}"):
+        self.status = status
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Mode resolution
+# ---------------------------------------------------------------------------
+
+
+def test_local_mode_when_no_base_url():
+    _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "COGNEE_API_KEY", "LLM_API_KEY")
+    mode = doctor._resolve_mode()
+    assert mode == "Local", f"expected Local, got {mode}"
+
+
+def test_server_mode_with_base_url():
+    os.environ["COGNEE_BASE_URL"] = "http://test-server:8011"
+    try:
+        mode = doctor._resolve_mode()
+        assert mode in ("Cloud", "Server"), f"expected Cloud or Server, got {mode}"
+    finally:
+        _reset_env("COGNEE_BASE_URL")
+
+
+# ---------------------------------------------------------------------------
+# Server URL display
+# ---------------------------------------------------------------------------
+
+
+def test_server_url_dash_in_local_mode():
+    _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "LLM_API_KEY")
+    display, _raw = doctor._resolve_server_url()
+    assert display == "-", f"expected '-', got {display}"
+
+
+def test_server_url_shown_in_server_mode():
+    os.environ["COGNEE_BASE_URL"] = "http://custom:9999"
+    try:
+        display, raw = doctor._resolve_server_url()
+        assert "custom:9999" in raw
+    finally:
+        _reset_env("COGNEE_BASE_URL")
+
+
+# ---------------------------------------------------------------------------
+# API key source
+# ---------------------------------------------------------------------------
+
+
+def test_api_key_source_env():
+    os.environ["COGNEE_API_KEY"] = "test-key-from-env"
+    try:
+        source = doctor._resolve_api_key_source()
+        assert source == "ENV", f"expected ENV, got {source}"
+    finally:
+        _reset_env("COGNEE_API_KEY")
+
+
+def test_api_key_source_config(tmp_path):
+    _reset_env("COGNEE_API_KEY")
+    # Temporarily swap the cache path to a temp file with a cached key.
+    original = doctor._API_KEY_CACHE
+    cache_file = tmp_path / "api_key.json"
+    cache_file.write_text(json.dumps({"api_key": "cached-key", "base_url": ""}))
+    doctor._API_KEY_CACHE = cache_file
+    try:
+        source = doctor._resolve_api_key_source()
+        assert source == "Config", f"expected Config, got {source}"
+    finally:
+        doctor._API_KEY_CACHE = original
+
+
+# ---------------------------------------------------------------------------
+# Health check
+# ---------------------------------------------------------------------------
+
+
+def test_health_reachable(monkeypatch):
+    body = json.dumps({"status": "ok"}).encode()
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *a, **k: _FakeResponse(200, body),
+    )
+    result = doctor._check_health("http://fake:8011")
+    assert result["reachable"] is True
+    assert result["latency_ms"] is not None and result["latency_ms"] >= 0
+
+
+def test_health_unreachable(monkeypatch):
+    def _raise(*a, **k):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", _raise)
+    result = doctor._check_health("http://fake:8011")
+    assert result["reachable"] is False
+    assert result["latency_ms"] is None
+
+
+# ---------------------------------------------------------------------------
+# Server version
+# ---------------------------------------------------------------------------
+
+
+def test_server_version_unknown_when_not_in_body():
+    assert doctor._resolve_server_version({"status": "ok"}) == "Unknown"
+    assert doctor._resolve_server_version(None) == "Unknown"
+
+
+def test_server_version_extracted_when_present():
+    assert doctor._resolve_server_version({"version": "1.2.3"}) == "1.2.3"
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker
+# ---------------------------------------------------------------------------
+
+
+def test_breaker_closed():
+    _reset_breaker()
+    state = doctor._resolve_circuit_breaker()
+    assert state == "Closed", f"expected Closed, got {state}"
+
+
+def test_breaker_open():
+    import time as _time
+
+    breaker_path = pathlib.Path(_TMP) / "recall-breaker.json"
+    breaker_path.write_text(
+        json.dumps({"failures": 10, "cooldown_until": _time.time() + 60}),
+        encoding="utf-8",
+    )
+    state = doctor._resolve_circuit_breaker()
+    assert state.startswith("Open"), f"expected Open..., got {state}"
+    _reset_breaker()
+
+
+# ---------------------------------------------------------------------------
+# Plugin version (inventory lookup)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_inventory_version(tmp_path):
+    inventory = tmp_path / "inventory.yml"
+    inventory.write_text(
+        textwrap.dedent("""\
+        integrations:
+          - slug: claude-code
+            current_version: "0.1.0"
+          - slug: codex
+            current_version: "1.0.3-local"
+        """),
+        encoding="utf-8",
+    )
+    assert doctor._parse_inventory_version(inventory, "codex") == "1.0.3-local"
+    assert doctor._parse_inventory_version(inventory, "claude-code") == "0.1.0"
+    assert doctor._parse_inventory_version(inventory, "nonexistent") == "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# JSON output
+# ---------------------------------------------------------------------------
+
+
+def test_json_output(monkeypatch):
+    body = json.dumps({"status": "ok"}).encode()
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda *a, **k: _FakeResponse(200, body),
+    )
+    _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "LLM_API_KEY")
+    _reset_breaker()
+
+    report = doctor.collect_report()
+    output = doctor.format_json(report)
+    parsed = json.loads(output)
+
+    expected_keys = {
+        "mode", "server_url", "api_key_source", "reachable", "latency_ms",
+        "plugin_version", "server_version", "embedding_model",
+        "embedding_dimensions", "circuit_breaker",
+    }
+    assert expected_keys == set(parsed.keys()), f"missing keys: {expected_keys - set(parsed.keys())}"
+
+
+# ---------------------------------------------------------------------------
+# Human-readable output
+# ---------------------------------------------------------------------------
+
+
+def test_human_output_contains_header():
+    _reset_breaker()
+    report = doctor.collect_report()
+    text = doctor.format_human(report)
+    assert "Cognee Doctor" in text
+    assert "Mode:" in text
+    assert "Circuit Breaker:" in text
+
+
+# ---------------------------------------------------------------------------
+# Standalone runner
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    failures = 0
+    skipped = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+
+        import inspect
+
+        sig = inspect.signature(fn)
+        params = list(sig.parameters.keys())
+
+        if "monkeypatch" in params or "tmp_path" in params:
+            skipped += 1
+            print(f"SKIP {name} (requires pytest fixtures)")
+            continue
+
+        try:
+            fn()
+            print(f"PASS {name}")
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL {name}: {e}")
+    if skipped:
+        print(f"\n{skipped} test(s) skipped (run with pytest for full coverage)")
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/tests/test_doctor.py
+++ b/integrations/codex/plugins/cognee/tests/test_doctor.py
@@ -21,22 +21,15 @@ import tempfile
 import textwrap
 import urllib.error
 
-# Put the scripts dir on sys.path so doctor.py and its siblings resolve.
 _SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parents[1] / "scripts")
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
-# Isolate the circuit-breaker state dir before importing _cognee_client.
 _TMP = tempfile.mkdtemp(prefix="cognee-doctor-codex-test-")
 os.environ["COGNEE_PLUGIN_STATE_DIR"] = _TMP
 
-import doctor  # noqa: E402
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
+# pyrefly: ignore [missing-import]
+import doctor  
 
 def _reset_env(*keys):
     """Remove env vars that affect config resolution."""
@@ -67,30 +60,49 @@ class _FakeResponse:
         pass
 
 
-# ---------------------------------------------------------------------------
-# Mode resolution
-# ---------------------------------------------------------------------------
-
-
 def test_local_mode_when_no_base_url():
     _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "COGNEE_API_KEY", "LLM_API_KEY")
     mode = doctor._resolve_mode()
     assert mode == "Local", f"expected Local, got {mode}"
 
 
-def test_server_mode_with_base_url():
-    os.environ["COGNEE_BASE_URL"] = "http://test-server:8011"
+def test_managed_mode_with_localhost():
+    os.environ["COGNEE_BASE_URL"] = "http://localhost:8011"
     try:
         mode = doctor._resolve_mode()
-        assert mode in ("Cloud", "Server"), f"expected Cloud or Server, got {mode}"
+        assert mode == "Local Managed", f"expected Local Managed, got {mode}"
     finally:
         _reset_env("COGNEE_BASE_URL")
 
 
-# ---------------------------------------------------------------------------
-# Server URL display
-# ---------------------------------------------------------------------------
+def test_managed_mode_with_127():
+    os.environ["COGNEE_BASE_URL"] = "http://127.0.0.1:8000"
+    try:
+        mode = doctor._resolve_mode()
+        assert mode == "Local Managed", f"expected Local Managed, got {mode}"
+    finally:
+        _reset_env("COGNEE_BASE_URL")
 
+
+def test_managed_mode_with_ipv6_loopback():
+    os.environ["COGNEE_BASE_URL"] = "http://[::1]:8000"
+    try:
+        mode = doctor._resolve_mode()
+        assert mode == "Local Managed", f"expected Local Managed, got {mode}"
+    finally:
+        _reset_env("COGNEE_BASE_URL")
+
+
+def test_cloud_mode_with_remote_url():
+    os.environ["COGNEE_BASE_URL"] = "https://company.cognee.ai"
+    try:
+        mode = doctor._resolve_mode()
+        assert mode == "Cloud", f"expected Cloud, got {mode}"
+    finally:
+        _reset_env("COGNEE_BASE_URL")
+
+
+# Server URL display
 
 def test_server_url_dash_in_local_mode():
     _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "LLM_API_KEY")
@@ -107,10 +119,7 @@ def test_server_url_shown_in_server_mode():
         _reset_env("COGNEE_BASE_URL")
 
 
-# ---------------------------------------------------------------------------
 # API key source
-# ---------------------------------------------------------------------------
-
 
 def test_api_key_source_env():
     os.environ["COGNEE_API_KEY"] = "test-key-from-env"
@@ -135,10 +144,7 @@ def test_api_key_source_config(tmp_path):
         doctor._API_KEY_CACHE = original
 
 
-# ---------------------------------------------------------------------------
 # Health check
-# ---------------------------------------------------------------------------
-
 
 def test_health_reachable(monkeypatch):
     body = json.dumps({"status": "ok"}).encode()
@@ -161,10 +167,7 @@ def test_health_unreachable(monkeypatch):
     assert result["latency_ms"] is None
 
 
-# ---------------------------------------------------------------------------
 # Server version
-# ---------------------------------------------------------------------------
-
 
 def test_server_version_unknown_when_not_in_body():
     assert doctor._resolve_server_version({"status": "ok"}) == "Unknown"
@@ -175,10 +178,7 @@ def test_server_version_extracted_when_present():
     assert doctor._resolve_server_version({"version": "1.2.3"}) == "1.2.3"
 
 
-# ---------------------------------------------------------------------------
 # Circuit breaker
-# ---------------------------------------------------------------------------
-
 
 def test_breaker_closed():
     _reset_breaker()
@@ -199,10 +199,7 @@ def test_breaker_open():
     _reset_breaker()
 
 
-# ---------------------------------------------------------------------------
 # Plugin version (inventory lookup)
-# ---------------------------------------------------------------------------
-
 
 def test_parse_inventory_version(tmp_path):
     inventory = tmp_path / "inventory.yml"
@@ -221,10 +218,7 @@ def test_parse_inventory_version(tmp_path):
     assert doctor._parse_inventory_version(inventory, "nonexistent") == "Unknown"
 
 
-# ---------------------------------------------------------------------------
 # JSON output
-# ---------------------------------------------------------------------------
-
 
 def test_json_output(monkeypatch):
     body = json.dumps({"status": "ok"}).encode()
@@ -247,11 +241,6 @@ def test_json_output(monkeypatch):
     assert expected_keys == set(parsed.keys()), f"missing keys: {expected_keys - set(parsed.keys())}"
 
 
-# ---------------------------------------------------------------------------
-# Human-readable output
-# ---------------------------------------------------------------------------
-
-
 def test_human_output_contains_header():
     _reset_breaker()
     report = doctor.collect_report()
@@ -260,10 +249,6 @@ def test_human_output_contains_header():
     assert "Mode:" in text
     assert "Circuit Breaker:" in text
 
-
-# ---------------------------------------------------------------------------
-# Standalone runner
-# ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
     failures = 0

--- a/integrations/codex/plugins/cognee/tests/test_doctor.py
+++ b/integrations/codex/plugins/cognee/tests/test_doctor.py
@@ -4,21 +4,19 @@ Tests verify behaviour with mocked HTTP and filesystem state, covering:
   - local vs server mode resolution
   - reachable vs unreachable health endpoint
   - env vs config API key source
+  - local (venv) / server cognee version + embedding fields
   - breaker state reporting
   - JSON output format
 
-Run:
-    pytest integrations/codex/plugins/cognee/tests/test_doctor.py
-    python integrations/codex/plugins/cognee/tests/test_doctor.py   # standalone
+Every test runs under plain `python3 tests/test_doctor.py` (no pytest
+fixtures) as well as under `pytest`, matching the sibling test convention.
 """
 
-import io
 import json
 import os
 import pathlib
 import sys
 import tempfile
-import textwrap
 import urllib.error
 
 _SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parents[1] / "scripts")
@@ -28,8 +26,9 @@ if _SCRIPTS_DIR not in sys.path:
 _TMP = tempfile.mkdtemp(prefix="cognee-doctor-codex-test-")
 os.environ["COGNEE_PLUGIN_STATE_DIR"] = _TMP
 
-# pyrefly: ignore [missing-import]
-import doctor  
+import _plugin_common  # noqa: E402
+import doctor  # noqa: E402
+
 
 def _reset_env(*keys):
     """Remove env vars that affect config resolution."""
@@ -44,7 +43,7 @@ def _reset_breaker():
 
 
 class _FakeResponse:
-    """Minimal stand-in for urllib.request.urlopen response."""
+    """Minimal stand-in for a urllib.request.urlopen response."""
 
     def __init__(self, status=200, body=b"{}"):
         self.status = status
@@ -60,17 +59,42 @@ class _FakeResponse:
         pass
 
 
+class _patch_urlopen:
+    """Context manager that swaps urllib.request.urlopen for a stub."""
+
+    def __init__(self, response=None, error=None):
+        self._response = response
+        self._error = error
+
+    def __enter__(self):
+        import urllib.request
+
+        self._mod = urllib.request
+        self._orig = urllib.request.urlopen
+
+        def _fake(*a, **k):
+            if self._error is not None:
+                raise self._error
+            return self._response
+
+        urllib.request.urlopen = _fake
+
+    def __exit__(self, *a):
+        self._mod.urlopen = self._orig
+
+
+# Mode resolution
+
+
 def test_local_mode_when_no_base_url():
     _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "COGNEE_API_KEY", "LLM_API_KEY")
-    mode = doctor._resolve_mode()
-    assert mode == "Local", f"expected Local, got {mode}"
+    assert doctor._resolve_mode() == "Local"
 
 
 def test_managed_mode_with_localhost():
     os.environ["COGNEE_BASE_URL"] = "http://localhost:8011"
     try:
-        mode = doctor._resolve_mode()
-        assert mode == "Local Managed", f"expected Local Managed, got {mode}"
+        assert doctor._resolve_mode() == "Local Managed"
     finally:
         _reset_env("COGNEE_BASE_URL")
 
@@ -78,8 +102,7 @@ def test_managed_mode_with_localhost():
 def test_managed_mode_with_127():
     os.environ["COGNEE_BASE_URL"] = "http://127.0.0.1:8000"
     try:
-        mode = doctor._resolve_mode()
-        assert mode == "Local Managed", f"expected Local Managed, got {mode}"
+        assert doctor._resolve_mode() == "Local Managed"
     finally:
         _reset_env("COGNEE_BASE_URL")
 
@@ -87,8 +110,7 @@ def test_managed_mode_with_127():
 def test_managed_mode_with_ipv6_loopback():
     os.environ["COGNEE_BASE_URL"] = "http://[::1]:8000"
     try:
-        mode = doctor._resolve_mode()
-        assert mode == "Local Managed", f"expected Local Managed, got {mode}"
+        assert doctor._resolve_mode() == "Local Managed"
     finally:
         _reset_env("COGNEE_BASE_URL")
 
@@ -96,24 +118,24 @@ def test_managed_mode_with_ipv6_loopback():
 def test_cloud_mode_with_remote_url():
     os.environ["COGNEE_BASE_URL"] = "https://company.cognee.ai"
     try:
-        mode = doctor._resolve_mode()
-        assert mode == "Cloud", f"expected Cloud, got {mode}"
+        assert doctor._resolve_mode() == "Cloud"
     finally:
         _reset_env("COGNEE_BASE_URL")
 
 
 # Server URL display
 
+
 def test_server_url_dash_in_local_mode():
     _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "LLM_API_KEY")
     display, _raw = doctor._resolve_server_url()
-    assert display == "-", f"expected '-', got {display}"
+    assert display == "-"
 
 
 def test_server_url_shown_in_server_mode():
     os.environ["COGNEE_BASE_URL"] = "http://custom:9999"
     try:
-        display, raw = doctor._resolve_server_url()
+        _display, raw = doctor._resolve_server_url()
         assert "custom:9999" in raw
     finally:
         _reset_env("COGNEE_BASE_URL")
@@ -121,56 +143,52 @@ def test_server_url_shown_in_server_mode():
 
 # API key source
 
+
 def test_api_key_source_env():
     os.environ["COGNEE_API_KEY"] = "test-key-from-env"
     try:
-        source = doctor._resolve_api_key_source()
-        assert source == "ENV", f"expected ENV, got {source}"
+        assert doctor._resolve_api_key_source() == "ENV"
     finally:
         _reset_env("COGNEE_API_KEY")
 
 
-def test_api_key_source_config(tmp_path):
-    _reset_env("COGNEE_API_KEY")
-    # Temporarily swap the cache path to a temp file with a cached key.
+def test_api_key_source_config():
+    # No env key; a cached key file should resolve to "Config".
+    _reset_env("COGNEE_API_KEY", "COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL")
     original = doctor._API_KEY_CACHE
-    cache_file = tmp_path / "api_key.json"
+    cache_file = pathlib.Path(_TMP) / "api_key.json"
     cache_file.write_text(json.dumps({"api_key": "cached-key", "base_url": ""}))
     doctor._API_KEY_CACHE = cache_file
     try:
-        source = doctor._resolve_api_key_source()
-        assert source == "Config", f"expected Config, got {source}"
+        assert doctor._resolve_api_key_source() == "Config"
     finally:
         doctor._API_KEY_CACHE = original
+        _reset_env("COGNEE_API_KEY")
 
 
 # Health check
 
-def test_health_reachable(monkeypatch):
-    body = json.dumps({"status": "ok"}).encode()
-    monkeypatch.setattr(
-        "urllib.request.urlopen",
-        lambda *a, **k: _FakeResponse(200, body),
-    )
-    result = doctor._check_health("http://fake:8011")
+
+def test_health_reachable():
+    body = json.dumps({"status": "ready"}).encode()
+    with _patch_urlopen(response=_FakeResponse(200, body)):
+        result = doctor._check_health("http://fake:8011")
     assert result["reachable"] is True
     assert result["latency_ms"] is not None and result["latency_ms"] >= 0
 
 
-def test_health_unreachable(monkeypatch):
-    def _raise(*a, **k):
-        raise urllib.error.URLError("connection refused")
-
-    monkeypatch.setattr("urllib.request.urlopen", _raise)
-    result = doctor._check_health("http://fake:8011")
+def test_health_unreachable():
+    with _patch_urlopen(error=urllib.error.URLError("connection refused")):
+        result = doctor._check_health("http://fake:8011")
     assert result["reachable"] is False
     assert result["latency_ms"] is None
 
 
-# Server version
+# Cognee versions
+
 
 def test_server_version_unknown_when_not_in_body():
-    assert doctor._resolve_server_version({"status": "ok"}) == "Unknown"
+    assert doctor._resolve_server_version({"status": "ready"}) == "Unknown"
     assert doctor._resolve_server_version(None) == "Unknown"
 
 
@@ -178,12 +196,38 @@ def test_server_version_extracted_when_present():
     assert doctor._resolve_server_version({"version": "1.2.3"}) == "1.2.3"
 
 
+def test_local_cognee_not_installed_when_venv_absent():
+    original = _plugin_common._VENV_PYTHON
+    _plugin_common._VENV_PYTHON = pathlib.Path(_TMP) / "no-such-venv" / "python"
+    try:
+        assert doctor._resolve_local_cognee_version() == "Not installed"
+    finally:
+        _plugin_common._VENV_PYTHON = original
+
+
+# Embedding
+
+
+def test_embedding_default_when_unset():
+    _reset_env("EMBEDDING_MODEL", "EMBEDDING_DIMENSIONS")
+    assert doctor._resolve_embedding() == ("Default", "Default")
+
+
+def test_embedding_from_env():
+    os.environ["EMBEDDING_MODEL"] = "openai/text-embedding-3-large"
+    os.environ["EMBEDDING_DIMENSIONS"] = "3072"
+    try:
+        assert doctor._resolve_embedding() == ("openai/text-embedding-3-large", "3072")
+    finally:
+        _reset_env("EMBEDDING_MODEL", "EMBEDDING_DIMENSIONS")
+
+
 # Circuit breaker
+
 
 def test_breaker_closed():
     _reset_breaker()
-    state = doctor._resolve_circuit_breaker()
-    assert state == "Closed", f"expected Closed, got {state}"
+    assert doctor._resolve_circuit_breaker() == "Closed"
 
 
 def test_breaker_open():
@@ -194,51 +238,35 @@ def test_breaker_open():
         json.dumps({"failures": 10, "cooldown_until": _time.time() + 60}),
         encoding="utf-8",
     )
-    state = doctor._resolve_circuit_breaker()
-    assert state.startswith("Open"), f"expected Open..., got {state}"
-    _reset_breaker()
+    try:
+        assert doctor._resolve_circuit_breaker().startswith("Open")
+    finally:
+        _reset_breaker()
 
 
-# Plugin version (inventory lookup)
-
-def test_parse_inventory_version(tmp_path):
-    inventory = tmp_path / "inventory.yml"
-    inventory.write_text(
-        textwrap.dedent("""\
-        integrations:
-          - slug: claude-code
-            current_version: "0.1.0"
-          - slug: codex
-            current_version: "1.0.3-local"
-        """),
-        encoding="utf-8",
-    )
-    assert doctor._parse_inventory_version(inventory, "codex") == "1.0.3-local"
-    assert doctor._parse_inventory_version(inventory, "claude-code") == "0.1.0"
-    assert doctor._parse_inventory_version(inventory, "nonexistent") == "Unknown"
+# Output
 
 
-# JSON output
-
-def test_json_output(monkeypatch):
-    body = json.dumps({"status": "ok"}).encode()
-    monkeypatch.setattr(
-        "urllib.request.urlopen",
-        lambda *a, **k: _FakeResponse(200, body),
-    )
+def test_json_output():
     _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "LLM_API_KEY")
     _reset_breaker()
-
-    report = doctor.collect_report()
-    output = doctor.format_json(report)
-    parsed = json.loads(output)
-
-    expected_keys = {
-        "mode", "server_url", "api_key_source", "reachable", "latency_ms",
-        "plugin_version", "server_version", "embedding_model",
-        "embedding_dimensions", "circuit_breaker",
+    body = json.dumps({"status": "ready"}).encode()
+    with _patch_urlopen(response=_FakeResponse(200, body)):
+        report = doctor.collect_report()
+    parsed = json.loads(doctor.format_json(report))
+    expected = {
+        "mode",
+        "server_url",
+        "api_key_source",
+        "reachable",
+        "latency_ms",
+        "cognee_local",
+        "cognee_server",
+        "embedding_model",
+        "embedding_dimensions",
+        "circuit_breaker",
     }
-    assert expected_keys == set(parsed.keys()), f"missing keys: {expected_keys - set(parsed.keys())}"
+    assert expected == set(parsed.keys()), f"keys mismatch: {expected ^ set(parsed.keys())}"
 
 
 def test_human_output_contains_header():
@@ -247,32 +275,19 @@ def test_human_output_contains_header():
     text = doctor.format_human(report)
     assert "Cognee Doctor" in text
     assert "Mode:" in text
+    assert "Cognee (local):" in text
     assert "Circuit Breaker:" in text
 
 
 if __name__ == "__main__":
     failures = 0
-    skipped = 0
-    for name, fn in sorted(globals().items()):
-        if not name.startswith("test_") or not callable(fn):
+    for _name, _fn in sorted(globals().items()):
+        if not _name.startswith("test_") or not callable(_fn):
             continue
-
-        import inspect
-
-        sig = inspect.signature(fn)
-        params = list(sig.parameters.keys())
-
-        if "monkeypatch" in params or "tmp_path" in params:
-            skipped += 1
-            print(f"SKIP {name} (requires pytest fixtures)")
-            continue
-
         try:
-            fn()
-            print(f"PASS {name}")
+            _fn()
+            print(f"PASS {_name}")
         except AssertionError as e:
             failures += 1
-            print(f"FAIL {name}: {e}")
-    if skipped:
-        print(f"\n{skipped} test(s) skipped (run with pytest for full coverage)")
+            print(f"FAIL {_name}: {e}")
     sys.exit(1 if failures else 0)


### PR DESCRIPTION
Reworks community PR #208 by @avanshh99, implementing [topoteretes/cognee#3551](https://github.com/topoteretes/cognee/issues/3551) — a read-only `cognee doctor` command for the **claude-code** and **codex** plugins that prints, in one output, everything needed to spot a broken setup.

Linear: **SDK-298**. Base branch `main` (this repo has no `dev`).

## What it does

`cognee doctor` (claude-code: `cognee-doctor.sh`; codex: `cognee-cli.sh doctor`), or `doctor.py [--json]`, prints:

```text
Cognee Doctor

Mode:                Local Managed
Server URL:          http://localhost:8011
API Key Source:      ENV
Reachable:           Yes
Latency:             12.3 ms
Cognee (local):      1.2.2.dev3
Cognee (server):     1.2.2.dev3
Embedding Model:     openai/text-embedding-3-large
Embedding Dims:      3072
Circuit Breaker:     Closed
```

Purely diagnostic — it never mutates configuration, initialises databases, registers resources, writes files, or changes runtime state. `--json` gives machine-readable output.

## Author's contribution (preserved)

The first three commits are @avanshh99's original work, with authorship intact: the command skeleton, the mode taxonomy (Local / Local Managed / Cloud), the health + latency probe, API-key-source and circuit-breaker reporting, the shell wrappers, and the unit tests.

The author's accidental first commit — which only *deleted* unrelated files (`n8n_workflows/**`, the root `pyproject.toml`, `scripts/check_version_pins.py`) — was dropped as out of scope for #3551.

## Maintainer rework (separate single-concern commits)

Reviewed against current code and the issue's field list. It was a solid read-only skeleton, but two required fields were stubbed, one reported the wrong datum, a Cloud-mode TLS bug false-negated reachability, and five tests never ran. Each fix is its own commit:

1. **feat: embedding model + dims from env** — were hardcoded `"Unknown"`, so two required fields carried no information. No cognee HTTP endpoint exposes embedding config (the settings endpoint returns only `llm` + `vector_db` and needs auth), so read the env cognee itself honours — `EMBEDDING_MODEL` / `EMBEDDING_DIMENSIONS` (→ "Default" when unset).
2. **feat: local (venv) cognee version, not the inventory entry** — the PR reported the *integration's* version parsed from `integrations/inventory.yml`, a monorepo-only file absent in an installed plugin (so the field was always "Unknown" in production) and inconsistent with the shipped `plugin.json`. Now probes the plugin's managed venv for the real cognee version; keeps the server's cognee version from `/health`. Relabeled **Cognee (local)** / **Cognee (server)** to match the issue's "plugin venv vs server". Removes the ~40-line inventory line-scanner.
3. **fix: shared TLS context for the health check** — `_check_health` called `urlopen` without `_https_context()`; as the plugin's own helper documents, macOS Python often fails HTTPS to Cognee Cloud with `CERTIFICATE_VERIFY_FAILED`, which made the doctor report a healthy Cloud instance as unreachable. Reuses the shared context (harmless for `http://` localhost).
4. **test: run every check under plain python3** — the tests used pytest `monkeypatch` / `tmp_path` fixtures, so 5 checks (health reachable/unreachable, config key source, JSON output, inventory parse) silently SKIPPED under the only mode these dirs run in (`python3 tests/test_*.py`; CI's matrix skips them, as they have no `pyproject.toml`). Rewritten to manual stubbing matching the sibling `test_cognee_client.py`; 20/20 run, with coverage added for the new fields.
5. **style: ruff format** — blank-line normalisation so `ruff format --check` (CI-enforced) stays clean.
6. **fix: `cognee doctor` runs from any directory (codex)** — codex dispatched the subcommand only after the repo-root gate, so `cognee doctor` exited 64 outside the Cognee repo; claude-code's wrapper runs anywhere. Dispatch doctor before the gate; the normal `uv run cognee-cli` path stays gated.

## Verification

- `python3 tests/test_doctor.py` — claude-code **20 pass / 0 skip / 0 fail**, codex **20 pass / 0 skip / 0 fail**.
- `ruff check` and `ruff format --check` clean at the repo's line-length = 100.
- Manual: human + `--json` output in Local mode; `cognee doctor` runs from a non-repo directory; embedding fields reflect the environment; the health check builds the shared TLS context for HTTPS.

Implements topoteretes/cognee#3551 (hackathon). Reworks #208.
