### PR TITLE
feat(claude-code,codex): local offline usage-metrics command (SDK-302)

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -239,6 +239,19 @@ Shared state (used by both Claude Code and Codex plugins):
 ~/.cognee-plugin/venv/            # shared Cognee virtualenv
 ```
 
+## Usage metrics
+
+For an offline usage rollup compiled purely from the local files above — no
+network, no `cognee` import — run:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/cognee-plugin" metrics          # readable rollup
+"${CLAUDE_PLUGIN_ROOT}/scripts/cognee-plugin" metrics --json   # JSON
+```
+
+It reports sessions, recalls and hit-rate, saves (prompt/trace/answer), the
+local-vs-cloud mode split, and how often an open recall breaker skipped recall.
+
 ## Updating
 
 The plugin is versioned with [semver](https://semver.org/) — see

--- a/integrations/claude-code/scripts/cognee-plugin
+++ b/integrations/claude-code/scripts/cognee-plugin
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+# Add script directory to Python path to import cognee_plugin
+sys.path.insert(0, str(Path(__file__).parent))
+
+import cognee_plugin
+
+if __name__ == "__main__":
+    sys.exit(cognee_plugin.main())

--- a/integrations/claude-code/scripts/cognee_plugin.py
+++ b/integrations/claude-code/scripts/cognee_plugin.py
@@ -1,13 +1,14 @@
-"""cognee-plugin — CLI utility for the cognee Claude-Code / Codex plugin.
+"""cognee-plugin - offline usage-metrics CLI for the cognee Claude Code plugin.
 
 Usage:
-    cognee-plugin metrics [--json] [--plugin <claude-code|codex>]
+    cognee-plugin metrics [--json]
 
-Computes usage rollup purely from local files — no network required:
-    ~/.cognee-plugin/<plugin>/hook.log
-    ~/.cognee-plugin/<plugin>/save_counter.json
-    ~/.cognee-plugin/<plugin>/last_recall.json
-    ~/.cognee-plugin/<plugin>/recall-audit.log
+Computes a usage rollup purely from this plugin's local state files - no
+network, no import of the cognee package:
+    ~/.cognee-plugin/claude-code/hook.log
+    ~/.cognee-plugin/claude-code/save_counter.json
+    ~/.cognee-plugin/claude-code/last_recall.json
+    ~/.cognee-plugin/claude-code/recall-audit.log
 """
 
 from __future__ import annotations
@@ -17,10 +18,15 @@ import json
 import sys
 from pathlib import Path
 
+# State this plugin's hooks write (mirrors _plugin_common._PLUGIN_DIR). The
+# codex copy of this file points at ".../codex"; each copy reads its own dir.
+_PLUGIN_DIR = Path.home() / ".cognee-plugin" / "claude-code"
+
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _parse_jsonl(path: Path) -> list:
     """Read a JSON-Lines file; skip malformed lines silently."""
@@ -59,31 +65,32 @@ def _read_json_file(path: Path) -> dict:
 # Metric computation
 # ---------------------------------------------------------------------------
 
+
 def _compute_metrics(plugin_dir: Path) -> dict:
-    hook_log_path     = plugin_dir / "hook.log"
+    hook_log_path = plugin_dir / "hook.log"
     save_counter_path = plugin_dir / "save_counter.json"
-    last_recall_path  = plugin_dir / "last_recall.json"
+    last_recall_path = plugin_dir / "last_recall.json"
     recall_audit_path = plugin_dir / "recall-audit.log"
 
     # -----------------------------------------------------------------------
-    # 1. hook.log — sessions, mode split, breaker trips, save events
+    # 1. hook.log - sessions, mode split, breaker events, save events
     # -----------------------------------------------------------------------
     hook_lines = _parse_jsonl(hook_log_path)
 
     unique_sessions: set = set()
     local_decisions = 0
     cloud_decisions = 0
-    breaker_trips = 0
+    breaker_open_events = 0
     saves_from_log = {"prompt": 0, "trace": 0, "answer": 0}
 
     for line in hook_lines:
         ev = line.get("event", "")
         detail = line.get("detail") or {}
 
-        # Collect session ids from any log line
+        # Some diagnostic events carry a session id in their detail payload.
         for key in ("session_id", "session"):
-            sid = detail.get(key) or line.get(key)
-            if sid and isinstance(sid, str):
+            sid = detail.get(key)
+            if isinstance(sid, str) and sid:
                 unique_sessions.add(sid)
 
         # Mode decisions. resolve_runtime_mode() emits "http" (cloud) or
@@ -96,9 +103,11 @@ def _compute_metrics(plugin_dir: Path) -> dict:
             elif mode:
                 local_decisions += 1
 
-        # Breaker trips recorded via hook_log
+        # recall_breaker_open is logged once per per-prompt recall skipped while
+        # the breaker is open; the 4 local files expose no open/close transition,
+        # so this counts recalls skipped by an open breaker, not distinct trips.
         if ev == "recall_breaker_open":
-            breaker_trips += 1
+            breaker_open_events += 1
 
         # Save events recorded in hook.log. Warmup-buffered trace/answer saves
         # log "store_buffered_warming" (tagged with the originating hook) rather
@@ -116,7 +125,7 @@ def _compute_metrics(plugin_dir: Path) -> dict:
                 saves_from_log["answer"] += 1
 
     # -----------------------------------------------------------------------
-    # 2. save_counter.json — session ids only
+    # 2. save_counter.json - session ids only
     # -----------------------------------------------------------------------
     # A per-turn buffer that read_and_reset_save_counter drains on every recall;
     # each save it records is also written to hook.log, so adding it to the
@@ -129,16 +138,14 @@ def _compute_metrics(plugin_dir: Path) -> dict:
     total_saves = dict(saves_from_log)
 
     # -----------------------------------------------------------------------
-    # 3. last_recall.json — most-recent recall hit counts
+    # 3. last_recall.json - session id only
     # -----------------------------------------------------------------------
-    last_recall = _read_json_file(last_recall_path)
-    last_hits = last_recall.get("hits") or {}
-    last_recall_ts = last_recall.get("ts", "")
-    if last_recall.get("session_id"):
-        unique_sessions.add(last_recall.get("session_id"))
+    lr_session = _read_json_file(last_recall_path).get("session_id")
+    if isinstance(lr_session, str) and lr_session:
+        unique_sessions.add(lr_session)
 
     # -----------------------------------------------------------------------
-    # 4. recall-audit.log — total recalls + hit rate
+    # 4. recall-audit.log - total recalls + hit rate
     # -----------------------------------------------------------------------
     audit_lines = _parse_jsonl(recall_audit_path)
     total_recalls = len(audit_lines)
@@ -148,10 +155,8 @@ def _compute_metrics(plugin_dir: Path) -> dict:
         total_hit_count = sum(int(v) for v in hits.values() if isinstance(v, (int, float)))
         if total_hit_count > 0:
             recall_hits += 1
-        
-        # Extract session ID from audit logs as well
         sid = entry.get("session_id")
-        if sid and isinstance(sid, str):
+        if isinstance(sid, str) and sid:
             unique_sessions.add(sid)
 
     hit_rate_pct = round(100.0 * recall_hits / total_recalls, 1) if total_recalls > 0 else 0.0
@@ -175,13 +180,7 @@ def _compute_metrics(plugin_dir: Path) -> dict:
             "local_count": local_decisions,
             "cloud_count": cloud_decisions,
         },
-        "circuit_breaker": {
-            "trips": breaker_trips,
-        },
-        "last_recall": {
-            "ts": last_recall_ts,
-            "hits": last_hits,
-        },
+        "breaker_open_events": breaker_open_events,
     }
 
 
@@ -189,44 +188,36 @@ def _compute_metrics(plugin_dir: Path) -> dict:
 # Output formatters
 # ---------------------------------------------------------------------------
 
-def _print_rollup(metrics: dict, plugin: str) -> None:
-    m = metrics
-    r = m["recalls"]
-    s = m["saves"]
-    ms = m["mode_split"]
-    cb = m["circuit_breaker"]
-    lr = m["last_recall"]
 
-    print("cognee-plugin metrics  [{}]".format(plugin))
+def _print_rollup(metrics: dict, plugin: str) -> None:
+    r = metrics["recalls"]
+    s = metrics["saves"]
+    ms = metrics["mode_split"]
+
+    print(f"cognee-plugin metrics  [{plugin}]")
     print("=" * 46)
-    print("  Sessions            : {}".format(m["sessions"]))
+    print(f"  Sessions            : {metrics['sessions']}")
     print()
-    print("  Recalls             : {}".format(r["total"]))
-    print("  Recall hits         : {}".format(r["hits"]))
-    print("  Hit rate            : {}%".format(r["hit_rate_pct"]))
-    if lr.get("ts"):
-        hits_str = "  ".join(
-            "{}={}".format(k, v) for k, v in (lr.get("hits") or {}).items()
-        )
-        print("  Last recall ts      : {}".format(lr["ts"]))
-        if hits_str:
-            print("  Last recall hits    : {}".format(hits_str))
+    print(f"  Recalls             : {r['total']}")
+    print(f"  Recall hits         : {r['hits']}")
+    print(f"  Hit rate            : {r['hit_rate_pct']}%")
     print()
-    print("  Saves (prompt)      : {}".format(s["prompt"]))
-    print("  Saves (trace)       : {}".format(s["trace"]))
-    print("  Saves (answer)      : {}".format(s["answer"]))
-    print("  Saves (total)       : {}".format(sum(s.values())))
+    print(f"  Saves (prompt)      : {s['prompt']}")
+    print(f"  Saves (trace)       : {s['trace']}")
+    print(f"  Saves (answer)      : {s['answer']}")
+    print(f"  Saves (total)       : {sum(s.values())}")
     print()
-    print("  Mode — local        : {}%  ({} decisions)".format(ms["local_pct"], ms["local_count"]))
-    print("  Mode — cloud        : {}%  ({} decisions)".format(ms["cloud_pct"], ms["cloud_count"]))
+    print(f"  Mode - local        : {ms['local_pct']}%  ({ms['local_count']} decisions)")
+    print(f"  Mode - cloud        : {ms['cloud_pct']}%  ({ms['cloud_count']} decisions)")
     print()
-    print("  Breaker trips       : {}".format(cb["trips"]))
+    print(f"  Breaker open events : {metrics['breaker_open_events']}")
     print("=" * 46)
 
 
 # ---------------------------------------------------------------------------
 # CLI entry point
 # ---------------------------------------------------------------------------
+
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -245,12 +236,6 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Output metrics as a JSON object instead of a human-readable rollup.",
     )
-    metrics_p.add_argument(
-        "--plugin",
-        default="claude-code",
-        choices=["claude-code", "codex"],
-        help="Which plugin state directory to read (default: claude-code).",
-    )
     return parser
 
 
@@ -263,23 +248,16 @@ def main(argv=None):
         return 1
 
     if args.command == "metrics":
-        plugin_name = args.plugin
-        if plugin_name == "codex":
-            plugin_dir = Path.home() / ".cognee-plugin" / "codex"
-        else:
-            plugin_dir = Path.home() / ".cognee-plugin" / "claude-code"
-
-        metrics = _compute_metrics(plugin_dir)
-
+        metrics = _compute_metrics(_PLUGIN_DIR)
         if args.as_json:
             print(json.dumps(metrics, indent=2))
         else:
-            _print_rollup(metrics, plugin_name)
-
+            _print_rollup(metrics, _PLUGIN_DIR.name)
         return 0
 
     parser.print_help(sys.stderr)
     return 1
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/integrations/claude-code/scripts/cognee_plugin.py
+++ b/integrations/claude-code/scripts/cognee_plugin.py
@@ -86,45 +86,47 @@ def _compute_metrics(plugin_dir: Path) -> dict:
             if sid and isinstance(sid, str):
                 unique_sessions.add(sid)
 
-        # Mode decisions
+        # Mode decisions. resolve_runtime_mode() emits "http" (cloud) or
+        # "local_sdk" (local); count any non-http mode as local so the split
+        # stays correct if another local mode name is ever added.
         if ev == "mode_decision":
             mode = detail.get("mode", "")
             if mode == "http":
                 cloud_decisions += 1
-            elif mode in ("local", "loopback"):
+            elif mode:
                 local_decisions += 1
 
         # Breaker trips recorded via hook_log
         if ev == "recall_breaker_open":
             breaker_trips += 1
 
-        # Save events that appear in hook.log
+        # Save events recorded in hook.log. Warmup-buffered trace/answer saves
+        # log "store_buffered_warming" (tagged with the originating hook) rather
+        # than trace_stored/stop_stored, so count those too for a full total.
         if ev == "prompt_pending":
             saves_from_log["prompt"] += 1
-        if ev == "trace_stored":
+        elif ev == "trace_stored":
             saves_from_log["trace"] += 1
-        if ev == "stop_stored":
+        elif ev == "stop_stored":
             saves_from_log["answer"] += 1
+        elif ev == "store_buffered_warming":
+            if detail.get("hook") == "tool":
+                saves_from_log["trace"] += 1
+            elif detail.get("hook") == "stop":
+                saves_from_log["answer"] += 1
 
     # -----------------------------------------------------------------------
-    # 2. save_counter.json — live per-session save counts
+    # 2. save_counter.json — session ids only
     # -----------------------------------------------------------------------
+    # A per-turn buffer that read_and_reset_save_counter drains on every recall;
+    # each save it records is also written to hook.log, so adding it to the
+    # totals would double-count. Read it only to recover session ids.
     save_data = _read_json_file(save_counter_path)
-    saves_counter = {"prompt": 0, "trace": 0, "answer": 0}
-    for _sid, counts in save_data.items():
-        if isinstance(counts, dict):
-            for kind in ("prompt", "trace", "answer"):
-                saves_counter[kind] += int(counts.get(kind, 0))
-        
-        # In case a session exists in save_counter but wasn't in hook.log
+    for _sid in save_data:
         if isinstance(_sid, str):
             unique_sessions.add(_sid)
 
-    # Prefer log-derived totals (historical) and supplement with live counter
-    total_saves = {
-        kind: saves_from_log[kind] + saves_counter[kind]
-        for kind in ("prompt", "trace", "answer")
-    }
+    total_saves = dict(saves_from_log)
 
     # -----------------------------------------------------------------------
     # 3. last_recall.json — most-recent recall hit counts

--- a/integrations/claude-code/scripts/cognee_plugin.py
+++ b/integrations/claude-code/scripts/cognee_plugin.py
@@ -1,0 +1,283 @@
+"""cognee-plugin — CLI utility for the cognee Claude-Code / Codex plugin.
+
+Usage:
+    cognee-plugin metrics [--json] [--plugin <claude-code|codex>]
+
+Computes usage rollup purely from local files — no network required:
+    ~/.cognee-plugin/<plugin>/hook.log
+    ~/.cognee-plugin/<plugin>/save_counter.json
+    ~/.cognee-plugin/<plugin>/last_recall.json
+    ~/.cognee-plugin/<plugin>/recall-audit.log
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_jsonl(path: Path) -> list:
+    """Read a JSON-Lines file; skip malformed lines silently."""
+    if not path.exists():
+        return []
+    lines = []
+    try:
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                obj = json.loads(raw)
+                if isinstance(obj, dict):
+                    lines.append(obj)
+            except json.JSONDecodeError:
+                pass
+    except OSError:
+        pass
+    return lines
+
+
+def _read_json_file(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return data
+    except (OSError, json.JSONDecodeError):
+        pass
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Metric computation
+# ---------------------------------------------------------------------------
+
+def _compute_metrics(plugin_dir: Path) -> dict:
+    hook_log_path     = plugin_dir / "hook.log"
+    save_counter_path = plugin_dir / "save_counter.json"
+    last_recall_path  = plugin_dir / "last_recall.json"
+    recall_audit_path = plugin_dir / "recall-audit.log"
+
+    # -----------------------------------------------------------------------
+    # 1. hook.log — sessions, mode split, breaker trips, save events
+    # -----------------------------------------------------------------------
+    hook_lines = _parse_jsonl(hook_log_path)
+
+    unique_sessions: set = set()
+    local_decisions = 0
+    cloud_decisions = 0
+    breaker_trips = 0
+    saves_from_log = {"prompt": 0, "trace": 0, "answer": 0}
+
+    for line in hook_lines:
+        ev = line.get("event", "")
+        detail = line.get("detail") or {}
+
+        # Collect session ids from any log line
+        for key in ("session_id", "session"):
+            sid = detail.get(key) or line.get(key)
+            if sid and isinstance(sid, str):
+                unique_sessions.add(sid)
+
+        # Mode decisions
+        if ev == "mode_decision":
+            mode = detail.get("mode", "")
+            if mode == "http":
+                cloud_decisions += 1
+            elif mode in ("local", "loopback"):
+                local_decisions += 1
+
+        # Breaker trips recorded via hook_log
+        if ev == "recall_breaker_open":
+            breaker_trips += 1
+
+        # Save events that appear in hook.log
+        if ev == "prompt_pending":
+            saves_from_log["prompt"] += 1
+        if ev == "trace_stored":
+            saves_from_log["trace"] += 1
+        if ev == "stop_stored":
+            saves_from_log["answer"] += 1
+
+    # -----------------------------------------------------------------------
+    # 2. save_counter.json — live per-session save counts
+    # -----------------------------------------------------------------------
+    save_data = _read_json_file(save_counter_path)
+    saves_counter = {"prompt": 0, "trace": 0, "answer": 0}
+    for _sid, counts in save_data.items():
+        if isinstance(counts, dict):
+            for kind in ("prompt", "trace", "answer"):
+                saves_counter[kind] += int(counts.get(kind, 0))
+        
+        # In case a session exists in save_counter but wasn't in hook.log
+        if isinstance(_sid, str):
+            unique_sessions.add(_sid)
+
+    # Prefer log-derived totals (historical) and supplement with live counter
+    total_saves = {
+        kind: saves_from_log[kind] + saves_counter[kind]
+        for kind in ("prompt", "trace", "answer")
+    }
+
+    # -----------------------------------------------------------------------
+    # 3. last_recall.json — most-recent recall hit counts
+    # -----------------------------------------------------------------------
+    last_recall = _read_json_file(last_recall_path)
+    last_hits = last_recall.get("hits") or {}
+    last_recall_ts = last_recall.get("ts", "")
+    if last_recall.get("session_id"):
+        unique_sessions.add(last_recall.get("session_id"))
+
+    # -----------------------------------------------------------------------
+    # 4. recall-audit.log — total recalls + hit rate
+    # -----------------------------------------------------------------------
+    audit_lines = _parse_jsonl(recall_audit_path)
+    total_recalls = len(audit_lines)
+    recall_hits = 0
+    for entry in audit_lines:
+        hits = entry.get("hits") or {}
+        total_hit_count = sum(int(v) for v in hits.values() if isinstance(v, (int, float)))
+        if total_hit_count > 0:
+            recall_hits += 1
+        
+        # Extract session ID from audit logs as well
+        sid = entry.get("session_id")
+        if sid and isinstance(sid, str):
+            unique_sessions.add(sid)
+
+    hit_rate_pct = round(100.0 * recall_hits / total_recalls, 1) if total_recalls > 0 else 0.0
+
+    total_sessions = len(unique_sessions)
+    total_decisions = local_decisions + cloud_decisions
+    local_pct = round(100.0 * local_decisions / total_decisions, 1) if total_decisions > 0 else 0.0
+    cloud_pct = round(100.0 * cloud_decisions / total_decisions, 1) if total_decisions > 0 else 0.0
+
+    return {
+        "sessions": total_sessions,
+        "recalls": {
+            "total": total_recalls,
+            "hits": recall_hits,
+            "hit_rate_pct": hit_rate_pct,
+        },
+        "saves": total_saves,
+        "mode_split": {
+            "local_pct": local_pct,
+            "cloud_pct": cloud_pct,
+            "local_count": local_decisions,
+            "cloud_count": cloud_decisions,
+        },
+        "circuit_breaker": {
+            "trips": breaker_trips,
+        },
+        "last_recall": {
+            "ts": last_recall_ts,
+            "hits": last_hits,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+def _print_rollup(metrics: dict, plugin: str) -> None:
+    m = metrics
+    r = m["recalls"]
+    s = m["saves"]
+    ms = m["mode_split"]
+    cb = m["circuit_breaker"]
+    lr = m["last_recall"]
+
+    print("cognee-plugin metrics  [{}]".format(plugin))
+    print("=" * 46)
+    print("  Sessions            : {}".format(m["sessions"]))
+    print()
+    print("  Recalls             : {}".format(r["total"]))
+    print("  Recall hits         : {}".format(r["hits"]))
+    print("  Hit rate            : {}%".format(r["hit_rate_pct"]))
+    if lr.get("ts"):
+        hits_str = "  ".join(
+            "{}={}".format(k, v) for k, v in (lr.get("hits") or {}).items()
+        )
+        print("  Last recall ts      : {}".format(lr["ts"]))
+        if hits_str:
+            print("  Last recall hits    : {}".format(hits_str))
+    print()
+    print("  Saves (prompt)      : {}".format(s["prompt"]))
+    print("  Saves (trace)       : {}".format(s["trace"]))
+    print("  Saves (answer)      : {}".format(s["answer"]))
+    print("  Saves (total)       : {}".format(sum(s.values())))
+    print()
+    print("  Mode — local        : {}%  ({} decisions)".format(ms["local_pct"], ms["local_count"]))
+    print("  Mode — cloud        : {}%  ({} decisions)".format(ms["cloud_pct"], ms["cloud_count"]))
+    print()
+    print("  Breaker trips       : {}".format(cb["trips"]))
+    print("=" * 46)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cognee-plugin",
+        description="Cognee plugin CLI utilities",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    metrics_p = sub.add_parser(
+        "metrics",
+        help="Print a usage rollup derived purely from local plugin files (no network).",
+    )
+    metrics_p.add_argument(
+        "--json",
+        dest="as_json",
+        action="store_true",
+        help="Output metrics as a JSON object instead of a human-readable rollup.",
+    )
+    metrics_p.add_argument(
+        "--plugin",
+        default="claude-code",
+        choices=["claude-code", "codex"],
+        help="Which plugin state directory to read (default: claude-code).",
+    )
+    return parser
+
+
+def main(argv=None):
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help(sys.stderr)
+        return 1
+
+    if args.command == "metrics":
+        plugin_name = args.plugin
+        if plugin_name == "codex":
+            plugin_dir = Path.home() / ".cognee-plugin" / "codex"
+        else:
+            plugin_dir = Path.home() / ".cognee-plugin" / "claude-code"
+
+        metrics = _compute_metrics(plugin_dir)
+
+        if args.as_json:
+            print(json.dumps(metrics, indent=2))
+        else:
+            _print_rollup(metrics, plugin_name)
+
+        return 0
+
+    parser.print_help(sys.stderr)
+    return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/claude-code/tests/test_metrics.py
+++ b/integrations/claude-code/tests/test_metrics.py
@@ -1,0 +1,200 @@
+"""Unit tests for the cognee-plugin metrics command.
+
+Tests parse mock log files in a temp directory — no network, no real plugin state.
+
+Run:
+    pytest integrations/claude-code/tests/test_metrics.py
+    python integrations/claude-code/tests/test_metrics.py  # standalone
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+import time
+
+# ---- resolve imports -------------------------------------------------------
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+import cognee_plugin  # type: ignore
+
+_compute_metrics = cognee_plugin._compute_metrics
+_parse_jsonl     = cognee_plugin._parse_jsonl
+_read_json_file  = cognee_plugin._read_json_file
+main             = cognee_plugin.main
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_dir():
+    """Return a fresh temp directory Path."""
+    return pathlib.Path(tempfile.mkdtemp(prefix="cognee-metrics-test-"))
+
+
+def _jsonl(*dicts):
+    return "\n".join(json.dumps(d) for d in dicts) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_empty_dir_returns_zeros():
+    """No files exist → every metric is zero / empty, no crash."""
+    d = _make_dir()
+    m = _compute_metrics(d)
+    assert m["sessions"] == 0
+    assert m["recalls"]["total"] == 0
+    assert m["recalls"]["hits"] == 0
+    assert m["recalls"]["hit_rate_pct"] == 0.0
+    assert m["saves"]["prompt"] == 0
+    assert m["saves"]["trace"] == 0
+    assert m["saves"]["answer"] == 0
+    assert m["mode_split"]["local_pct"] == 0.0
+    assert m["mode_split"]["cloud_pct"] == 0.0
+    assert m["circuit_breaker"]["trips"] == 0
+
+
+def test_session_counting_from_hook_log():
+    d = _make_dir()
+    (d / "hook.log").write_text(
+        _jsonl(
+            {"ts": "2025-01-01T00:00:00Z", "event": "mode_decision",
+             "detail": {"mode": "local", "session_id": "sess-aaa"}},
+            {"ts": "2025-01-01T00:01:00Z", "event": "prompt_pending",
+             "detail": {"session_id": "sess-aaa"}},
+            {"ts": "2025-01-01T01:00:00Z", "event": "mode_decision",
+             "detail": {"mode": "http",  "session_id": "sess-bbb"}},
+        ),
+        encoding="utf-8",
+    )
+    m = _compute_metrics(d)
+    assert m["sessions"] == 2
+    assert m["mode_split"]["local_count"] == 1
+    assert m["mode_split"]["cloud_count"] == 1
+    assert m["mode_split"]["local_pct"] == 50.0
+    assert m["mode_split"]["cloud_pct"] == 50.0
+
+
+def test_save_counter_json_aggregated():
+    d = _make_dir()
+    (d / "save_counter.json").write_text(json.dumps({
+        "sess-1": {"prompt": 3, "trace": 1, "answer": 2},
+        "sess-2": {"prompt": 1, "trace": 0, "answer": 1},
+    }), encoding="utf-8")
+    m = _compute_metrics(d)
+    # Both sessions should be summed
+    assert m["saves"]["prompt"] == 4
+    assert m["saves"]["trace"] == 1
+    assert m["saves"]["answer"] == 3
+
+
+def test_recall_audit_hit_rate():
+    d = _make_dir()
+    audit_entries = [
+        # 2 hits  → counted as a hit
+        {"ts": "T1", "session_id": "s", "prompt": "q1", "hits": {"session": 2, "graph": 0}},
+        # 0 hits  → counted as miss
+        {"ts": "T2", "session_id": "s", "prompt": "q2", "hits": {"session": 0, "graph": 0}},
+        # 1 hit   → counted as hit
+        {"ts": "T3", "session_id": "s", "prompt": "q3", "hits": {"session": 0, "graph": 1}},
+    ]
+    (d / "recall-audit.log").write_text(
+        _jsonl(*audit_entries), encoding="utf-8"
+    )
+    m = _compute_metrics(d)
+    assert m["recalls"]["total"] == 3
+    assert m["recalls"]["hits"] == 2
+    assert m["recalls"]["hit_rate_pct"] == round(100.0 * 2 / 3, 1)
+
+
+def test_breaker_trips_from_hook_log():
+    d = _make_dir()
+    (d / "hook.log").write_text(
+        _jsonl(
+            {"ts": "T1", "event": "recall_breaker_open", "detail": {"retry_in": 90}},
+            {"ts": "T2", "event": "recall_breaker_open", "detail": {"retry_in": 45}},
+            {"ts": "T3", "event": "mode_decision",       "detail": {"mode": "local"}},
+        ),
+        encoding="utf-8",
+    )
+    m = _compute_metrics(d)
+    assert m["circuit_breaker"]["trips"] == 2
+
+
+def test_last_recall_json_surfaced():
+    d = _make_dir()
+    (d / "last_recall.json").write_text(json.dumps({
+        "session_id": "s1",
+        "ts": "2025-06-01T10:00:00+00:00",
+        "hits": {"session": 3, "trace": 1, "graph_context": 0},
+        "saves_last_turn": {"prompt": 1, "trace": 0, "answer": 1},
+    }), encoding="utf-8")
+    m = _compute_metrics(d)
+    assert m["last_recall"]["ts"] == "2025-06-01T10:00:00+00:00"
+    assert m["last_recall"]["hits"]["session"] == 3
+
+
+def test_json_output_flag(capsys=None):
+    """--json flag should produce parseable JSON."""
+    d = _make_dir()
+    import io, contextlib
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        # Call compute directly and dump JSON (mirrors main() flow)
+        m = _compute_metrics(d)
+        print(json.dumps(m, indent=2))
+
+    parsed = json.loads(buf.getvalue())
+    assert "sessions" in parsed
+    assert "recalls" in parsed
+    assert "saves" in parsed
+    assert "mode_split" in parsed
+    assert "circuit_breaker" in parsed
+
+
+def test_malformed_log_lines_skipped():
+    """Bad JSON lines in hook.log should be silently skipped."""
+    d = _make_dir()
+    content = (
+        '{"ts":"T1","event":"prompt_pending","detail":{"session_id":"s1"}}\n'
+        'NOT VALID JSON\n'
+        '{"ts":"T2","event":"stop_stored","detail":{"session_id":"s1"}}\n'
+    )
+    (d / "hook.log").write_text(content, encoding="utf-8")
+    # Should not raise
+    m = _compute_metrics(d)
+    assert m["saves"]["prompt"] == 1
+    assert m["saves"]["answer"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Standalone runner (no pytest required)
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    failures = 0
+    tests = [
+        test_empty_dir_returns_zeros,
+        test_session_counting_from_hook_log,
+        test_save_counter_json_aggregated,
+        test_recall_audit_hit_rate,
+        test_breaker_trips_from_hook_log,
+        test_last_recall_json_surfaced,
+        test_json_output_flag,
+        test_malformed_log_lines_skipped,
+    ]
+    for fn in tests:
+        try:
+            fn()
+            print("PASS", fn.__name__)
+        except Exception as e:
+            failures += 1
+            print("FAIL", fn.__name__, "-", e)
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -181,6 +181,19 @@ tail -f ~/.cognee-plugin/codex/exit-watcher.log
 tail -f ~/.cognee-plugin/codex/watcher.log
 ```
 
+## Usage metrics
+
+For an offline usage rollup compiled purely from the local files above — no
+network, no `cognee` import — run:
+
+```bash
+python3 "${PLUGIN_ROOT}/scripts/cognee-plugin" metrics          # readable rollup
+python3 "${PLUGIN_ROOT}/scripts/cognee-plugin" metrics --json   # JSON
+```
+
+It reports sessions, recalls and hit-rate, saves (prompt/trace/answer), the
+local-vs-cloud mode split, and how often an open recall breaker skipped recall.
+
 ## Updating
 
 The `cognee` marketplace tracks the repository's `main` branch (`git-subdir`,

--- a/integrations/codex/plugins/cognee/scripts/cognee-plugin
+++ b/integrations/codex/plugins/cognee/scripts/cognee-plugin
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+# Add script directory to Python path to import cognee_plugin
+sys.path.insert(0, str(Path(__file__).parent))
+
+import cognee_plugin
+
+if __name__ == "__main__":
+    sys.exit(cognee_plugin.main())

--- a/integrations/codex/plugins/cognee/scripts/cognee_plugin.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_plugin.py
@@ -86,45 +86,47 @@ def _compute_metrics(plugin_dir: Path) -> dict:
             if sid and isinstance(sid, str):
                 unique_sessions.add(sid)
 
-        # Mode decisions
+        # Mode decisions. resolve_runtime_mode() emits "http" (cloud) or
+        # "local_sdk" (local); count any non-http mode as local so the split
+        # stays correct if another local mode name is ever added.
         if ev == "mode_decision":
             mode = detail.get("mode", "")
             if mode == "http":
                 cloud_decisions += 1
-            elif mode in ("local", "loopback"):
+            elif mode:
                 local_decisions += 1
 
         # Breaker trips recorded via hook_log
         if ev == "recall_breaker_open":
             breaker_trips += 1
 
-        # Save events that appear in hook.log
+        # Save events recorded in hook.log. Warmup-buffered trace/answer saves
+        # log "store_buffered_warming" (tagged with the originating hook) rather
+        # than trace_stored/stop_stored, so count those too for a full total.
         if ev == "prompt_pending":
             saves_from_log["prompt"] += 1
-        if ev == "trace_stored":
+        elif ev == "trace_stored":
             saves_from_log["trace"] += 1
-        if ev == "stop_stored":
+        elif ev == "stop_stored":
             saves_from_log["answer"] += 1
+        elif ev == "store_buffered_warming":
+            if detail.get("hook") == "tool":
+                saves_from_log["trace"] += 1
+            elif detail.get("hook") == "stop":
+                saves_from_log["answer"] += 1
 
     # -----------------------------------------------------------------------
-    # 2. save_counter.json — live per-session save counts
+    # 2. save_counter.json — session ids only
     # -----------------------------------------------------------------------
+    # A per-turn buffer that read_and_reset_save_counter drains on every recall;
+    # each save it records is also written to hook.log, so adding it to the
+    # totals would double-count. Read it only to recover session ids.
     save_data = _read_json_file(save_counter_path)
-    saves_counter = {"prompt": 0, "trace": 0, "answer": 0}
-    for _sid, counts in save_data.items():
-        if isinstance(counts, dict):
-            for kind in ("prompt", "trace", "answer"):
-                saves_counter[kind] += int(counts.get(kind, 0))
-        
-        # In case a session exists in save_counter but wasn't in hook.log
+    for _sid in save_data:
         if isinstance(_sid, str):
             unique_sessions.add(_sid)
 
-    # Prefer log-derived totals (historical) and supplement with live counter
-    total_saves = {
-        kind: saves_from_log[kind] + saves_counter[kind]
-        for kind in ("prompt", "trace", "answer")
-    }
+    total_saves = dict(saves_from_log)
 
     # -----------------------------------------------------------------------
     # 3. last_recall.json — most-recent recall hit counts

--- a/integrations/codex/plugins/cognee/scripts/cognee_plugin.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_plugin.py
@@ -1,0 +1,283 @@
+"""cognee-plugin — CLI utility for the cognee Claude-Code / Codex plugin.
+
+Usage:
+    cognee-plugin metrics [--json] [--plugin <claude-code|codex>]
+
+Computes usage rollup purely from local files — no network required:
+    ~/.cognee-plugin/<plugin>/hook.log
+    ~/.cognee-plugin/<plugin>/save_counter.json
+    ~/.cognee-plugin/<plugin>/last_recall.json
+    ~/.cognee-plugin/<plugin>/recall-audit.log
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_jsonl(path: Path) -> list:
+    """Read a JSON-Lines file; skip malformed lines silently."""
+    if not path.exists():
+        return []
+    lines = []
+    try:
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                obj = json.loads(raw)
+                if isinstance(obj, dict):
+                    lines.append(obj)
+            except json.JSONDecodeError:
+                pass
+    except OSError:
+        pass
+    return lines
+
+
+def _read_json_file(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return data
+    except (OSError, json.JSONDecodeError):
+        pass
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Metric computation
+# ---------------------------------------------------------------------------
+
+def _compute_metrics(plugin_dir: Path) -> dict:
+    hook_log_path     = plugin_dir / "hook.log"
+    save_counter_path = plugin_dir / "save_counter.json"
+    last_recall_path  = plugin_dir / "last_recall.json"
+    recall_audit_path = plugin_dir / "recall-audit.log"
+
+    # -----------------------------------------------------------------------
+    # 1. hook.log — sessions, mode split, breaker trips, save events
+    # -----------------------------------------------------------------------
+    hook_lines = _parse_jsonl(hook_log_path)
+
+    unique_sessions: set = set()
+    local_decisions = 0
+    cloud_decisions = 0
+    breaker_trips = 0
+    saves_from_log = {"prompt": 0, "trace": 0, "answer": 0}
+
+    for line in hook_lines:
+        ev = line.get("event", "")
+        detail = line.get("detail") or {}
+
+        # Collect session ids from any log line
+        for key in ("session_id", "session"):
+            sid = detail.get(key) or line.get(key)
+            if sid and isinstance(sid, str):
+                unique_sessions.add(sid)
+
+        # Mode decisions
+        if ev == "mode_decision":
+            mode = detail.get("mode", "")
+            if mode == "http":
+                cloud_decisions += 1
+            elif mode in ("local", "loopback"):
+                local_decisions += 1
+
+        # Breaker trips recorded via hook_log
+        if ev == "recall_breaker_open":
+            breaker_trips += 1
+
+        # Save events that appear in hook.log
+        if ev == "prompt_pending":
+            saves_from_log["prompt"] += 1
+        if ev == "trace_stored":
+            saves_from_log["trace"] += 1
+        if ev == "stop_stored":
+            saves_from_log["answer"] += 1
+
+    # -----------------------------------------------------------------------
+    # 2. save_counter.json — live per-session save counts
+    # -----------------------------------------------------------------------
+    save_data = _read_json_file(save_counter_path)
+    saves_counter = {"prompt": 0, "trace": 0, "answer": 0}
+    for _sid, counts in save_data.items():
+        if isinstance(counts, dict):
+            for kind in ("prompt", "trace", "answer"):
+                saves_counter[kind] += int(counts.get(kind, 0))
+        
+        # In case a session exists in save_counter but wasn't in hook.log
+        if isinstance(_sid, str):
+            unique_sessions.add(_sid)
+
+    # Prefer log-derived totals (historical) and supplement with live counter
+    total_saves = {
+        kind: saves_from_log[kind] + saves_counter[kind]
+        for kind in ("prompt", "trace", "answer")
+    }
+
+    # -----------------------------------------------------------------------
+    # 3. last_recall.json — most-recent recall hit counts
+    # -----------------------------------------------------------------------
+    last_recall = _read_json_file(last_recall_path)
+    last_hits = last_recall.get("hits") or {}
+    last_recall_ts = last_recall.get("ts", "")
+    if last_recall.get("session_id"):
+        unique_sessions.add(last_recall.get("session_id"))
+
+    # -----------------------------------------------------------------------
+    # 4. recall-audit.log — total recalls + hit rate
+    # -----------------------------------------------------------------------
+    audit_lines = _parse_jsonl(recall_audit_path)
+    total_recalls = len(audit_lines)
+    recall_hits = 0
+    for entry in audit_lines:
+        hits = entry.get("hits") or {}
+        total_hit_count = sum(int(v) for v in hits.values() if isinstance(v, (int, float)))
+        if total_hit_count > 0:
+            recall_hits += 1
+        
+        # Extract session ID from audit logs as well
+        sid = entry.get("session_id")
+        if sid and isinstance(sid, str):
+            unique_sessions.add(sid)
+
+    hit_rate_pct = round(100.0 * recall_hits / total_recalls, 1) if total_recalls > 0 else 0.0
+
+    total_sessions = len(unique_sessions)
+    total_decisions = local_decisions + cloud_decisions
+    local_pct = round(100.0 * local_decisions / total_decisions, 1) if total_decisions > 0 else 0.0
+    cloud_pct = round(100.0 * cloud_decisions / total_decisions, 1) if total_decisions > 0 else 0.0
+
+    return {
+        "sessions": total_sessions,
+        "recalls": {
+            "total": total_recalls,
+            "hits": recall_hits,
+            "hit_rate_pct": hit_rate_pct,
+        },
+        "saves": total_saves,
+        "mode_split": {
+            "local_pct": local_pct,
+            "cloud_pct": cloud_pct,
+            "local_count": local_decisions,
+            "cloud_count": cloud_decisions,
+        },
+        "circuit_breaker": {
+            "trips": breaker_trips,
+        },
+        "last_recall": {
+            "ts": last_recall_ts,
+            "hits": last_hits,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+def _print_rollup(metrics: dict, plugin: str) -> None:
+    m = metrics
+    r = m["recalls"]
+    s = m["saves"]
+    ms = m["mode_split"]
+    cb = m["circuit_breaker"]
+    lr = m["last_recall"]
+
+    print("cognee-plugin metrics  [{}]".format(plugin))
+    print("=" * 46)
+    print("  Sessions            : {}".format(m["sessions"]))
+    print()
+    print("  Recalls             : {}".format(r["total"]))
+    print("  Recall hits         : {}".format(r["hits"]))
+    print("  Hit rate            : {}%".format(r["hit_rate_pct"]))
+    if lr.get("ts"):
+        hits_str = "  ".join(
+            "{}={}".format(k, v) for k, v in (lr.get("hits") or {}).items()
+        )
+        print("  Last recall ts      : {}".format(lr["ts"]))
+        if hits_str:
+            print("  Last recall hits    : {}".format(hits_str))
+    print()
+    print("  Saves (prompt)      : {}".format(s["prompt"]))
+    print("  Saves (trace)       : {}".format(s["trace"]))
+    print("  Saves (answer)      : {}".format(s["answer"]))
+    print("  Saves (total)       : {}".format(sum(s.values())))
+    print()
+    print("  Mode — local        : {}%  ({} decisions)".format(ms["local_pct"], ms["local_count"]))
+    print("  Mode — cloud        : {}%  ({} decisions)".format(ms["cloud_pct"], ms["cloud_count"]))
+    print()
+    print("  Breaker trips       : {}".format(cb["trips"]))
+    print("=" * 46)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cognee-plugin",
+        description="Cognee plugin CLI utilities",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    metrics_p = sub.add_parser(
+        "metrics",
+        help="Print a usage rollup derived purely from local plugin files (no network).",
+    )
+    metrics_p.add_argument(
+        "--json",
+        dest="as_json",
+        action="store_true",
+        help="Output metrics as a JSON object instead of a human-readable rollup.",
+    )
+    metrics_p.add_argument(
+        "--plugin",
+        default="claude-code",
+        choices=["claude-code", "codex"],
+        help="Which plugin state directory to read (default: claude-code).",
+    )
+    return parser
+
+
+def main(argv=None):
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help(sys.stderr)
+        return 1
+
+    if args.command == "metrics":
+        plugin_name = args.plugin
+        if plugin_name == "codex":
+            plugin_dir = Path.home() / ".cognee-plugin" / "codex"
+        else:
+            plugin_dir = Path.home() / ".cognee-plugin" / "claude-code"
+
+        metrics = _compute_metrics(plugin_dir)
+
+        if args.as_json:
+            print(json.dumps(metrics, indent=2))
+        else:
+            _print_rollup(metrics, plugin_name)
+
+        return 0
+
+    parser.print_help(sys.stderr)
+    return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/codex/plugins/cognee/scripts/cognee_plugin.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_plugin.py
@@ -1,13 +1,14 @@
-"""cognee-plugin — CLI utility for the cognee Claude-Code / Codex plugin.
+"""cognee-plugin - offline usage-metrics CLI for the cognee Codex plugin.
 
 Usage:
-    cognee-plugin metrics [--json] [--plugin <claude-code|codex>]
+    cognee-plugin metrics [--json]
 
-Computes usage rollup purely from local files — no network required:
-    ~/.cognee-plugin/<plugin>/hook.log
-    ~/.cognee-plugin/<plugin>/save_counter.json
-    ~/.cognee-plugin/<plugin>/last_recall.json
-    ~/.cognee-plugin/<plugin>/recall-audit.log
+Computes a usage rollup purely from this plugin's local state files - no
+network, no import of the cognee package:
+    ~/.cognee-plugin/codex/hook.log
+    ~/.cognee-plugin/codex/save_counter.json
+    ~/.cognee-plugin/codex/last_recall.json
+    ~/.cognee-plugin/codex/recall-audit.log
 """
 
 from __future__ import annotations
@@ -17,10 +18,16 @@ import json
 import sys
 from pathlib import Path
 
+# State this plugin's hooks write (mirrors _plugin_common._PLUGIN_DIR). The
+# claude-code copy of this file points at ".../claude-code"; each copy reads
+# its own dir.
+_PLUGIN_DIR = Path.home() / ".cognee-plugin" / "codex"
+
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _parse_jsonl(path: Path) -> list:
     """Read a JSON-Lines file; skip malformed lines silently."""
@@ -59,31 +66,32 @@ def _read_json_file(path: Path) -> dict:
 # Metric computation
 # ---------------------------------------------------------------------------
 
+
 def _compute_metrics(plugin_dir: Path) -> dict:
-    hook_log_path     = plugin_dir / "hook.log"
+    hook_log_path = plugin_dir / "hook.log"
     save_counter_path = plugin_dir / "save_counter.json"
-    last_recall_path  = plugin_dir / "last_recall.json"
+    last_recall_path = plugin_dir / "last_recall.json"
     recall_audit_path = plugin_dir / "recall-audit.log"
 
     # -----------------------------------------------------------------------
-    # 1. hook.log — sessions, mode split, breaker trips, save events
+    # 1. hook.log - sessions, mode split, breaker events, save events
     # -----------------------------------------------------------------------
     hook_lines = _parse_jsonl(hook_log_path)
 
     unique_sessions: set = set()
     local_decisions = 0
     cloud_decisions = 0
-    breaker_trips = 0
+    breaker_open_events = 0
     saves_from_log = {"prompt": 0, "trace": 0, "answer": 0}
 
     for line in hook_lines:
         ev = line.get("event", "")
         detail = line.get("detail") or {}
 
-        # Collect session ids from any log line
+        # Some diagnostic events carry a session id in their detail payload.
         for key in ("session_id", "session"):
-            sid = detail.get(key) or line.get(key)
-            if sid and isinstance(sid, str):
+            sid = detail.get(key)
+            if isinstance(sid, str) and sid:
                 unique_sessions.add(sid)
 
         # Mode decisions. resolve_runtime_mode() emits "http" (cloud) or
@@ -96,9 +104,11 @@ def _compute_metrics(plugin_dir: Path) -> dict:
             elif mode:
                 local_decisions += 1
 
-        # Breaker trips recorded via hook_log
+        # recall_breaker_open is logged once per per-prompt recall skipped while
+        # the breaker is open; the 4 local files expose no open/close transition,
+        # so this counts recalls skipped by an open breaker, not distinct trips.
         if ev == "recall_breaker_open":
-            breaker_trips += 1
+            breaker_open_events += 1
 
         # Save events recorded in hook.log. Warmup-buffered trace/answer saves
         # log "store_buffered_warming" (tagged with the originating hook) rather
@@ -116,7 +126,7 @@ def _compute_metrics(plugin_dir: Path) -> dict:
                 saves_from_log["answer"] += 1
 
     # -----------------------------------------------------------------------
-    # 2. save_counter.json — session ids only
+    # 2. save_counter.json - session ids only
     # -----------------------------------------------------------------------
     # A per-turn buffer that read_and_reset_save_counter drains on every recall;
     # each save it records is also written to hook.log, so adding it to the
@@ -129,16 +139,14 @@ def _compute_metrics(plugin_dir: Path) -> dict:
     total_saves = dict(saves_from_log)
 
     # -----------------------------------------------------------------------
-    # 3. last_recall.json — most-recent recall hit counts
+    # 3. last_recall.json - session id only
     # -----------------------------------------------------------------------
-    last_recall = _read_json_file(last_recall_path)
-    last_hits = last_recall.get("hits") or {}
-    last_recall_ts = last_recall.get("ts", "")
-    if last_recall.get("session_id"):
-        unique_sessions.add(last_recall.get("session_id"))
+    lr_session = _read_json_file(last_recall_path).get("session_id")
+    if isinstance(lr_session, str) and lr_session:
+        unique_sessions.add(lr_session)
 
     # -----------------------------------------------------------------------
-    # 4. recall-audit.log — total recalls + hit rate
+    # 4. recall-audit.log - total recalls + hit rate
     # -----------------------------------------------------------------------
     audit_lines = _parse_jsonl(recall_audit_path)
     total_recalls = len(audit_lines)
@@ -148,10 +156,8 @@ def _compute_metrics(plugin_dir: Path) -> dict:
         total_hit_count = sum(int(v) for v in hits.values() if isinstance(v, (int, float)))
         if total_hit_count > 0:
             recall_hits += 1
-        
-        # Extract session ID from audit logs as well
         sid = entry.get("session_id")
-        if sid and isinstance(sid, str):
+        if isinstance(sid, str) and sid:
             unique_sessions.add(sid)
 
     hit_rate_pct = round(100.0 * recall_hits / total_recalls, 1) if total_recalls > 0 else 0.0
@@ -175,13 +181,7 @@ def _compute_metrics(plugin_dir: Path) -> dict:
             "local_count": local_decisions,
             "cloud_count": cloud_decisions,
         },
-        "circuit_breaker": {
-            "trips": breaker_trips,
-        },
-        "last_recall": {
-            "ts": last_recall_ts,
-            "hits": last_hits,
-        },
+        "breaker_open_events": breaker_open_events,
     }
 
 
@@ -189,44 +189,36 @@ def _compute_metrics(plugin_dir: Path) -> dict:
 # Output formatters
 # ---------------------------------------------------------------------------
 
-def _print_rollup(metrics: dict, plugin: str) -> None:
-    m = metrics
-    r = m["recalls"]
-    s = m["saves"]
-    ms = m["mode_split"]
-    cb = m["circuit_breaker"]
-    lr = m["last_recall"]
 
-    print("cognee-plugin metrics  [{}]".format(plugin))
+def _print_rollup(metrics: dict, plugin: str) -> None:
+    r = metrics["recalls"]
+    s = metrics["saves"]
+    ms = metrics["mode_split"]
+
+    print(f"cognee-plugin metrics  [{plugin}]")
     print("=" * 46)
-    print("  Sessions            : {}".format(m["sessions"]))
+    print(f"  Sessions            : {metrics['sessions']}")
     print()
-    print("  Recalls             : {}".format(r["total"]))
-    print("  Recall hits         : {}".format(r["hits"]))
-    print("  Hit rate            : {}%".format(r["hit_rate_pct"]))
-    if lr.get("ts"):
-        hits_str = "  ".join(
-            "{}={}".format(k, v) for k, v in (lr.get("hits") or {}).items()
-        )
-        print("  Last recall ts      : {}".format(lr["ts"]))
-        if hits_str:
-            print("  Last recall hits    : {}".format(hits_str))
+    print(f"  Recalls             : {r['total']}")
+    print(f"  Recall hits         : {r['hits']}")
+    print(f"  Hit rate            : {r['hit_rate_pct']}%")
     print()
-    print("  Saves (prompt)      : {}".format(s["prompt"]))
-    print("  Saves (trace)       : {}".format(s["trace"]))
-    print("  Saves (answer)      : {}".format(s["answer"]))
-    print("  Saves (total)       : {}".format(sum(s.values())))
+    print(f"  Saves (prompt)      : {s['prompt']}")
+    print(f"  Saves (trace)       : {s['trace']}")
+    print(f"  Saves (answer)      : {s['answer']}")
+    print(f"  Saves (total)       : {sum(s.values())}")
     print()
-    print("  Mode — local        : {}%  ({} decisions)".format(ms["local_pct"], ms["local_count"]))
-    print("  Mode — cloud        : {}%  ({} decisions)".format(ms["cloud_pct"], ms["cloud_count"]))
+    print(f"  Mode - local        : {ms['local_pct']}%  ({ms['local_count']} decisions)")
+    print(f"  Mode - cloud        : {ms['cloud_pct']}%  ({ms['cloud_count']} decisions)")
     print()
-    print("  Breaker trips       : {}".format(cb["trips"]))
+    print(f"  Breaker open events : {metrics['breaker_open_events']}")
     print("=" * 46)
 
 
 # ---------------------------------------------------------------------------
 # CLI entry point
 # ---------------------------------------------------------------------------
+
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -245,12 +237,6 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Output metrics as a JSON object instead of a human-readable rollup.",
     )
-    metrics_p.add_argument(
-        "--plugin",
-        default="claude-code",
-        choices=["claude-code", "codex"],
-        help="Which plugin state directory to read (default: claude-code).",
-    )
     return parser
 
 
@@ -263,23 +249,16 @@ def main(argv=None):
         return 1
 
     if args.command == "metrics":
-        plugin_name = args.plugin
-        if plugin_name == "codex":
-            plugin_dir = Path.home() / ".cognee-plugin" / "codex"
-        else:
-            plugin_dir = Path.home() / ".cognee-plugin" / "claude-code"
-
-        metrics = _compute_metrics(plugin_dir)
-
+        metrics = _compute_metrics(_PLUGIN_DIR)
         if args.as_json:
             print(json.dumps(metrics, indent=2))
         else:
-            _print_rollup(metrics, plugin_name)
-
+            _print_rollup(metrics, _PLUGIN_DIR.name)
         return 0
 
     parser.print_help(sys.stderr)
     return 1
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/integrations/codex/tests/test_metrics.py
+++ b/integrations/codex/tests/test_metrics.py
@@ -6,7 +6,7 @@ lines are {ts, pid, event, detail}; mode_decision.detail.mode is "local_sdk" or
 "http"; warmup-buffered saves log "store_buffered_warming"; recall-audit.log /
 save_counter.json / last_recall.json match their writers.
 
-Run: python integrations/claude-code/tests/test_metrics.py  (or via pytest)
+Run: python integrations/codex/tests/test_metrics.py  (or via pytest)
 """
 
 from __future__ import annotations
@@ -18,7 +18,9 @@ import pathlib
 import sys
 import tempfile
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "scripts"))
+sys.path.insert(
+    0, str(pathlib.Path(__file__).resolve().parents[1] / "plugins" / "cognee" / "scripts")
+)
 
 import cognee_plugin  # noqa: E402
 
@@ -96,7 +98,7 @@ def test_saves_counted_once_from_hook_log():
         _hook("stop_stored", chars=42),
     )
     (d / "save_counter.json").write_text(
-        json.dumps({"claude_s1": {"prompt": 1, "trace": 1, "answer": 1}}), encoding="utf-8"
+        json.dumps({"codex_s1": {"prompt": 1, "trace": 1, "answer": 1}}), encoding="utf-8"
     )
     assert cognee_plugin._compute_metrics(d)["saves"] == {"prompt": 2, "trace": 1, "answer": 1}
 


### PR DESCRIPTION
Reworks community PR #205 (by @nexpectArpit) for hackathon issue topoteretes/cognee#3682 — an **offline `cognee-plugin metrics` command** for the Claude Code and Codex plugins. Tracked in SDK-302.

The command compiles a usage rollup — sessions, recalls + hit-rate, saves (prompt/trace/answer), local-vs-cloud split, breaker activity — purely from the four local state files (`hook.log`, `save_counter.json`, `last_recall.json`, `recall-audit.log`), with no network and no import of the `cognee` package.

The original commit is preserved (attribution to @nexpectArpit); maintainer changes are layered on top as separate single-concern commits.

## What the rework changes

Reviewed against the real log writers (every finding verified against source plus an end-to-end run on real-schema fixtures). The offline-first shape and the four-file contract are sound and kept; the numbers it produced were not.

**Correctness (`fix`)**
- **Mode split dropped every local decision.** `resolve_runtime_mode()` only emits `"http"` or `"local_sdk"`, but the classifier matched local on `("local", "loopback")` — strings the plugin never writes — so the split reported 100% cloud / 0% local for the default local-SDK user. Any non-`http` mode now counts as local.
- **Saves were double-counted.** `save_counter.json` is a per-turn buffer that `read_and_reset_save_counter` drains on every recall, and each save it holds is also written to `hook.log`; the two were summed. `hook.log` is now the single durable source (including warmup-buffered saves that `trace_stored`/`stop_stored` miss); `save_counter.json` is read only to recover session ids.

**Simplify + portability (`refactor`)**
- Dropped the `--plugin` selector; the byte-identical codex copy defaulted to `--plugin claude-code` and read the wrong state dir. Each mirrored copy now reads its own dir, matching the per-integration convention of every sibling script.
- Report `breaker_open_events` (recalls skipped while the breaker was open) rather than "trips": the four files expose no distinct open/close transition, so a per-recall skip count is the honest signal (a single outage otherwise reads as N trips).
- Dropped the out-of-scope `last_recall` ts/hits output block; ASCII-only rollup (no `UnicodeEncodeError` on a legacy Windows console); f-strings to match the rest of the plugin.

**Tests (`test`)** — the original suite asserted against schemas the plugin never emits (mode `"local"`, session ids nested in mainline `hook.log` detail) and never drove the CLI, so it passed green while masking both bugs. Rebuilt on the real writer schemas with a regression for each fix plus CLI coverage, and added the codex test mirror the original PR omitted.

**Docs (`docs`)** — documented the command in both READMEs so it is discoverable.

## Verification
- **Unit:** claude-code `test_metrics.py` (11) and codex `test_metrics.py` (11) pass, standalone and under pytest.
- **End-to-end:** the executable `cognee-plugin metrics` wrapper, run under a temp `HOME` with real-schema fixtures → sessions 1, recalls 2 (1 hit, 50%), saves 1/2/1, mode 75% local / 25% cloud, breaker 1; `--json` emits the same shape.
- **Lint:** `ruff check` + `ruff format --check` clean across `integrations/`.

Closes topoteretes/cognee#3682. Supersedes #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
