### PR TITLE
feat(claude-code,codex): surface cognify lag instead of silent empty recall (SDK-299)

### DIFF
--- a/integrations/claude-code/agents/cognee-recall.md
+++ b/integrations/claude-code/agents/cognee-recall.md
@@ -47,6 +47,7 @@ curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
 - **An empty result is only valid if it came from the server.** `cognee-cli` is a thin client over the same server and can print empty stdout even when content exists. **Never conclude "not found" from an empty/clean CLI run** — confirm with the `curl` above first.
 - **Do not re-run the same search to "retry."** One server answer is authoritative — report it and stop. (Re-running the CLI and chasing async warnings is how a confident-but-wrong "nothing found" verdict gets produced.)
 - **If the output is an `{"error": ...}` object instead of a list**, the server was reachable but rejected/failed the request (e.g. auth) — report that error and check `COGNEE_API_KEY`. It is **not** "no results", and the wrapper deliberately does **not** fall back to the local CLI in that case.
+- **If the output is an object with `captured_pending`**, the server found nothing yet but content captured this session is still waiting on cognify — suggest retrying shortly (the background sync picks it up) or `/cognee-memory:cognee-sync` instead of reporting "not found" or grepping the transcript.
 
 ## Output
 

--- a/integrations/claude-code/scripts/_cognee_client.py
+++ b/integrations/claude-code/scripts/_cognee_client.py
@@ -108,10 +108,44 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
     return result
 
 
+def annotate_empty_recall(result, session_id):
+    """Distinguish "nothing stored" from "captured, not yet cognified" on empty recall.
+
+    A 2xx empty list stays authoritative, but when the local session-cache bridge
+    still holds qa/trace content whose digest the drain has not marked cognified,
+    a bare ``[]`` would read as "no memory" and push the caller to transcript
+    grep. Return a distinct envelope carrying the pending counts instead. Every
+    non-empty result (hits, error envelope, UNREACHABLE) passes through unchanged,
+    as does a genuine empty (no pending captures).
+    """
+    if result != []:
+        return result
+    try:
+        # Lazy import: _plugin_common is stdlib-only, but keep this script
+        # functional standalone even if the module is absent/unreadable.
+        from _plugin_common import pending_capture_counts
+
+        pending = pending_capture_counts(session_id)
+    except Exception:
+        return result
+    if not any(pending.values()):
+        return result
+    return {
+        "recall": [],
+        "captured_pending": pending,
+        "authoritative": True,
+        "hint": (
+            "content captured this session is not yet cognified; "
+            "retry shortly (the background sync picks it up) or run /cognee-memory:cognee-sync; "
+            "do not fall back to transcript search"
+        ),
+    }
+
+
 def main(argv):
     # argv: service_url, api_key, query, session_id, scope, top_k[, dataset]
     a = list(argv) + [""] * 7
-    result = recall(a[0], a[1], a[2], a[3], a[4], a[5], a[6])
+    result = annotate_empty_recall(recall(a[0], a[1], a[2], a[3], a[4], a[5], a[6]), a[3])
     print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
 
 

--- a/integrations/claude-code/scripts/_cognee_client.py
+++ b/integrations/claude-code/scripts/_cognee_client.py
@@ -133,7 +133,6 @@ def annotate_empty_recall(result, session_id):
     return {
         "recall": [],
         "captured_pending": pending,
-        "authoritative": True,
         "hint": (
             "content captured this session is not yet cognified; "
             "retry shortly (the background sync picks it up) or run /cognee-memory:cognee-sync; "

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1556,11 +1556,13 @@ def _multipart_body(
     return b"".join(chunks), boundary
 
 
-def _format_cached_bridge_document(dataset: str, session_id: str) -> tuple[str, str]:
-    cache = _load_json_file(_bridge_file(session_id))
-    key = _bridge_cache_key(dataset, session_id)
-    session_cache = cache.get(key, {})
+def _format_bridge_docs(session_cache: dict, session_id: str) -> tuple[str, str]:
+    """Build the (qa_doc, trace_doc) pair for one bridge-cache key.
 
+    Shared by the drain (which hashes + posts the docs) and
+    ``pending_capture_counts`` (which hashes them to detect not-yet-cognified
+    content), so both always compute identical digests for identical content.
+    """
     qa_lines: list[str] = []
     for entry in session_cache.get("qa", []) or []:
         question = str(entry.get("question") or "").strip()
@@ -1582,6 +1584,65 @@ def _format_cached_bridge_document(dataset: str, session_id: str) -> tuple[str, 
     if trace_doc:
         trace_doc = f"Session ID: {session_id}\n\n{trace_doc}"
     return qa_doc, trace_doc
+
+
+def _format_cached_bridge_document(dataset: str, session_id: str) -> tuple[str, str]:
+    cache = _load_json_file(_bridge_file(session_id))
+    key = _bridge_cache_key(dataset, session_id)
+    return _format_bridge_docs(cache.get(key, {}), session_id)
+
+
+def pending_capture_counts(session_id: str) -> dict:
+    """Count bridge entries captured this session but not yet confirmed cognified.
+
+    The drain (``persist_session_cache_to_graph_via_http``) marks each qa/trace
+    document as cognified by storing its sha256 digest under
+    ``_state["{dataset}:{session_id}:{kind}"]``. A kind whose current digest is
+    absent or stale is captured-but-not-yet-queryable, which lets callers tell
+    "nothing stored" apart from "stored, cognify still pending" on empty recall.
+
+    Scans every file in ``_BRIDGE_DIR`` rather than only ``_bridge_file(session_id)``:
+    bridge filenames are scoped by COGNEE_SESSION_KEY, which hook processes set but
+    the ``cognee-search.sh`` shell environment may not, so matching by the
+    ``:{session_id}`` key suffix works from both paths (session ids are sanitized
+    to ``[alnum-_.]``, so the suffix match cannot split a session id).
+
+    Best-effort, never raises: any read/parse failure counts as zero pending.
+    """
+    pending = {"qa": 0, "trace": 0}
+    if not session_id:
+        return pending
+    try:
+        bridge_paths = sorted(_BRIDGE_DIR.glob("*.json")) if _BRIDGE_DIR.exists() else []
+    except OSError as exc:
+        hook_log("pending_capture_scan_failed", {"error": str(exc)[:200]})
+        return pending
+    suffix = f":{session_id}"
+    for path in bridge_paths:
+        # Per-file guard: a bridge file with a corrupt SHAPE (valid JSON, wrong
+        # entry types) must skip that file, not abort the caller's hook output.
+        try:
+            cache = _load_json_file(path)
+            if not isinstance(cache, dict):
+                continue
+            state = cache.get("_state") if isinstance(cache.get("_state"), dict) else {}
+            for key, session_cache in cache.items():
+                if (
+                    key == "_state"
+                    or not key.endswith(suffix)
+                    or not isinstance(session_cache, dict)
+                ):
+                    continue
+                qa_doc, trace_doc = _format_bridge_docs(session_cache, session_id)
+                for kind, document in (("qa", qa_doc), ("trace", trace_doc)):
+                    if not document:
+                        continue
+                    digest = hashlib.sha256(document.encode("utf-8")).hexdigest()
+                    if state.get(f"{key}:{kind}") != digest:
+                        pending[kind] += len(session_cache.get(kind) or [])
+        except Exception as exc:
+            hook_log("pending_capture_read_failed", {"path": str(path), "error": str(exc)[:200]})
+    return pending
 
 
 def _post_remember_document(

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1604,12 +1604,19 @@ def pending_capture_counts(session_id: str) -> dict:
     Scans every file in ``_BRIDGE_DIR`` rather than only ``_bridge_file(session_id)``:
     bridge filenames are scoped by COGNEE_SESSION_KEY, which hook processes set but
     the ``cognee-search.sh`` shell environment may not, so matching by the
-    ``:{session_id}`` key suffix works from both paths (session ids are sanitized
-    to ``[alnum-_.]``, so the suffix match cannot split a session id).
+    ``:{session_id}`` key suffix works from both paths. The id is sanitized first so
+    it matches the write-side key regardless of caller, and the colon anchor means
+    the suffix match cannot split a session id.
 
     Best-effort, never raises: any read/parse failure counts as zero pending.
     """
     pending = {"qa": 0, "trace": 0}
+    # Normalize to the write-side convention: append_http_bridge_entry always keys the
+    # bridge on the *sanitized* id, but a caller may pass a raw one (e.g. the explicit
+    # search path's ${COGNEE_SESSION_ID} fallback). Sanitizing here keeps both the
+    # ":{session_id}" suffix and the digest (which embeds the id) aligned with what the
+    # drain wrote — otherwise the match silently finds nothing and the hint dies.
+    session_id = _sanitize_session_key(session_id)
     if not session_id:
         return pending
     try:

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -26,6 +26,7 @@ from _plugin_common import (
     load_resolved,
     mark_server_ready,
     notify,
+    pending_capture_counts,
     quiet_hook_output,
     read_and_reset_save_counter,
     recall_via_http,
@@ -378,9 +379,28 @@ async def _run(prompt: str) -> dict | None:
         hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
         notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
     else:
-        full_context = f"{header}\n\n(no memory matches for this prompt)"
-        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
-        notify(f"no recall matches; saves last turn {saves_last_turn}")
+        # Empty recall is not always "no memory": content captured this session
+        # may still be waiting on cognify. Surface that so the agent does not
+        # silently fall back to transcript grep.
+        pending = pending_capture_counts(session_id)
+        if any(pending.values()):
+            full_context = (
+                f"{header}\n\n(no cognified memory matches yet: "
+                f"{pending['qa']} QA / {pending['trace']} trace entries captured this session "
+                "are not yet confirmed cognified; retry next turn or run "
+                "/cognee-memory:cognee-sync; do not fall back to transcript search)"
+            )
+            hook_log(
+                "context_lookup_pending_cognify",
+                {"pending": pending, "saves_last_turn": saves_last_turn},
+            )
+            notify(
+                f"recall empty but capture pending ({pending}); saves last turn {saves_last_turn}"
+            )
+        else:
+            full_context = f"{header}\n\n(no memory matches for this prompt)"
+            hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
+            notify(f"no recall matches; saves last turn {saves_last_turn}")
 
     # Audit log: persist full recall details per turn. The hook output stays a
     # short summary because Codex renders additionalContext in the terminal.

--- a/integrations/claude-code/skills/cognee-search/SKILL.md
+++ b/integrations/claude-code/skills/cognee-search/SKILL.md
@@ -80,6 +80,8 @@ Results include a `_source` field:
 
 Session entries tagged with `[category:agent]` are automatic tool call logs.
 
+An object with a `captured_pending` field (`{"recall": [], "captured_pending": {...}, "hint": ...}`) means the server found nothing **yet**, but content captured this session is still waiting on cognify — it is not "no memory". Retry shortly (the background sync picks it up) or run `/cognee-memory:cognee-sync` instead of falling back to transcript search.
+
 ## Decision table
 
 | Signal | Action |
@@ -89,4 +91,5 @@ Session entries tagged with `[category:agent]` are automatic tool call logs.
 | "what does the codebase do" / "what did we do last time" | `cognee-search.sh "<query>" 10 --graph` |
 | Need a specific category | use the `node_name` curl form above (`["user_context"\|"project_docs"\|"agent_actions"]`) |
 | Auto context insufficient | `cognee-search.sh "<query>" 10 --session` |
+| Output has `captured_pending` | Content captured but not yet cognified — retry shortly or run `/cognee-memory:cognee-sync`; do **not** transcript-grep |
 | **Result empty but you expect content** | **Ground-truth via the `curl` above before concluding "not found"** |

--- a/integrations/claude-code/tests/test_cognee_client.py
+++ b/integrations/claude-code/tests/test_cognee_client.py
@@ -113,6 +113,70 @@ def test_dataset_forwarded_to_transport():
     assert captured.get("dataset") == "my_dataset"
 
 
+def _patched_pending(value):
+    """Temporarily replace _plugin_common.pending_capture_counts; return a restorer."""
+    import _plugin_common as pc
+
+    orig = pc.pending_capture_counts
+    pc.pending_capture_counts = value if callable(value) else (lambda session_id: value)
+
+    def _restore():
+        pc.pending_capture_counts = orig
+
+    return _restore
+
+
+def test_annotate_empty_recall_with_pending_returns_envelope():
+    # topoteretes/cognee#3553: empty recall + captured-but-uncognified bridge
+    # content must be distinguishable from a genuine empty.
+    restore = _patched_pending({"qa": 2, "trace": 1})
+    try:
+        out = cc.annotate_empty_recall([], "claude_abc123")
+    finally:
+        restore()
+    assert isinstance(out, dict)
+    assert out["recall"] == []
+    assert out["captured_pending"] == {"qa": 2, "trace": 1}
+    # It is NOT an error envelope: the empty recall itself was authoritative.
+    assert out["authoritative"] is True and "error" not in out
+    assert "not yet cognified" in out["hint"]
+
+
+def test_annotate_empty_recall_without_pending_stays_empty():
+    restore = _patched_pending({"qa": 0, "trace": 0})
+    try:
+        assert cc.annotate_empty_recall([], "claude_abc123") == []
+    finally:
+        restore()
+
+
+def test_annotate_passes_through_non_empty_results():
+    def _boom(session_id):
+        raise AssertionError("pending check must not run for non-empty results")
+
+    restore = _patched_pending(_boom)
+    try:
+        hits = [{"text": "hit"}]
+        err = {"error": "boom", "status": 500, "authoritative": False}
+        assert cc.annotate_empty_recall(hits, "s") == hits
+        assert cc.annotate_empty_recall(err, "s") == err
+        assert cc.annotate_empty_recall(UNREACHABLE, "s") == UNREACHABLE
+    finally:
+        restore()
+
+
+def test_annotate_never_raises_when_pending_check_fails():
+    # A broken bridge read must degrade to the plain authoritative empty.
+    def _boom(session_id):
+        raise OSError("disk on fire")
+
+    restore = _patched_pending(_boom)
+    try:
+        assert cc.annotate_empty_recall([], "claude_abc123") == []
+    finally:
+        restore()
+
+
 if __name__ == "__main__":
     failures = 0
     for name, fn in sorted(globals().items()):

--- a/integrations/claude-code/tests/test_cognee_client.py
+++ b/integrations/claude-code/tests/test_cognee_client.py
@@ -138,7 +138,7 @@ def test_annotate_empty_recall_with_pending_returns_envelope():
     assert out["recall"] == []
     assert out["captured_pending"] == {"qa": 2, "trace": 1}
     # It is NOT an error envelope: the empty recall itself was authoritative.
-    assert out["authoritative"] is True and "error" not in out
+    assert "error" not in out
     assert "not yet cognified" in out["hint"]
 
 

--- a/integrations/claude-code/tests/test_pending_capture.py
+++ b/integrations/claude-code/tests/test_pending_capture.py
@@ -1,0 +1,251 @@
+"""Unit tests for pending_capture_counts (_plugin_common.py).
+
+Covers the contract from topoteretes/cognee#3553:
+- bridge qa/trace content whose digest is absent/stale in ``_state`` counts as
+  captured-but-not-yet-cognified ("stored, not yet queryable");
+- fully-drained content (digests match) counts as zero pending, so a genuine
+  empty recall stays a genuine empty;
+- other sessions' keys, corrupted files, and a missing bridge dir never leak
+  counts or raise;
+- the digest scheme stays pinned to the REAL drain
+  (persist_session_cache_to_graph_via_http), not a parallel reimplementation.
+
+Run: `pytest integrations/claude-code/tests/test_pending_capture.py`
+(or `python integrations/claude-code/tests/test_pending_capture.py` standalone).
+"""
+
+import hashlib
+import json
+import pathlib
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+
+import _plugin_common as pc  # noqa: E402
+
+SESSION = "claude_abc123"
+DATASET = "agent_sessions"
+KEY = f"{DATASET}:{SESSION}"
+
+
+def _with_fresh_bridge_dir(fn):
+    """Point pc._BRIDGE_DIR at a fresh temp dir for the test, then restore it.
+
+    Deliberately not functools.wraps: pytest would follow ``__wrapped__`` to the
+    inner ``(tmp)`` signature and go looking for a ``tmp`` fixture.
+    """
+
+    def wrapper():
+        orig = pc._BRIDGE_DIR
+        pc._BRIDGE_DIR = pathlib.Path(tempfile.mkdtemp(prefix="cognee-bridge-test-"))
+        try:
+            fn(pc._BRIDGE_DIR)
+        finally:
+            pc._BRIDGE_DIR = orig
+
+    wrapper.__name__ = fn.__name__
+    wrapper.__doc__ = fn.__doc__
+    return wrapper
+
+
+def _write_bridge(tmp: pathlib.Path, cache, name: str = "scope.json") -> None:
+    payload = cache if isinstance(cache, str) else json.dumps(cache)
+    (tmp / name).write_text(payload, encoding="utf-8")
+
+
+def _digest(session_cache: dict, kind: str) -> str:
+    """Compute the digest the drain would store for one kind of this cache."""
+    qa_doc, trace_doc = pc._format_bridge_docs(session_cache, SESSION)
+    document = qa_doc if kind == "qa" else trace_doc
+    return hashlib.sha256(document.encode("utf-8")).hexdigest()
+
+
+@_with_fresh_bridge_dir
+def test_missing_bridge_dir_is_zero(tmp):
+    pc._BRIDGE_DIR = tmp / "nope"
+    assert pc.pending_capture_counts(SESSION) == {"qa": 0, "trace": 0}
+
+
+@_with_fresh_bridge_dir
+def test_empty_session_id_is_zero(tmp):
+    _write_bridge(tmp, {KEY: {"qa": [{"question": "q", "answer": "a"}], "trace": []}})
+    assert pc.pending_capture_counts("") == {"qa": 0, "trace": 0}
+
+
+@_with_fresh_bridge_dir
+def test_uncognified_entries_are_pending(tmp):
+    # Captured content with no _state at all: everything is pending.
+    _write_bridge(
+        tmp,
+        {
+            KEY: {
+                "qa": [
+                    {"question": "q1", "answer": "a1"},
+                    {"question": "q2", "answer": "a2"},
+                ],
+                "trace": ["tool call one"],
+            }
+        },
+    )
+    assert pc.pending_capture_counts(SESSION) == {"qa": 2, "trace": 1}
+
+
+@_with_fresh_bridge_dir
+def test_fully_cognified_is_zero(tmp):
+    # Digests match what the drain stored: a genuine empty stays a genuine empty.
+    session_cache = {
+        "qa": [{"question": "q1", "answer": "a1"}],
+        "trace": ["tool call one"],
+    }
+    _write_bridge(
+        tmp,
+        {
+            KEY: session_cache,
+            "_state": {
+                f"{KEY}:qa": _digest(session_cache, "qa"),
+                f"{KEY}:trace": _digest(session_cache, "trace"),
+            },
+        },
+    )
+    assert pc.pending_capture_counts(SESSION) == {"qa": 0, "trace": 0}
+
+
+@_with_fresh_bridge_dir
+def test_partially_cognified_counts_only_unmarked(tmp):
+    # qa drained, trace not: only trace is pending.
+    session_cache = {
+        "qa": [{"question": "q1", "answer": "a1"}],
+        "trace": ["tool call one", "tool call two"],
+    }
+    _write_bridge(
+        tmp,
+        {
+            KEY: session_cache,
+            "_state": {f"{KEY}:qa": _digest(session_cache, "qa")},
+        },
+    )
+    assert pc.pending_capture_counts(SESSION) == {"qa": 0, "trace": 2}
+
+
+@_with_fresh_bridge_dir
+def test_stale_digest_counts_as_pending(tmp):
+    # Content appended AFTER the last drain: the stored digest no longer matches.
+    drained = {"qa": [{"question": "q1", "answer": "a1"}], "trace": []}
+    grown = {
+        "qa": [
+            {"question": "q1", "answer": "a1"},
+            {"question": "q2", "answer": "a2"},
+        ],
+        "trace": [],
+    }
+    _write_bridge(
+        tmp,
+        {
+            KEY: grown,
+            "_state": {f"{KEY}:qa": _digest(drained, "qa")},
+        },
+    )
+    assert pc.pending_capture_counts(SESSION) == {"qa": 2, "trace": 0}
+
+
+@_with_fresh_bridge_dir
+def test_other_session_keys_are_ignored(tmp):
+    _write_bridge(
+        tmp,
+        {f"{DATASET}:claude_other999": {"qa": [{"question": "q", "answer": "a"}], "trace": []}},
+    )
+    assert pc.pending_capture_counts(SESSION) == {"qa": 0, "trace": 0}
+
+
+@_with_fresh_bridge_dir
+def test_corrupted_bridge_file_is_zero_and_does_not_raise(tmp):
+    _write_bridge(tmp, "not json{")
+    assert pc.pending_capture_counts(SESSION) == {"qa": 0, "trace": 0}
+
+
+@_with_fresh_bridge_dir
+def test_corrupt_shape_is_skipped_and_does_not_raise(tmp):
+    # Valid JSON, corrupt SHAPE (qa entries are not dicts): the bad file is
+    # skipped, a good file alongside it is still counted, nothing raises.
+    _write_bridge(tmp, {KEY: {"qa": ["not-a-dict"], "trace": []}}, name="bad.json")
+    _write_bridge(
+        tmp,
+        {KEY: {"qa": [{"question": "q1", "answer": "a1"}], "trace": []}},
+        name="good.json",
+    )
+    assert pc.pending_capture_counts(SESSION) == {"qa": 1, "trace": 0}
+
+
+@_with_fresh_bridge_dir
+def test_pending_found_across_multiple_bridge_files(tmp):
+    # The hooks and the search shell can resolve different bridge filenames
+    # (COGNEE_SESSION_KEY vs fallback scope); the dir scan must find the
+    # session's keys regardless of which file holds them.
+    _write_bridge(tmp, {"other:key": {"qa": [], "trace": ["x"]}}, name="a.json")
+    _write_bridge(
+        tmp,
+        {KEY: {"qa": [{"question": "q1", "answer": "a1"}], "trace": []}},
+        name="b.json",
+    )
+    assert pc.pending_capture_counts(SESSION) == {"qa": 1, "trace": 0}
+
+
+@_with_fresh_bridge_dir
+def test_real_drain_clears_pending(tmp):
+    # Pin pending_capture_counts to the REAL drain's _state key scheme: run
+    # persist_session_cache_to_graph_via_http against a real bridge file (only
+    # the HTTP seams mocked), then confirm pending drops to zero. If the drain's
+    # state_key composition ever changed, this test fails instead of both sides
+    # drifting apart silently.
+    bridge_path = tmp / f"{SESSION}.json"
+    bridge_path.write_text(
+        json.dumps({KEY: {"qa": [{"question": "q1", "answer": "a1"}], "trace": ["tool call one"]}}),
+        encoding="utf-8",
+    )
+    assert pc.pending_capture_counts(SESSION) == {"qa": 1, "trace": 1}
+
+    saved = {
+        k: getattr(pc, k)
+        for k in (
+            "_local_api_url",
+            "_backend_reachable",
+            "_api_key",
+            "_bridge_file",
+            "_post_remember_document",
+            "wait_for_cognify",
+            "hook_log",
+        )
+    }
+    pc._local_api_url = lambda: "http://x"
+    pc._backend_reachable = lambda url: True
+    pc._api_key = lambda: "k"
+    pc._bridge_file = lambda sid: bridge_path
+    pc._post_remember_document = lambda *a, **k: {
+        "ok": True,
+        "dataset_id": "d1",
+        "pipeline_run_id": "p1",
+    }
+    pc.wait_for_cognify = lambda *a, **k: "completed"
+    pc.hook_log = lambda *a, **k: None
+    try:
+        wrote = pc.persist_session_cache_to_graph_via_http(DATASET, SESSION)
+    finally:
+        for k, v in saved.items():
+            setattr(pc, k, v)
+
+    assert wrote is True
+    assert pc.pending_capture_counts(SESSION) == {"qa": 0, "trace": 0}
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print("PASS", name)
+            except AssertionError as e:
+                failures += 1
+                print("FAIL", name, e)
+    sys.exit(1 if failures else 0)

--- a/integrations/claude-code/tests/test_pending_capture.py
+++ b/integrations/claude-code/tests/test_pending_capture.py
@@ -238,6 +238,35 @@ def test_real_drain_clears_pending(tmp):
     assert pc.pending_capture_counts(SESSION) == {"qa": 0, "trace": 0}
 
 
+@_with_fresh_bridge_dir
+def test_unsanitized_session_id_matches_sanitized_key(tmp):
+    # The write path always keys the bridge on the SANITIZED id ("my project" ->
+    # "my_project"); the explicit-search path may hand the reader the raw value
+    # (cognee-search.sh's ${COGNEE_SESSION_ID} fallback). The reader must normalize
+    # so the ":{session_id}" suffix still matches the sanitized bridge key.
+    raw = "my project"
+    sanitized = pc._sanitize_session_key(raw)  # "my_project"
+    assert sanitized != raw
+    _write_bridge(
+        tmp,
+        {f"{DATASET}:{sanitized}": {"qa": [{"question": "q1", "answer": "a1"}], "trace": []}},
+    )
+    assert pc.pending_capture_counts(raw) == {"qa": 1, "trace": 0}
+    assert pc.pending_capture_counts(sanitized) == {"qa": 1, "trace": 0}
+
+
+@_with_fresh_bridge_dir
+def test_suffix_match_is_colon_anchored(tmp):
+    # The docstring promises the ":{session_id}" match "cannot split a session id".
+    # A key whose id is a non-colon-anchored tail of the session id must NOT match:
+    # session "claude_abc123" must not be counted for key "...:xclaude_abc123".
+    _write_bridge(
+        tmp,
+        {f"{DATASET}:xclaude_abc123": {"qa": [{"question": "q", "answer": "a"}], "trace": []}},
+    )
+    assert pc.pending_capture_counts(SESSION) == {"qa": 0, "trace": 0}
+
+
 if __name__ == "__main__":
     failures = 0
     for name, fn in sorted(globals().items()):

--- a/integrations/codex/plugins/cognee/scripts/_cognee_client.py
+++ b/integrations/codex/plugins/cognee/scripts/_cognee_client.py
@@ -108,10 +108,45 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
     return result
 
 
+def annotate_empty_recall(result, session_id):
+    """Distinguish "nothing stored" from "captured, not yet cognified" on empty recall.
+
+    A 2xx empty list stays authoritative, but when the local session-cache bridge
+    still holds qa/trace content whose digest the drain has not marked cognified,
+    a bare ``[]`` would read as "no memory" and push the caller to transcript
+    grep. Return a distinct envelope carrying the pending counts instead. Every
+    non-empty result (hits, error envelope, UNREACHABLE) passes through unchanged,
+    as does a genuine empty (no pending captures).
+    """
+    if result != []:
+        return result
+    try:
+        # Lazy import: _plugin_common is stdlib-only, but keep this script
+        # functional standalone even if the module is absent/unreadable.
+        from _plugin_common import pending_capture_counts
+
+        pending = pending_capture_counts(session_id)
+    except Exception:
+        return result
+    if not any(pending.values()):
+        return result
+    return {
+        "recall": [],
+        "captured_pending": pending,
+        "authoritative": True,
+        "hint": (
+            "content captured this session is not yet cognified; "
+            "retry shortly (the background sync picks it up) or run "
+            'python3 "${CODEX_PLUGIN_ROOT}/scripts/sync-session-to-graph.py"; '
+            "do not fall back to transcript search"
+        ),
+    }
+
+
 def main(argv):
     # argv: service_url, api_key, query, session_id, scope, top_k[, dataset]
     a = list(argv) + [""] * 7
-    result = recall(a[0], a[1], a[2], a[3], a[4], a[5], a[6])
+    result = annotate_empty_recall(recall(a[0], a[1], a[2], a[3], a[4], a[5], a[6]), a[3])
     print(UNREACHABLE if result == UNREACHABLE else json.dumps(result))
 
 

--- a/integrations/codex/plugins/cognee/scripts/_cognee_client.py
+++ b/integrations/codex/plugins/cognee/scripts/_cognee_client.py
@@ -133,7 +133,6 @@ def annotate_empty_recall(result, session_id):
     return {
         "recall": [],
         "captured_pending": pending,
-        "authoritative": True,
         "hint": (
             "content captured this session is not yet cognified; "
             "retry shortly (the background sync picks it up) or run "

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -1447,11 +1447,13 @@ def _multipart_body(
     return b"".join(chunks), boundary
 
 
-def _format_cached_bridge_document(dataset: str, session_id: str) -> tuple[str, str]:
-    cache = _load_json_file(_bridge_file(session_id))
-    key = _bridge_cache_key(dataset, session_id)
-    session_cache = cache.get(key, {})
+def _format_bridge_docs(session_cache: dict, session_id: str) -> tuple[str, str]:
+    """Build the (qa_doc, trace_doc) pair for one bridge-cache key.
 
+    Shared by the drain (which hashes + posts the docs) and
+    ``pending_capture_counts`` (which hashes them to detect not-yet-cognified
+    content), so both always compute identical digests for identical content.
+    """
     qa_lines: list[str] = []
     for entry in session_cache.get("qa", []) or []:
         question = str(entry.get("question") or "").strip()
@@ -1473,6 +1475,65 @@ def _format_cached_bridge_document(dataset: str, session_id: str) -> tuple[str, 
     if trace_doc:
         trace_doc = f"Session ID: {session_id}\n\n{trace_doc}"
     return qa_doc, trace_doc
+
+
+def _format_cached_bridge_document(dataset: str, session_id: str) -> tuple[str, str]:
+    cache = _load_json_file(_bridge_file(session_id))
+    key = _bridge_cache_key(dataset, session_id)
+    return _format_bridge_docs(cache.get(key, {}), session_id)
+
+
+def pending_capture_counts(session_id: str) -> dict:
+    """Count bridge entries captured this session but not yet confirmed cognified.
+
+    The drain (``persist_session_cache_to_graph_via_http``) marks each qa/trace
+    document as cognified by storing its sha256 digest under
+    ``_state["{dataset}:{session_id}:{kind}"]``. A kind whose current digest is
+    absent or stale is captured-but-not-yet-queryable, which lets callers tell
+    "nothing stored" apart from "stored, cognify still pending" on empty recall.
+
+    Scans every file in ``_BRIDGE_DIR`` rather than only ``_bridge_file(session_id)``:
+    bridge filenames are scoped by COGNEE_SESSION_KEY, which hook processes set but
+    the ``cognee-search.sh`` shell environment may not, so matching by the
+    ``:{session_id}`` key suffix works from both paths (session ids are sanitized
+    to ``[alnum-_.]``, so the suffix match cannot split a session id).
+
+    Best-effort, never raises: any read/parse failure counts as zero pending.
+    """
+    pending = {"qa": 0, "trace": 0}
+    if not session_id:
+        return pending
+    try:
+        bridge_paths = sorted(_BRIDGE_DIR.glob("*.json")) if _BRIDGE_DIR.exists() else []
+    except OSError as exc:
+        hook_log("pending_capture_scan_failed", {"error": str(exc)[:200]})
+        return pending
+    suffix = f":{session_id}"
+    for path in bridge_paths:
+        # Per-file guard: a bridge file with a corrupt SHAPE (valid JSON, wrong
+        # entry types) must skip that file, not abort the caller's hook output.
+        try:
+            cache = _load_json_file(path)
+            if not isinstance(cache, dict):
+                continue
+            state = cache.get("_state") if isinstance(cache.get("_state"), dict) else {}
+            for key, session_cache in cache.items():
+                if (
+                    key == "_state"
+                    or not key.endswith(suffix)
+                    or not isinstance(session_cache, dict)
+                ):
+                    continue
+                qa_doc, trace_doc = _format_bridge_docs(session_cache, session_id)
+                for kind, document in (("qa", qa_doc), ("trace", trace_doc)):
+                    if not document:
+                        continue
+                    digest = hashlib.sha256(document.encode("utf-8")).hexdigest()
+                    if state.get(f"{key}:{kind}") != digest:
+                        pending[kind] += len(session_cache.get(kind) or [])
+        except Exception as exc:
+            hook_log("pending_capture_read_failed", {"path": str(path), "error": str(exc)[:200]})
+    return pending
 
 
 def _post_remember_document(

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -1495,12 +1495,19 @@ def pending_capture_counts(session_id: str) -> dict:
     Scans every file in ``_BRIDGE_DIR`` rather than only ``_bridge_file(session_id)``:
     bridge filenames are scoped by COGNEE_SESSION_KEY, which hook processes set but
     the ``cognee-search.sh`` shell environment may not, so matching by the
-    ``:{session_id}`` key suffix works from both paths (session ids are sanitized
-    to ``[alnum-_.]``, so the suffix match cannot split a session id).
+    ``:{session_id}`` key suffix works from both paths. The id is sanitized first so
+    it matches the write-side key regardless of caller, and the colon anchor means
+    the suffix match cannot split a session id.
 
     Best-effort, never raises: any read/parse failure counts as zero pending.
     """
     pending = {"qa": 0, "trace": 0}
+    # Normalize to the write-side convention: append_http_bridge_entry always keys the
+    # bridge on the *sanitized* id, but a caller may pass a raw one (e.g. the explicit
+    # search path's ${COGNEE_SESSION_ID} fallback). Sanitizing here keeps both the
+    # ":{session_id}" suffix and the digest (which embeds the id) aligned with what the
+    # drain wrote — otherwise the match silently finds nothing and the hint dies.
+    session_id = _sanitize_session_key(session_id)
     if not session_id:
         return pending
     try:

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -26,6 +26,7 @@ from _plugin_common import (
     load_resolved,
     mark_server_ready,
     notify,
+    pending_capture_counts,
     quiet_hook_output,
     read_and_reset_save_counter,
     recall_via_http,
@@ -370,9 +371,29 @@ async def _run(prompt: str) -> dict | None:
         hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
         notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
     else:
-        full_context = f"{header}\n\n(no memory matches for this prompt)"
-        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
-        notify(f"no recall matches; saves last turn {saves_last_turn}")
+        # Empty recall is not always "no memory": content captured this session
+        # may still be waiting on cognify. Surface that so the agent does not
+        # silently fall back to transcript grep.
+        pending = pending_capture_counts(session_id)
+        if any(pending.values()):
+            full_context = (
+                f"{header}\n\n(no cognified memory matches yet: "
+                f"{pending['qa']} QA / {pending['trace']} trace entries captured this session "
+                "are not yet confirmed cognified; retry next turn or run "
+                'python3 "${CODEX_PLUGIN_ROOT}/scripts/sync-session-to-graph.py"; '
+                "do not fall back to transcript search)"
+            )
+            hook_log(
+                "context_lookup_pending_cognify",
+                {"pending": pending, "saves_last_turn": saves_last_turn},
+            )
+            notify(
+                f"recall empty but capture pending ({pending}); saves last turn {saves_last_turn}"
+            )
+        else:
+            full_context = f"{header}\n\n(no memory matches for this prompt)"
+            hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
+            notify(f"no recall matches; saves last turn {saves_last_turn}")
 
     # Audit log: persist full recall details per turn for debugging.
     try:

--- a/integrations/codex/plugins/cognee/skills/memory/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/memory/SKILL.md
@@ -58,7 +58,7 @@ curl -s -X POST "${COGNEE_BASE_URL:-http://localhost:8011}/api/v1/recall" \
   -d '{"query": "<question>", "top_k": 10, "only_context": true, "scope": ["graph"]}'
 ```
 
-Omit `-H "X-Api-Key: ..."` for a local single-user server (auth is optional). An empty list `[]` from the server is authoritative — the server searched and found nothing.
+Omit `-H "X-Api-Key: ..."` for a local single-user server (auth is optional). An empty list `[]` from the server is authoritative — the server searched and found nothing. One exception: if the plugin's search wrapper returns an object with `captured_pending`, content captured this session is still waiting on cognify — retry shortly or run `python3 "${CODEX_PLUGIN_ROOT}/scripts/sync-session-to-graph.py"` instead of treating it as "no memory" or grepping the transcript.
 
 **Fallback only — server unreachable:**
 

--- a/integrations/codex/tests/test_pending_capture.py
+++ b/integrations/codex/tests/test_pending_capture.py
@@ -1,0 +1,187 @@
+"""Codex mirror of the cognify-lag capture tests (topoteretes/cognee#3553).
+
+The feature is duplicated across the claude-code and codex plugin trees; the
+claude-code copy is covered by integrations/claude-code/tests/. This is the
+codex mirror — it pins the behaviour that is codex-specific or that a silent
+copy-drift between the two _plugin_common.py / _cognee_client.py files would
+break:
+
+- pending_capture_counts detects captured-but-uncognified content and normalizes
+  the session id to the sanitized write-side key (so the explicit-search path's
+  raw ${COGNEE_SESSION_ID} fallback still matches);
+- the colon-anchored suffix match cannot split a session id;
+- annotate_empty_recall emits the codex hint (python3 sync-session-to-graph.py)
+  and no unconsumed `authoritative` field, and passes non-empty results through.
+
+Run: python integrations/codex/tests/test_pending_capture.py (or via pytest).
+"""
+
+import hashlib
+import json
+import pathlib
+import sys
+import tempfile
+
+sys.path.insert(
+    0, str(pathlib.Path(__file__).resolve().parents[1] / "plugins" / "cognee" / "scripts")
+)
+
+import _cognee_client as cc  # noqa: E402
+import _plugin_common as pc  # noqa: E402
+from _recall_http import UNREACHABLE  # noqa: E402
+
+SESSION = "codex_abc123"
+DATASET = "agent_sessions"
+KEY = f"{DATASET}:{SESSION}"
+
+
+def _with_fresh_bridge_dir(fn):
+    """Point pc._BRIDGE_DIR at a fresh temp dir for the test, then restore it."""
+
+    def wrapper():
+        orig = pc._BRIDGE_DIR
+        pc._BRIDGE_DIR = pathlib.Path(tempfile.mkdtemp(prefix="cognee-bridge-codex-test-"))
+        try:
+            fn(pc._BRIDGE_DIR)
+        finally:
+            pc._BRIDGE_DIR = orig
+
+    wrapper.__name__ = fn.__name__
+    wrapper.__doc__ = fn.__doc__
+    return wrapper
+
+
+def _write_bridge(tmp: pathlib.Path, cache, name: str = "scope.json") -> None:
+    (tmp / name).write_text(json.dumps(cache), encoding="utf-8")
+
+
+def _digest(session_cache: dict, kind: str) -> str:
+    qa_doc, trace_doc = pc._format_bridge_docs(session_cache, SESSION)
+    document = qa_doc if kind == "qa" else trace_doc
+    return hashlib.sha256(document.encode("utf-8")).hexdigest()
+
+
+def _patched_pending(value):
+    """Temporarily replace _plugin_common.pending_capture_counts; return a restorer."""
+    orig = pc.pending_capture_counts
+    pc.pending_capture_counts = value if callable(value) else (lambda session_id: value)
+
+    def _restore():
+        pc.pending_capture_counts = orig
+
+    return _restore
+
+
+@_with_fresh_bridge_dir
+def test_uncognified_entries_are_pending(tmp):
+    _write_bridge(
+        tmp,
+        {KEY: {"qa": [{"question": "q1", "answer": "a1"}], "trace": ["tool call one"]}},
+    )
+    assert pc.pending_capture_counts(SESSION) == {"qa": 1, "trace": 1}
+
+
+@_with_fresh_bridge_dir
+def test_fully_cognified_is_zero(tmp):
+    session_cache = {"qa": [{"question": "q1", "answer": "a1"}], "trace": ["tool call one"]}
+    _write_bridge(
+        tmp,
+        {
+            KEY: session_cache,
+            "_state": {
+                f"{KEY}:qa": _digest(session_cache, "qa"),
+                f"{KEY}:trace": _digest(session_cache, "trace"),
+            },
+        },
+    )
+    assert pc.pending_capture_counts(SESSION) == {"qa": 0, "trace": 0}
+
+
+@_with_fresh_bridge_dir
+def test_unsanitized_session_id_matches_sanitized_key(tmp):
+    # The explicit-search path may hand the reader a raw id; the write side keyed
+    # the bridge on the sanitized one. The reader must normalize so they match.
+    raw = "my project"
+    sanitized = pc._sanitize_session_key(raw)  # "my_project"
+    assert sanitized != raw
+    _write_bridge(
+        tmp,
+        {f"{DATASET}:{sanitized}": {"qa": [{"question": "q1", "answer": "a1"}], "trace": []}},
+    )
+    assert pc.pending_capture_counts(raw) == {"qa": 1, "trace": 0}
+
+
+@_with_fresh_bridge_dir
+def test_suffix_match_is_colon_anchored(tmp):
+    _write_bridge(
+        tmp,
+        {f"{DATASET}:xcodex_abc123": {"qa": [{"question": "q", "answer": "a"}], "trace": []}},
+    )
+    assert pc.pending_capture_counts(SESSION) == {"qa": 0, "trace": 0}
+
+
+@_with_fresh_bridge_dir
+def test_corrupted_bridge_file_is_zero_and_does_not_raise(tmp):
+    (tmp / "scope.json").write_text("not json{", encoding="utf-8")
+    assert pc.pending_capture_counts(SESSION) == {"qa": 0, "trace": 0}
+
+
+def test_annotate_empty_recall_emits_codex_hint_without_authoritative():
+    restore = _patched_pending({"qa": 2, "trace": 1})
+    try:
+        out = cc.annotate_empty_recall([], SESSION)
+    finally:
+        restore()
+    assert out["recall"] == []
+    assert out["captured_pending"] == {"qa": 2, "trace": 1}
+    assert "authoritative" not in out  # dropped: nothing consumes it
+    assert "error" not in out
+    # Codex has no /cognee-memory:cognee-sync skill; it points at the script.
+    assert "sync-session-to-graph.py" in out["hint"]
+
+
+def test_annotate_empty_recall_without_pending_stays_empty():
+    restore = _patched_pending({"qa": 0, "trace": 0})
+    try:
+        assert cc.annotate_empty_recall([], SESSION) == []
+    finally:
+        restore()
+
+
+def test_annotate_passes_through_non_empty_results():
+    def _boom(session_id):
+        raise AssertionError("pending check must not run for non-empty results")
+
+    restore = _patched_pending(_boom)
+    try:
+        hits = [{"text": "hit"}]
+        err = {"error": "boom", "status": 500, "authoritative": False}
+        assert cc.annotate_empty_recall(hits, SESSION) == hits
+        assert cc.annotate_empty_recall(err, SESSION) == err
+        assert cc.annotate_empty_recall(UNREACHABLE, SESSION) == UNREACHABLE
+    finally:
+        restore()
+
+
+def test_annotate_never_raises_when_pending_check_fails():
+    def _boom(session_id):
+        raise OSError("disk on fire")
+
+    restore = _patched_pending(_boom)
+    try:
+        assert cc.annotate_empty_recall([], SESSION) == []
+    finally:
+        restore()
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
Reworks #204 · addresses topoteretes/cognee#3553 · SDK-299

## What this does

Recall is server-first, so a 2xx empty list is authoritative — "nothing was ever stored" and "captured this session but cognify has not finished" are byte-identical `[]` (a bare `[]` on the explicit search path, `(no memory matches for this prompt)` on the per-prompt hook). The agent then silently falls back to transcript grep even though the content is already captured and on its way into the graph. This surfaces a distinct "captured, not yet cognified" signal on both recall surfaces so the agent retries (or runs the sync) instead.

No new server endpoint — the signal already exists locally. In API mode every turn is mirrored into a per-session bridge file; the drain marks each qa/trace document cognified by storing its sha256 digest under `_state` only after the cognify pipeline completes. A kind whose current digest is absent/stale is exactly "captured, not yet queryable". `pending_capture_counts` reads that; `annotate_empty_recall` wraps the explicit-search empty into `{"recall": [], "captured_pending": {...}, "hint": ...}`; the per-prompt hook turns the same signal into a retry hint. Mirrored across `claude-code` and `codex`.

## Provenance

Built on the community contribution in #204 by @AbdulWasih05 for the hackathon issue. The original commit is preserved as-is (attribution retained); maintainer changes are layered on top as separate single-concern commits. Cherry-picked onto current `main`, which also drops an incidental codex `systemMessage` delta present in the PR branch only as base skew (the original commit never touched it).

## Review outcome

Reviewed against current `main` with an adversarial multi-agent pass (every finding independently verified). The core mechanism is sound and preserved: the digest scheme matches the drain exactly, and the extracted `_format_bridge_docs` keeps the reader and the drain from ever computing divergent digests. Three changes were layered on top:

1. **fix: normalize the session id in `pending_capture_counts`.** The bridge is always keyed on the *sanitized* id, but the explicit-search path (`cognee-search.sh`) can hand the reader a raw `${COGNEE_SESSION_ID}` fallback. The reader matched the bare `:{session_id}` suffix — and built the digest, which embeds the id — from that raw value, so on the degraded search path the match silently found nothing and the hint died, reintroducing the exact silent empty the issue targets. Fixed by sanitizing on entry so the reader matches the write-side convention regardless of caller. (The happy path was already fine: the server returns the sanitized id.)
2. **refactor: drop the unconsumed `authoritative` field** from the pending envelope — nothing branches on it (`cognee-search.sh` prints the JSON verbatim; docs/agents key off `captured_pending`) and the documented SKILL.md shape already omits it.
3. **test: add a codex mirror** of the capture tests (the original shipped tests for `claude-code` only), plus `claude-code` cases pinning the sanitization fix and the colon-anchored suffix-collision safety.

## Verification (local)

- `claude-code`: `test_pending_capture.py` (13) and `test_cognee_client.py` (12) pass standalone. `codex`: `test_pending_capture.py` (9) pass. The rest of both suites are green except two failures that pre-exist on `main` and are untouched here (`test_bridge_poll.py`, `test_improve_sync.py` — test doubles predate the `context=` `urlopen` kwarg).
- End-to-end through the real `_cognee_client.py` entrypoint against a stub server returning `[]`, on the degraded fallback path (raw `"my project"` id, no `COGNEE_SESSION_KEY`), for both plugins: pending captures → the envelope; fully cognified → bare `[]`; nothing captured → bare `[]`. "Nothing stored" and "stored, not yet queryable" are distinguishable.
- `ruff check` and `ruff format --check` clean on all changed files (line-length 100).

## Known limitations (deliberately out of scope)

- The bridge-dir scan grows O(session files) with no pruning subsystem (files are tiny, best-effort); pruning belongs in a separate hygiene change.
- On older servers/proxies lacking the cognify status route, the drain marks digests optimistically on an `unknown` outcome, so pending can under-report during that narrow lag window.

Both predate this feature and live in the drain, not the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
