### PR TITLE
feat(claude-code,codex): per-scope recall timing + hit counts on context-lookup events (SDK-300)

### DIFF
--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -223,6 +223,15 @@ async def _run(prompt: str) -> dict | None:
 
         user = await resolve_user(_load_user_id())
 
+    # Per-scope instrumentation (WS7 observability): capture {hits, elapsed_ms}
+    # for every scope — including scopes that error or are skipped by the budget
+    # — keyed by a stable, human-readable label derived from scope_specs. Purely
+    # additive: it must not touch recall results, ordering, or control flow, and
+    # must never raise into the keystroke->answer path. Captured before the
+    # breaker-open branch below can blank scope_specs, so all 5 labels survive.
+    scope_labels = [spec[0][0] for spec in scope_specs]
+    per_scope: dict[str, dict] = {}
+
     # Hard time-box: this hook is on the keystroke->answer path, so recall must
     # never be the long pole. Each scope gets a short per-call timeout, and the
     # whole loop stops once the overall budget is spent. Partial results are fine.
@@ -242,9 +251,12 @@ async def _run(prompt: str) -> dict | None:
             hook_log("recall_breaker_open", {"retry_in": _bretry})
             scope_specs = []
     for scope_list, qtype, context_profile in scope_specs:
+        label = scope_list[0]
         if time.monotonic() >= budget_deadline:
             hook_log("recall_budget_exceeded", {"collected": len(results)})
             break
+        part = None
+        t0 = time.monotonic()
         try:
             if cloud_mode:
                 part = recall_via_http(
@@ -276,6 +288,19 @@ async def _run(prompt: str) -> dict | None:
                 results.extend(part)
         except Exception as exc:
             hook_log("recall_error", {"scope": scope_list, "error": str(exc)[:200]})
+        finally:
+            # hits = raw count from this scope's call (pre-bucketing/filtering);
+            # elapsed_ms measured around the call, recorded even when it errored.
+            per_scope[label] = {
+                "hits": len(part or []),
+                "elapsed_ms": round((time.monotonic() - t0) * 1000, 1),
+            }
+
+    # Backfill scopes that never ran — skipped by the budget break above or by
+    # the breaker-open reset (scope_specs = []) — so the event always carries all
+    # 5 scopes in their canonical order with a 0-hit/0-ms skipped marker.
+    for label in scope_labels:
+        per_scope.setdefault(label, {"hits": 0, "elapsed_ms": 0, "skipped": True})
 
     # Bucket results by _source for human-readable output.
     # Local SDK mode returns Pydantic models (ResponseQAEntry, etc.); cloud
@@ -329,6 +354,7 @@ async def _run(prompt: str) -> dict | None:
                     .datetime.now(__import__("datetime").timezone.utc)
                     .isoformat(timespec="seconds"),
                     "hits": counts,
+                    "per_scope": per_scope,
                     "saves_last_turn": saves_last_turn,
                 }
             ),
@@ -375,11 +401,17 @@ async def _run(prompt: str) -> dict | None:
             f"{header}\n\nRelevant context from this session's memory:\n\n"
             + "\n".join(section_lines).strip()
         )
-        hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
+        hook_log(
+            "context_lookup_hit",
+            {"counts": counts, "per_scope": per_scope, "saves_last_turn": saves_last_turn},
+        )
         notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
     else:
         full_context = f"{header}\n\n(no memory matches for this prompt)"
-        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
+        hook_log(
+            "context_lookup_empty",
+            {"per_scope": per_scope, "saves_last_turn": saves_last_turn},
+        )
         notify(f"no recall matches; saves last turn {saves_last_turn}")
 
     # Audit log: persist full recall details per turn. The hook output stays a
@@ -399,6 +431,7 @@ async def _run(prompt: str) -> dict | None:
                         "session_id": session_id,
                         "prompt": prompt,
                         "hits": counts,
+                        "per_scope": per_scope,
                         "context": full_context,
                     }
                 )

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -224,13 +224,16 @@ async def _run(prompt: str) -> dict | None:
         user = await resolve_user(_load_user_id())
 
     # Per-scope instrumentation (WS7 observability): capture {hits, elapsed_ms}
-    # for every scope — including scopes that error or are skipped by the budget
-    # — keyed by a stable, human-readable label derived from scope_specs. Purely
-    # additive: it must not touch recall results, ordering, or control flow, and
-    # must never raise into the keystroke->answer path. Captured before the
-    # breaker-open branch below can blank scope_specs, so all 5 labels survive.
-    scope_labels = [spec[0][0] for spec in scope_specs]
-    per_scope: dict[str, dict] = {}
+    # for every scope, keyed by its stable label. Pre-seed all 5 scopes as
+    # skipped, in canonical order and before the breaker-open branch below can
+    # blank scope_specs, so the event always carries the full set; the loop
+    # overwrites each scope that actually runs. Purely additive: it must not
+    # touch recall results, ordering, or control flow, and must never raise into
+    # the keystroke->answer path.
+    per_scope: dict[str, dict] = {
+        scope_list[0]: {"hits": 0, "elapsed_ms": 0, "skipped": True}
+        for scope_list, _qtype, _profile in scope_specs
+    }
 
     # Hard time-box: this hook is on the keystroke->answer path, so recall must
     # never be the long pole. Each scope gets a short per-call timeout, and the
@@ -251,7 +254,6 @@ async def _run(prompt: str) -> dict | None:
             hook_log("recall_breaker_open", {"retry_in": _bretry})
             scope_specs = []
     for scope_list, qtype, context_profile in scope_specs:
-        label = scope_list[0]
         if time.monotonic() >= budget_deadline:
             hook_log("recall_budget_exceeded", {"collected": len(results)})
             break
@@ -291,16 +293,10 @@ async def _run(prompt: str) -> dict | None:
         finally:
             # hits = raw count from this scope's call (pre-bucketing/filtering);
             # elapsed_ms measured around the call, recorded even when it errored.
-            per_scope[label] = {
+            per_scope[scope_list[0]] = {
                 "hits": len(part or []),
                 "elapsed_ms": round((time.monotonic() - t0) * 1000, 1),
             }
-
-    # Backfill scopes that never ran — skipped by the budget break above or by
-    # the breaker-open reset (scope_specs = []) — so the event always carries all
-    # 5 scopes in their canonical order with a 0-hit/0-ms skipped marker.
-    for label in scope_labels:
-        per_scope.setdefault(label, {"hits": 0, "elapsed_ms": 0, "skipped": True})
 
     # Bucket results by _source for human-readable output.
     # Local SDK mode returns Pydantic models (ResponseQAEntry, etc.); cloud

--- a/integrations/claude-code/tests/test_per_scope_timing.py
+++ b/integrations/claude-code/tests/test_per_scope_timing.py
@@ -1,0 +1,168 @@
+"""Unit tests for per-scope recall instrumentation (session-context-lookup.py).
+
+Recall fans out over 5 scopes (session/trace/graph_context/graph/session_context).
+This test drives the hook's ``_run`` in cloud mode with a fake ``recall_via_http``
+and asserts the emitted recall event carries a per-scope ``{hits, elapsed_ms}``
+breakdown for all 5 scopes — including scopes that return nothing — without
+changing the existing aggregate ``counts``.
+
+Run: `pytest integrations/claude-code/tests/test_per_scope_timing.py -v`
+(or `python integrations/claude-code/tests/test_per_scope_timing.py` standalone).
+"""
+
+import asyncio
+import importlib.util
+import os
+import pathlib
+import sys
+import types
+
+# Pin the loop-guard so importing the plugin never re-execs into its venv.
+os.environ.setdefault("COGNEE_PLUGIN_IN_VENV", "1")
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+# The circuit breaker is imported lazily inside _run (cloud mode). Inject a
+# fake so the test is deterministic regardless of any on-disk breaker state.
+_fake_client = types.ModuleType("_cognee_client")
+_fake_client.breaker_open = lambda: (False, 0)
+sys.modules["_cognee_client"] = _fake_client
+
+
+def _load_hook_module():
+    """Import the hyphenated hook script under a clean module name."""
+    path = SCRIPTS / "session-context-lookup.py"
+    spec = importlib.util.spec_from_file_location("session_context_lookup", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+SCOPES = ["session", "trace", "graph_context", "graph", "session_context"]
+
+
+def _run_with_recall(mod, monkeypatch, tmp_home, recall_map):
+    """Drive _run in cloud mode with a fake recall, returning captured events."""
+    events: list[tuple[str, dict]] = []
+
+    def _fake_recall(prompt, **kwargs):
+        return list(recall_map.get(kwargs["scope"][0], []))
+
+    monkeypatch.setattr(mod, "hook_log", lambda ev, detail=None: events.append((ev, detail or {})))
+    monkeypatch.setattr(mod, "notify", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "resolve_runtime_mode",
+                        lambda: {"mode": "http", "base_url": "https://cloud.example"})
+    monkeypatch.setattr(mod, "server_ready_hint", lambda _url: True)
+    monkeypatch.setattr(mod, "_load_session_id", lambda: "sess-123")
+    monkeypatch.setattr(mod, "read_and_reset_save_counter",
+                        lambda _sid: {"prompt": 0, "trace": 0, "answer": 0})
+    monkeypatch.setattr(mod, "recall_via_http", _fake_recall)
+    # Redirect last_recall.json / recall-audit.log writes into a tmp HOME.
+    monkeypatch.setenv("HOME", str(tmp_home))
+    monkeypatch.setenv("USERPROFILE", str(tmp_home))
+
+    output = asyncio.run(mod._run("please recall something relevant"))
+    return output, events
+
+
+def _event(events, name):
+    for ev, detail in events:
+        if ev == name:
+            return detail
+    return None
+
+
+def _assert_valid_per_scope(per_scope):
+    assert list(per_scope.keys()) == SCOPES, f"expected all 5 scopes in order, got {per_scope}"
+    for label, rec in per_scope.items():
+        assert isinstance(rec["hits"], int), f"{label} hits not int: {rec}"
+        assert isinstance(rec["elapsed_ms"], (int, float)), f"{label} elapsed not numeric: {rec}"
+        assert rec["elapsed_ms"] >= 0
+
+
+def test_per_scope_on_hit(monkeypatch, tmp_path):
+    """A hit emits context_lookup_hit carrying per-scope hits + timing."""
+    mod = _load_hook_module()
+    recall_map = {
+        "session": [{"question": "q1", "answer": "a1"}],
+        "trace": [],
+        "graph_context": [{"source": "graph_context", "content": "ctx"}],
+        "graph": [{"source": "graph", "content": "gg"}],
+        "session_context": [],
+    }
+    _out, events = _run_with_recall(mod, monkeypatch, tmp_path, recall_map)
+
+    detail = _event(events, "context_lookup_hit")
+    assert detail is not None, "expected a context_lookup_hit event"
+    assert "counts" in detail, "existing aggregate counts must be preserved"
+    per_scope = detail["per_scope"]
+    _assert_valid_per_scope(per_scope)
+    # Raw per-scope hit attribution (pre-bucketing): graph is NOT folded here.
+    assert per_scope["session"]["hits"] == 1
+    assert per_scope["trace"]["hits"] == 0
+    assert per_scope["graph_context"]["hits"] == 1
+    assert per_scope["graph"]["hits"] == 1
+    assert per_scope["session_context"]["hits"] == 0
+
+
+def test_per_scope_on_empty(monkeypatch, tmp_path):
+    """A total miss still emits per-scope timing for all 5 scopes."""
+    mod = _load_hook_module()
+    recall_map = {s: [] for s in SCOPES}
+    _out, events = _run_with_recall(mod, monkeypatch, tmp_path, recall_map)
+
+    detail = _event(events, "context_lookup_empty")
+    assert detail is not None, "expected a context_lookup_empty event"
+    per_scope = detail["per_scope"]
+    _assert_valid_per_scope(per_scope)
+    assert all(rec["hits"] == 0 for rec in per_scope.values())
+
+
+def _run_all():
+    """Standalone runner (no pytest) using a minimal monkeypatch shim."""
+    class _MP:
+        def __init__(self):
+            self._undo = []
+
+        def setattr(self, obj, name, val):
+            self._undo.append((obj, name, getattr(obj, name)))
+            setattr(obj, name, val)
+
+        def setenv(self, name, val):
+            self._undo.append((os.environ, name, os.environ.get(name)))
+            os.environ[name] = val
+
+        def undo(self):
+            for obj, name, old in reversed(self._undo):
+                if obj is os.environ:
+                    if old is None:
+                        os.environ.pop(name, None)
+                    else:
+                        os.environ[name] = old
+                else:
+                    setattr(obj, name, old)
+
+    import tempfile
+
+    green, red, bold, reset = "\033[32m", "\033[31m", "\033[1m", "\033[0m"
+    failures = 0
+    for test in (test_per_scope_on_hit, test_per_scope_on_empty):
+        mp = _MP()
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                test(mp, pathlib.Path(td))
+            print(f"{green}PASS{reset}  {test.__name__}")
+        except AssertionError as exc:
+            failures += 1
+            print(f"{red}FAIL{reset}  {test.__name__}: {exc}")
+        finally:
+            mp.undo()
+    if failures:
+        print(f"{red}{bold}{failures} FAILED{reset}")
+        sys.exit(1)
+    print(f"{green}{bold}2 passed{reset}")
+
+
+if __name__ == "__main__":
+    _run_all()

--- a/integrations/claude-code/tests/test_per_scope_timing.py
+++ b/integrations/claude-code/tests/test_per_scope_timing.py
@@ -1,13 +1,12 @@
 """Unit tests for per-scope recall instrumentation (session-context-lookup.py).
 
 Recall fans out over 5 scopes (session/trace/graph_context/graph/session_context).
-This test drives the hook's ``_run`` in cloud mode with a fake ``recall_via_http``
-and asserts the emitted recall event carries a per-scope ``{hits, elapsed_ms}``
-breakdown for all 5 scopes — including scopes that return nothing — without
-changing the existing aggregate ``counts``.
+These tests drive the hook's ``_run`` in cloud mode with a fake ``recall_via_http``
+and assert the emitted recall event carries a per-scope ``{hits, elapsed_ms}``
+breakdown for all 5 scopes — including scopes that return nothing or never run —
+without changing the existing aggregate ``counts``.
 
-Run: `pytest integrations/claude-code/tests/test_per_scope_timing.py -v`
-(or `python integrations/claude-code/tests/test_per_scope_timing.py` standalone).
+Run: python integrations/claude-code/tests/test_per_scope_timing.py (or via pytest).
 """
 
 import asyncio
@@ -15,6 +14,7 @@ import importlib.util
 import os
 import pathlib
 import sys
+import tempfile
 import types
 
 # Pin the loop-guard so importing the plugin never re-execs into its venv.
@@ -23,11 +23,7 @@ os.environ.setdefault("COGNEE_PLUGIN_IN_VENV", "1")
 SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
-# The circuit breaker is imported lazily inside _run (cloud mode). Inject a
-# fake so the test is deterministic regardless of any on-disk breaker state.
-_fake_client = types.ModuleType("_cognee_client")
-_fake_client.breaker_open = lambda: (False, 0)
-sys.modules["_cognee_client"] = _fake_client
+SCOPES = ["session", "trace", "graph_context", "graph", "session_context"]
 
 
 def _load_hook_module():
@@ -39,30 +35,48 @@ def _load_hook_module():
     return mod
 
 
-SCOPES = ["session", "trace", "graph_context", "graph", "session_context"]
+def _drive_run(recall_map, *, breaker=(False, 0)):
+    """Drive _run in cloud mode with a fake recall; return (output, events).
 
+    Stubs the module's I/O helpers on a freshly imported hook module, injects a
+    fake _cognee_client breaker, and points last_recall.json / recall-audit.log
+    writes at a throwaway HOME. Global state (sys.modules, os.environ) is
+    restored so the suite stays order-independent under pytest.
+    """
+    mod = _load_hook_module()
+    events = []
 
-def _run_with_recall(mod, monkeypatch, tmp_home, recall_map):
-    """Drive _run in cloud mode with a fake recall, returning captured events."""
-    events: list[tuple[str, dict]] = []
+    mod.hook_log = lambda ev, detail=None: events.append((ev, detail or {}))
+    mod.notify = lambda *a, **k: None
+    mod.resolve_runtime_mode = lambda: {"mode": "http", "base_url": "https://cloud.example"}
+    mod.server_ready_hint = lambda _url: True
+    mod._load_session_id = lambda: "sess-123"
+    mod.read_and_reset_save_counter = lambda _sid: {"prompt": 0, "trace": 0, "answer": 0}
+    mod.recall_via_http = lambda prompt, **kw: list(recall_map.get(kw["scope"][0], []))
 
-    def _fake_recall(prompt, **kwargs):
-        return list(recall_map.get(kwargs["scope"][0], []))
+    # The breaker is imported lazily inside _run (cloud mode); inject a fake so
+    # the test is deterministic regardless of any on-disk breaker state.
+    fake_client = types.ModuleType("_cognee_client")
+    fake_client.breaker_open = lambda: breaker
+    saved_client = sys.modules.get("_cognee_client")
+    sys.modules["_cognee_client"] = fake_client
 
-    monkeypatch.setattr(mod, "hook_log", lambda ev, detail=None: events.append((ev, detail or {})))
-    monkeypatch.setattr(mod, "notify", lambda *a, **k: None)
-    monkeypatch.setattr(mod, "resolve_runtime_mode",
-                        lambda: {"mode": "http", "base_url": "https://cloud.example"})
-    monkeypatch.setattr(mod, "server_ready_hint", lambda _url: True)
-    monkeypatch.setattr(mod, "_load_session_id", lambda: "sess-123")
-    monkeypatch.setattr(mod, "read_and_reset_save_counter",
-                        lambda _sid: {"prompt": 0, "trace": 0, "answer": 0})
-    monkeypatch.setattr(mod, "recall_via_http", _fake_recall)
-    # Redirect last_recall.json / recall-audit.log writes into a tmp HOME.
-    monkeypatch.setenv("HOME", str(tmp_home))
-    monkeypatch.setenv("USERPROFILE", str(tmp_home))
-
-    output = asyncio.run(mod._run("please recall something relevant"))
+    saved_env = {k: os.environ.get(k) for k in ("HOME", "USERPROFILE")}
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        os.environ["USERPROFILE"] = home
+        try:
+            output = asyncio.run(mod._run("please recall something relevant"))
+        finally:
+            for k, v in saved_env.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+            if saved_client is None:
+                sys.modules.pop("_cognee_client", None)
+            else:
+                sys.modules["_cognee_client"] = saved_client
     return output, events
 
 
@@ -81,9 +95,8 @@ def _assert_valid_per_scope(per_scope):
         assert rec["elapsed_ms"] >= 0
 
 
-def test_per_scope_on_hit(monkeypatch, tmp_path):
+def test_per_scope_on_hit():
     """A hit emits context_lookup_hit carrying per-scope hits + timing."""
-    mod = _load_hook_module()
     recall_map = {
         "session": [{"question": "q1", "answer": "a1"}],
         "trace": [],
@@ -91,7 +104,7 @@ def test_per_scope_on_hit(monkeypatch, tmp_path):
         "graph": [{"source": "graph", "content": "gg"}],
         "session_context": [],
     }
-    _out, events = _run_with_recall(mod, monkeypatch, tmp_path, recall_map)
+    _out, events = _drive_run(recall_map)
 
     detail = _event(events, "context_lookup_hit")
     assert detail is not None, "expected a context_lookup_hit event"
@@ -106,63 +119,39 @@ def test_per_scope_on_hit(monkeypatch, tmp_path):
     assert per_scope["session_context"]["hits"] == 0
 
 
-def test_per_scope_on_empty(monkeypatch, tmp_path):
-    """A total miss still emits per-scope timing for all 5 scopes."""
-    mod = _load_hook_module()
-    recall_map = {s: [] for s in SCOPES}
-    _out, events = _run_with_recall(mod, monkeypatch, tmp_path, recall_map)
+def test_per_scope_on_empty():
+    """A total miss still emits per-scope timing for all 5 scopes (all ran)."""
+    _out, events = _drive_run({s: [] for s in SCOPES})
 
     detail = _event(events, "context_lookup_empty")
     assert detail is not None, "expected a context_lookup_empty event"
     per_scope = detail["per_scope"]
     _assert_valid_per_scope(per_scope)
     assert all(rec["hits"] == 0 for rec in per_scope.values())
+    # Every scope ran, so none carries the skipped marker.
+    assert not any(rec.get("skipped") for rec in per_scope.values())
 
 
-def _run_all():
-    """Standalone runner (no pytest) using a minimal monkeypatch shim."""
-    class _MP:
-        def __init__(self):
-            self._undo = []
+def test_all_scopes_skipped_when_breaker_open():
+    """Breaker-open runs no scope, yet all 5 are still reported as skipped."""
+    _out, events = _drive_run({s: [] for s in SCOPES}, breaker=(True, 30))
 
-        def setattr(self, obj, name, val):
-            self._undo.append((obj, name, getattr(obj, name)))
-            setattr(obj, name, val)
-
-        def setenv(self, name, val):
-            self._undo.append((os.environ, name, os.environ.get(name)))
-            os.environ[name] = val
-
-        def undo(self):
-            for obj, name, old in reversed(self._undo):
-                if obj is os.environ:
-                    if old is None:
-                        os.environ.pop(name, None)
-                    else:
-                        os.environ[name] = old
-                else:
-                    setattr(obj, name, old)
-
-    import tempfile
-
-    green, red, bold, reset = "\033[32m", "\033[31m", "\033[1m", "\033[0m"
-    failures = 0
-    for test in (test_per_scope_on_hit, test_per_scope_on_empty):
-        mp = _MP()
-        try:
-            with tempfile.TemporaryDirectory() as td:
-                test(mp, pathlib.Path(td))
-            print(f"{green}PASS{reset}  {test.__name__}")
-        except AssertionError as exc:
-            failures += 1
-            print(f"{red}FAIL{reset}  {test.__name__}: {exc}")
-        finally:
-            mp.undo()
-    if failures:
-        print(f"{red}{bold}{failures} FAILED{reset}")
-        sys.exit(1)
-    print(f"{green}{bold}2 passed{reset}")
+    detail = _event(events, "context_lookup_empty")
+    assert detail is not None, "expected a context_lookup_empty event"
+    per_scope = detail["per_scope"]
+    _assert_valid_per_scope(per_scope)
+    assert all(rec.get("skipped") for rec in per_scope.values())
+    assert all(rec["hits"] == 0 and rec["elapsed_ms"] == 0 for rec in per_scope.values())
 
 
 if __name__ == "__main__":
-    _run_all()
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -214,13 +214,16 @@ async def _run(prompt: str) -> dict | None:
         user = await resolve_user(_load_user_id())
 
     # Per-scope instrumentation (WS7 observability): capture {hits, elapsed_ms}
-    # for every scope — including scopes that error or are skipped by the budget
-    # — keyed by a stable, human-readable label derived from scope_specs. Purely
-    # additive: it must not touch recall results, ordering, or control flow, and
-    # must never raise into the keystroke->answer path. Captured before the
-    # breaker-open branch below can blank scope_specs, so all 5 labels survive.
-    scope_labels = [spec[0][0] for spec in scope_specs]
-    per_scope: dict[str, dict] = {}
+    # for every scope, keyed by its stable label. Pre-seed all 5 scopes as
+    # skipped, in canonical order and before the breaker-open branch below can
+    # blank scope_specs, so the event always carries the full set; the loop
+    # overwrites each scope that actually runs. Purely additive: it must not
+    # touch recall results, ordering, or control flow, and must never raise into
+    # the keystroke->answer path.
+    per_scope: dict[str, dict] = {
+        scope_list[0]: {"hits": 0, "elapsed_ms": 0, "skipped": True}
+        for scope_list, _qtype, _profile in scope_specs
+    }
 
     # Hard time-box: this hook is on the keystroke->answer path, so recall must
     # never be the long pole. Each scope gets a short per-call timeout, and the
@@ -241,7 +244,6 @@ async def _run(prompt: str) -> dict | None:
             hook_log("recall_breaker_open", {"retry_in": _bretry})
             scope_specs = []
     for scope_list, qtype, context_profile in scope_specs:
-        label = scope_list[0]
         if time.monotonic() >= budget_deadline:
             hook_log("recall_budget_exceeded", {"collected": len(results)})
             break
@@ -281,16 +283,10 @@ async def _run(prompt: str) -> dict | None:
         finally:
             # hits = raw count from this scope's call (pre-bucketing/filtering);
             # elapsed_ms measured around the call, recorded even when it errored.
-            per_scope[label] = {
+            per_scope[scope_list[0]] = {
                 "hits": len(part or []),
                 "elapsed_ms": round((time.monotonic() - t0) * 1000, 1),
             }
-
-    # Backfill scopes that never ran — skipped by the budget break above or by
-    # the breaker-open reset (scope_specs = []) — so the event always carries all
-    # 5 scopes in their canonical order with a 0-hit/0-ms skipped marker.
-    for label in scope_labels:
-        per_scope.setdefault(label, {"hits": 0, "elapsed_ms": 0, "skipped": True})
 
     # Bucket results by _source for human-readable output.
     # Local SDK mode returns Pydantic models (ResponseQAEntry, etc.); cloud

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -213,6 +213,15 @@ async def _run(prompt: str) -> dict | None:
 
         user = await resolve_user(_load_user_id())
 
+    # Per-scope instrumentation (WS7 observability): capture {hits, elapsed_ms}
+    # for every scope — including scopes that error or are skipped by the budget
+    # — keyed by a stable, human-readable label derived from scope_specs. Purely
+    # additive: it must not touch recall results, ordering, or control flow, and
+    # must never raise into the keystroke->answer path. Captured before the
+    # breaker-open branch below can blank scope_specs, so all 5 labels survive.
+    scope_labels = [spec[0][0] for spec in scope_specs]
+    per_scope: dict[str, dict] = {}
+
     # Hard time-box: this hook is on the keystroke->answer path, so recall must
     # never be the long pole. Each scope gets a short per-call timeout, and the
     # whole loop stops once the overall budget is spent. Partial results are fine.
@@ -232,9 +241,12 @@ async def _run(prompt: str) -> dict | None:
             hook_log("recall_breaker_open", {"retry_in": _bretry})
             scope_specs = []
     for scope_list, qtype, context_profile in scope_specs:
+        label = scope_list[0]
         if time.monotonic() >= budget_deadline:
             hook_log("recall_budget_exceeded", {"collected": len(results)})
             break
+        part = None
+        t0 = time.monotonic()
         try:
             if cloud_mode:
                 part = recall_via_http(
@@ -266,6 +278,19 @@ async def _run(prompt: str) -> dict | None:
                 results.extend(part)
         except Exception as exc:
             hook_log("recall_error", {"scope": scope_list, "error": str(exc)[:200]})
+        finally:
+            # hits = raw count from this scope's call (pre-bucketing/filtering);
+            # elapsed_ms measured around the call, recorded even when it errored.
+            per_scope[label] = {
+                "hits": len(part or []),
+                "elapsed_ms": round((time.monotonic() - t0) * 1000, 1),
+            }
+
+    # Backfill scopes that never ran — skipped by the budget break above or by
+    # the breaker-open reset (scope_specs = []) — so the event always carries all
+    # 5 scopes in their canonical order with a 0-hit/0-ms skipped marker.
+    for label in scope_labels:
+        per_scope.setdefault(label, {"hits": 0, "elapsed_ms": 0, "skipped": True})
 
     # Bucket results by _source for human-readable output.
     # Local SDK mode returns Pydantic models (ResponseQAEntry, etc.); cloud
@@ -319,6 +344,7 @@ async def _run(prompt: str) -> dict | None:
                     .datetime.now(__import__("datetime").timezone.utc)
                     .isoformat(timespec="seconds"),
                     "hits": counts,
+                    "per_scope": per_scope,
                     "saves_last_turn": saves_last_turn,
                 }
             ),
@@ -367,11 +393,17 @@ async def _run(prompt: str) -> dict | None:
             f"{header}\n\nRelevant context from this session's memory:\n\n"
             + "\n".join(section_lines).strip()
         )
-        hook_log("context_lookup_hit", {"counts": counts, "saves_last_turn": saves_last_turn})
+        hook_log(
+            "context_lookup_hit",
+            {"counts": counts, "per_scope": per_scope, "saves_last_turn": saves_last_turn},
+        )
         notify(f"injected context ({counts}); saves last turn {saves_last_turn}")
     else:
         full_context = f"{header}\n\n(no memory matches for this prompt)"
-        hook_log("context_lookup_empty", {"saves_last_turn": saves_last_turn})
+        hook_log(
+            "context_lookup_empty",
+            {"per_scope": per_scope, "saves_last_turn": saves_last_turn},
+        )
         notify(f"no recall matches; saves last turn {saves_last_turn}")
 
     # Audit log: persist full recall details per turn for debugging.
@@ -390,6 +422,7 @@ async def _run(prompt: str) -> dict | None:
                         "session_id": session_id,
                         "prompt": prompt,
                         "hits": counts,
+                        "per_scope": per_scope,
                         "context": full_context,
                     }
                 )


### PR DESCRIPTION
Reworks community hackathon PR #191 (by @rahulm820) for topoteretes/cognee#3684 — adds per-scope `{hits, elapsed_ms}` telemetry to the recall path so we can tell which of the 5 recall scopes is slow and which is contributing hits. The contributor's original commit is preserved here with attribution.

Closes topoteretes/cognee#3684.

## What changed

Recall fans out over 5 scopes (`session`, `trace`, `graph_context`, `graph`, `session_context`) but the emitted events only recorded aggregate hit counts bucketed by result `_source` — `graph` folded into the `graph_context` bucket, and no timing was captured at all. The per-scope loop in `session-context-lookup.py` (claude-code + codex twin) now builds an ordered `per_scope: {label: {hits, elapsed_ms}}` map covering all 5 scopes and attaches it, alongside the existing `counts`, to `context_lookup_hit`, `context_lookup_empty`, `last_recall.json`, and `recall-audit.log`.

Purely additive — recall results, ordering, bucketing, output payload, per-call timeouts, and the budget short-circuit are untouched. `hits` is the raw pre-bucketing call count (so `graph` is attributed distinctly rather than folded), timing is measured in a `try/finally` so it survives an erroring scope, and scopes skipped by the budget deadline or an open circuit breaker are still reported as `{hits: 0, elapsed_ms: 0, skipped: true}` so every event carries all 5 scopes.

Example payload:

```json
{
  "per_scope": {
    "session":         { "hits": 1, "elapsed_ms": 12.4 },
    "trace":           { "hits": 0, "elapsed_ms": 3.1 },
    "graph_context":   { "hits": 1, "elapsed_ms": 8.7 },
    "graph":           { "hits": 1, "elapsed_ms": 5.2 },
    "session_context": { "hits": 0, "elapsed_ms": 0, "skipped": true }
  },
  "counts": { "session": 1, "trace": 0, "graph_context": 2, "session_context": 0 }
}
```

## Commits

- `feat(observability)` — the contributor's original commit (@rahulm820), preserved verbatim.
- `refactor(observability)` — collapse the `scope_labels` snapshot + in-loop label + post-loop `setdefault` backfill into one pre-seeded dict the loop overwrites. Identical emitted output (keys, canonical order, values, `skipped` marker), fewer moving parts; verified equivalent across all paths (all-run, budget break, breaker-open, scope raises). Applied identically to both twins.
- `test(observability)` — align the test with the sibling plugin-test convention (fixture-free functions, direct save/restore stubbing, `globals()`-iterating `__main__` runner), dropping the pytest `monkeypatch`/`tmp_path` fixtures and the hand-rolled `_MP` shim they required. Add a breaker-open case covering the previously-untested skip path, and make the file `ruff format`-clean — the PR was failing the `lint.yml` gate.

## Verification

- `python3 integrations/claude-code/tests/test_per_scope_timing.py` → 3 passed (hit / empty / breaker-open-skipped); also green under `pytest`.
- `ruff check` + `ruff format --check` clean on all three changed files (line-length = 100).
- The claude-code and codex `per_scope` changes are byte-identical.

Note: these plugin-tree integrations have no `pyproject.toml`, so CI's `test-python` matrix skips them — the tests run manually via `python3 tests/test_*.py`; the sole automated gate is `lint.yml` (ruff), now green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
