### PR TITLE
feat(claude-code): project-level .cognee/session-config.json dataset picker (SDK-304)

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -107,6 +107,13 @@ Or persist it per-project in `.cognee/session-config.json` in your workspace roo
 { "dataset": "my-project-memory" }
 ```
 
+For safety, the project picker file only honors non-sensitive selection keys
+(`dataset`, `session_strategy`, `session_prefix`, `agent_name`, `top_k`) — any
+other key (e.g. `base_url`, `api_key`) is ignored, so opening a repo that ships a
+`.cognee/session-config.json` can never redirect your backend or inject
+credentials. Commit it for a shared project default, or `.gitignore` it for a
+personal local override.
+
 Dataset resolution precedence is `COGNEE_PLUGIN_DATASET` (env) > the project
 picker > the built-in default (`agent_sessions`). The global
 `~/.cognee-plugin/claude-code/config.json` may still show a `dataset` value for

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -101,6 +101,14 @@ Set a custom dataset at launch:
 export COGNEE_PLUGIN_DATASET="my-project-memory"
 ```
 
+Or persist it per-project in `.cognee/session-config.json` in your workspace root:
+
+```json
+{ "dataset": "my-project-memory" }
+```
+
+Dataset resolution precedence is `COGNEE_PLUGIN_DATASET` (env) > the project
+picker > the built-in default (`agent_sessions`). The global
 `~/.cognee-plugin/claude-code/config.json` may still show a `dataset` value for
 visibility, but runtime dataset selection does not read it.
 
@@ -327,8 +335,9 @@ skips local-path (dev) installs. Turn it off with `COGNEE_UPDATE_CHECK=false`.
 
 Config precedence:
 1. env vars
-2. `~/.cognee-plugin/claude-code/config.json`
-3. defaults
+2. project picker (`.cognee/session-config.json` in workspace root)
+3. global config (`~/.cognee-plugin/claude-code/config.json`)
+4. defaults
 
 | Key | Env var(s) | Default | Notes |
 |---|---|---|---|

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -37,12 +37,25 @@ _USER_SETTINGS = Path.home() / ".claude" / "settings.json"
 _OWNED_STATUSLINE_MARKER = "cognee-statusline"
 
 
-def _active_dataset() -> str:
+def _active_dataset(cwd: str = "") -> str:
     # 1. env var (inherited from the shell that launched Claude Code)
     v = os.environ.get("COGNEE_PLUGIN_DATASET", "").strip()
     if v:
         return v
-    # 2. default
+    # 2. project picker (.cognee/session-config.json). Mirror config.py's root
+    # resolution (cwd > CLAUDE_CWD > getcwd) so the displayed dataset matches
+    # what the hooks resolve. The global config file is deliberately not read
+    # here — like load_config, it does not drive the dataset (visibility-only).
+    try:
+        root = cwd or os.environ.get("CLAUDE_CWD") or os.getcwd()
+        picker = json.loads((Path(root) / ".cognee" / "session-config.json").read_text("utf-8"))
+        if isinstance(picker, dict):
+            v = str(picker.get("dataset") or "").strip()
+            if v:
+                return v
+    except Exception:
+        pass
+    # 3. default
     return _DEFAULT_DATASET
 
 
@@ -193,7 +206,7 @@ def main() -> None:
         return
 
     sys.stdout.write(
-        f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}{_update_segment()}"
+        f"{_health_prefix()}cognee: {_active_dataset(cwd)} · {_active_mode()}{_update_segment()}"
     )
 
 

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -22,6 +22,8 @@ _SERVER_READY_PATH = _SHARED_ROOT / "server-ready.json"
 _BREAKER_PATH = _SHARED_ROOT / "recall-breaker.json"
 _UPDATE_CHECK_PATH = _SHARED_ROOT / "claude-code" / "update-check.json"
 _DEFAULT_DATASET = "agent_sessions"
+# Cap for the untrusted project picker file (see config.py _read_project_picker).
+_PICKER_MAX_BYTES = 64 * 1024
 
 # Self-eviction: when the plugin is uninstalled/disabled but its files still
 # linger in the version cache (Claude Code does not remove the statusLine key we
@@ -48,11 +50,15 @@ def _active_dataset(cwd: str = "") -> str:
     # here — like load_config, it does not drive the dataset (visibility-only).
     try:
         root = cwd or os.environ.get("CLAUDE_CWD") or os.getcwd()
-        picker = json.loads((Path(root) / ".cognee" / "session-config.json").read_text("utf-8"))
-        if isinstance(picker, dict):
-            v = str(picker.get("dataset") or "").strip()
-            if v:
-                return v
+        p = Path(root) / ".cognee" / "session-config.json"
+        # Untrusted committed file: skip symlinks and cap the size, mirroring
+        # config.py's _read_project_picker.
+        if not p.is_symlink() and p.is_file() and p.stat().st_size <= _PICKER_MAX_BYTES:
+            picker = json.loads(p.read_text("utf-8"))
+            if isinstance(picker, dict):
+                v = str(picker.get("dataset") or "").strip()
+                if v:
+                    return v
     except Exception:
         pass
     # 3. default

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -101,6 +101,16 @@ _ENV_MAP = {
 }
 
 
+# Keys a project-committed picker file may set. Deliberately excludes secrets
+# and backend routing (api_key, llm_api_key, base_url, backend, user_*) so that
+# merely opening a repo with a `.cognee/session-config.json` can never redirect
+# your Cognee backend or inject credentials — the picker's job is dataset/session
+# selection only (issue #3686: "the dataset configuration key").
+_PICKER_ALLOWED_KEYS = frozenset(
+    {"dataset", "session_strategy", "session_prefix", "agent_name", "top_k"}
+)
+
+
 def _read_project_picker(cwd: Optional[str] = None) -> dict:
     """Read .cognee/session-config.json from the project directory.
 
@@ -108,6 +118,10 @@ def _read_project_picker(cwd: Optional[str] = None) -> dict:
     payload) > CLAUDE_CWD env (background workers with no payload) >
     os.getcwd() (last resort — NOT reliable inside a global-plugin hook
     process, kept only as a final fallback).
+
+    Only the non-sensitive keys in ``_PICKER_ALLOWED_KEYS`` are honored; any
+    other key in the file is ignored so an untrusted repo file cannot influence
+    auth or backend routing.
     """
     project_dir = Path(cwd or os.environ.get("CLAUDE_CWD") or os.getcwd())
     picker_path = project_dir / ".cognee" / "session-config.json"
@@ -123,11 +137,18 @@ def _read_project_picker(cwd: Optional[str] = None) -> dict:
         return {}
     if not isinstance(data, dict):
         return {}
-    # Only non-null AND non-empty-string values fall through — matches the
-    # existing config-file layer's semantics (line 112: `v is not None and v != ""`)
-    # so an explicit `{"dataset": null}` or `{"dataset": ""}` cleanly no-ops
-    # instead of resolving to an empty dataset name downstream.
-    return {k: v for k, v in data.items() if v is not None and v != ""}
+    # Only allowlisted, non-null AND non-empty-string values fall through — the
+    # empty/null check matches the config-file layer's semantics (line 112:
+    # `v is not None and v != ""`) so an explicit `{"dataset": null}` or
+    # `{"dataset": ""}` cleanly no-ops instead of resolving to an empty name.
+    ignored = [k for k in data if k not in _PICKER_ALLOWED_KEYS]
+    if ignored:
+        _config_log("session_picker_ignored_keys", {"keys": sorted(ignored)[:20]})
+    return {
+        k: v
+        for k, v in data.items()
+        if k in _PICKER_ALLOWED_KEYS and v is not None and v != ""
+    }
 
 
 def load_config(cwd: Optional[str] = None) -> dict:

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -105,10 +105,16 @@ _ENV_MAP = {
 # and backend routing (api_key, llm_api_key, base_url, backend, user_*) so that
 # merely opening a repo with a `.cognee/session-config.json` can never redirect
 # your Cognee backend or inject credentials — the picker's job is dataset/session
-# selection only (issue #3686: "the dataset configuration key").
+# selection only (issue #3686: "the dataset configuration key"). dataset is the
+# key in use today; the others are accepted for forward-compat with the config
+# system (they map to existing _DEFAULTS / _ENV_MAP entries).
 _PICKER_ALLOWED_KEYS = frozenset(
     {"dataset", "session_strategy", "session_prefix", "agent_name", "top_k"}
 )
+# A picker file is committed to a repo, so it is untrusted input: cap the size
+# we are willing to read (a dataset picker is a few bytes; anything larger is a
+# mistake or a self-DoS via a symlink to a huge/endless file).
+_PICKER_MAX_BYTES = 64 * 1024
 
 
 def _read_project_picker(cwd: Optional[str] = None) -> dict:
@@ -119,18 +125,23 @@ def _read_project_picker(cwd: Optional[str] = None) -> dict:
     os.getcwd() (last resort — NOT reliable inside a global-plugin hook
     process, kept only as a final fallback).
 
-    Only the non-sensitive keys in ``_PICKER_ALLOWED_KEYS`` are honored; any
-    other key in the file is ignored so an untrusted repo file cannot influence
-    auth or backend routing.
+    The file is untrusted (it ships in whatever repo you open), so this fails
+    safe: symlinks and oversized/unreadable/malformed files all fall through to
+    the lower config layers instead of raising into the hook. Only the
+    non-sensitive keys in ``_PICKER_ALLOWED_KEYS`` are honored, so a repo file
+    cannot influence auth or backend routing.
     """
     project_dir = Path(cwd or os.environ.get("CLAUDE_CWD") or os.getcwd())
     picker_path = project_dir / ".cognee" / "session-config.json"
 
-    if not picker_path.exists():
-        return {}
     try:
+        if picker_path.is_symlink() or not picker_path.is_file():
+            return {}
+        if picker_path.stat().st_size > _PICKER_MAX_BYTES:
+            _config_log("session_picker_too_large", {"path": str(picker_path)})
+            return {}
         data = json.loads(picker_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
+    except Exception as exc:
         _config_log(
             "session_picker_load_failed", {"path": str(picker_path), "error": str(exc)[:200]}
         )
@@ -138,16 +149,14 @@ def _read_project_picker(cwd: Optional[str] = None) -> dict:
     if not isinstance(data, dict):
         return {}
     # Only allowlisted, non-null AND non-empty-string values fall through — the
-    # empty/null check matches the config-file layer's semantics (line 112:
-    # `v is not None and v != ""`) so an explicit `{"dataset": null}` or
-    # `{"dataset": ""}` cleanly no-ops instead of resolving to an empty name.
+    # empty/null check matches the config-file layer's semantics (`v is not None
+    # and v != ""`) so an explicit `{"dataset": null}` or `{"dataset": ""}`
+    # cleanly no-ops instead of resolving to an empty name.
     ignored = [k for k in data if k not in _PICKER_ALLOWED_KEYS]
     if ignored:
         _config_log("session_picker_ignored_keys", {"keys": sorted(ignored)[:20]})
     return {
-        k: v
-        for k, v in data.items()
-        if k in _PICKER_ALLOWED_KEYS and v is not None and v != ""
+        k: v for k, v in data.items() if k in _PICKER_ALLOWED_KEYS and v is not None and v != ""
     }
 
 

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -101,8 +101,37 @@ _ENV_MAP = {
 }
 
 
-def load_config() -> dict:
-    """Load merged config: defaults → file → env vars."""
+def _read_project_picker(cwd: Optional[str] = None) -> dict:
+    """Read .cognee/session-config.json from the project directory.
+
+    Resolution order for the project root: explicit cwd arg (from a hook's
+    payload) > CLAUDE_CWD env (background workers with no payload) >
+    os.getcwd() (last resort — NOT reliable inside a global-plugin hook
+    process, kept only as a final fallback).
+    """
+    project_dir = Path(cwd or os.environ.get("CLAUDE_CWD") or os.getcwd())
+    picker_path = project_dir / ".cognee" / "session-config.json"
+
+    if not picker_path.exists():
+        return {}
+    try:
+        data = json.loads(picker_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        _config_log(
+            "session_picker_load_failed", {"path": str(picker_path), "error": str(exc)[:200]}
+        )
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    # Only non-null AND non-empty-string values fall through — matches the
+    # existing config-file layer's semantics (line 112: `v is not None and v != ""`)
+    # so an explicit `{"dataset": null}` or `{"dataset": ""}` cleanly no-ops
+    # instead of resolving to an empty dataset name downstream.
+    return {k: v for k, v in data.items() if v is not None and v != ""}
+
+
+def load_config(cwd: Optional[str] = None) -> dict:
+    """Load merged config: defaults → file → project picker → env vars."""
     config = dict(_DEFAULTS)
 
     # Layer 2: config file
@@ -126,7 +155,10 @@ def load_config() -> dict:
                 "config_file_load_failed", {"path": str(_CONFIG_FILE), "error": str(exc)[:200]}
             )
 
-    # Layer 3: env vars (highest priority)
+    # Layer 3: project-level picker (.cognee/session-config.json)
+    config.update(_read_project_picker(cwd))
+
+    # Layer 4: env vars (highest priority)
     for env_key, config_key in _ENV_MAP.items():
         val = os.environ.get(env_key, "")
         if val:

--- a/integrations/claude-code/scripts/pre-compact.py
+++ b/integrations/claude-code/scripts/pre-compact.py
@@ -32,14 +32,14 @@ _TRACE_TOP_K = 8
 _GRAPH_TOP_K = 3
 
 
-def _load_resolved_fields() -> tuple[str, str]:
+def _load_resolved_fields(cwd: str = "") -> tuple[str, str]:
     """Return (session_id, dataset) from resolved cache or config."""
     resolved = load_resolved()
     session_id = resolved.get("session_id", "")
     dataset = resolved.get("dataset", "")
     if not session_id or not dataset:
-        config = load_config()
-        session_id = session_id or get_session_id(config)
+        config = load_config(cwd)
+        session_id = session_id or get_session_id(config, cwd)
         dataset = dataset or get_dataset(config)
     return session_id, dataset
 
@@ -136,13 +136,13 @@ def _format_graph_section(entries: list) -> str:
     return "\n".join(lines) if len(lines) > 1 else ""
 
 
-async def _run():
-    session_id, dataset = _load_resolved_fields()
+async def _run(cwd: str = ""):
+    session_id, dataset = _load_resolved_fields(cwd)
     if not session_id:
         hook_log("no_session_id", {"event": "precompact"})
         return
 
-    config = load_config()
+    config = load_config(cwd)
     await ensure_cognee_ready(config)
 
     # Short queries: use the session's recent activity as the seed
@@ -245,8 +245,9 @@ def main():
     if session_key_candidate:
         set_session_key(session_key_candidate)
 
+    cwd = str(payload.get("cwd") or "")
     try:
-        asyncio.run(_run())
+        asyncio.run(_run(cwd))
     except Exception as exc:
         hook_log("precompact_run_exception", {"error": str(exc)[:200]})
 

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -1010,8 +1010,8 @@ async def _run_bootstrap(bootstrap: dict) -> None:
          booted, because registration is per-session (the connection handle is
          the Cognee session id) under the single principal.
     """
-    config = load_config()
-    cwd = str(bootstrap.get("cwd") or os.getcwd())
+    cwd = str(bootstrap.get("cwd") or os.environ.get("CLAUDE_CWD") or os.getcwd())
+    config = load_config(cwd)
     session_id = str(bootstrap.get("session_id", "") or "")
     session_key = str(bootstrap.get("session_key", "") or "")
     dataset = str(bootstrap.get("dataset", "") or get_dataset(config))
@@ -1238,9 +1238,9 @@ def _apply_update_nudge(output: dict) -> dict:
 
 async def _start(payload: dict | None = None) -> dict:
     _ensure_statusline_configured()
-    config = load_config()
     payload = payload or {}
     cwd = str(payload.get("cwd") or os.environ.get("CLAUDE_CWD") or os.getcwd())
+    config = load_config(cwd)
     # The service URL is the sole router (api_key is optional auth, with a
     # default-user fallback in registration). COGNEE_AGENT_MODE is NOT decided
     # here: it's set only when we actually boot a server (in

--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -113,15 +113,15 @@ def _infer_status(payload: dict) -> tuple[str, str]:
     return "success", ""
 
 
-def _load_session() -> tuple[str, str, str]:
+def _load_session(cwd: str = "") -> tuple[str, str, str]:
     """Load session_id, dataset, user_id from resolved cache with fallbacks."""
     resolved = load_resolved()
     session_id = resolved.get("session_id", "")
     dataset = resolved.get("dataset", "")
     user_id = resolved.get("user_id", "")
     if not session_id or not dataset:
-        config = load_config()
-        session_id = session_id or get_session_id(config)
+        config = load_config(cwd)
+        session_id = session_id or get_session_id(config, cwd)
         dataset = dataset or get_dataset(config)
     return session_id, dataset, user_id
 
@@ -155,12 +155,13 @@ async def _store_tool_call(payload: dict) -> None:
 
     return_value = _truncate_str(tool_output, _MAX_RETURN_BYTES)
 
-    session_id, dataset, user_id = _load_session()
+    cwd = str(payload.get("cwd") or "")
+    session_id, dataset, user_id = _load_session(cwd)
     if not session_id:
         hook_log("no_session_id", {"tool": tool_name})
         return
 
-    config = load_config()
+    config = load_config(cwd)
     runtime = resolve_runtime_mode()
     use_http = runtime["mode"] == "http"
     hook_log(
@@ -270,12 +271,13 @@ async def _store_assistant_stop(payload: dict) -> None:
 
     msg = _truncate_str(msg, _MAX_ASSISTANT_BYTES)
 
-    session_id, dataset, user_id = _load_session()
+    cwd = str(payload.get("cwd") or "")
+    session_id, dataset, user_id = _load_session(cwd)
     if not session_id:
         hook_log("no_session_id", {"event": "stop"})
         return
 
-    config = load_config()
+    config = load_config(cwd)
     runtime = resolve_runtime_mode()
     use_http = runtime["mode"] == "http"
     hook_log(

--- a/integrations/claude-code/scripts/store-user-prompt.py
+++ b/integrations/claude-code/scripts/store-user-prompt.py
@@ -43,14 +43,14 @@ _WATCHER_STOP = _STATE_DIR / "watcher.stop"
 _WATCHER_SCRIPT = Path(__file__).with_name("idle-watcher.py")
 
 
-def _load_session() -> tuple[str, str, str]:
+def _load_session(cwd: str = "") -> tuple[str, str, str]:
     resolved = load_resolved()
     session_id = resolved.get("session_id", "")
     dataset = resolved.get("dataset", "")
     user_id = resolved.get("user_id", "")
     if not session_id or not dataset:
-        config = load_config()
-        session_id = session_id or get_session_id(config)
+        config = load_config(cwd)
+        session_id = session_id or get_session_id(config, cwd)
         dataset = dataset or get_dataset(config)
     return session_id, dataset, user_id
 
@@ -126,12 +126,13 @@ def _prompt_context(payload: dict) -> str:
 
 
 async def _store(prompt: str, payload: dict):
-    session_id, dataset, user_id = _load_session()
+    cwd = str(payload.get("cwd") or "")
+    session_id, dataset, user_id = _load_session(cwd)
     if not session_id:
         hook_log("no_session_id", {"event": "prompt"})
         return
 
-    config = load_config()
+    config = load_config(cwd)
     touch_activity()
     _ensure_idle_watcher(session_id, dataset, user_id, config)
 

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -189,7 +189,7 @@ def _is_session_end_payload(payload_raw: str) -> bool:
     return event == "SessionEnd" or _contains_session_end(payload)
 
 
-def _load_resolved() -> tuple:
+def _load_resolved(cwd: str = "") -> tuple:
     """
     Load session ID, dataset, user ID,
     agent session name, registration marker, and API key marker.
@@ -226,8 +226,8 @@ def _load_resolved() -> tuple:
             session_key,
         )
 
-    config = load_config()
-    fallback_session_id = get_session_id(config)
+    config = load_config(cwd)
+    fallback_session_id = get_session_id(config, cwd)
     fallback_agent_session_name = session_key or ""
     if env_service_url:
         os.environ["COGNEE_BASE_URL"] = env_service_url
@@ -242,9 +242,11 @@ def _load_resolved() -> tuple:
     )
 
 
-async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: bool = False):
+async def _sync(
+    stop_watcher: bool, unregister_on_finish: bool = False, strict: bool = False, cwd: str = ""
+):
     session_id, dataset, user_id, agent_session_name, was_registered, has_api_key, session_key = (
-        _load_resolved()
+        _load_resolved(cwd)
     )
     target_sessions = [session_id] if session_id else []
     hook_log(
@@ -263,7 +265,7 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: 
             _stop_idle_watcher()
             hook_log("sync_stopped_watcher", {"session": session_id, "dataset": dataset})
 
-        config = load_config()
+        config = load_config(cwd)
         api_mode = http_api_ready()
         lock = nullcontext(True) if api_mode else sync_lock("sync-session-to-graph")
         with lock as acquired:
@@ -363,6 +365,7 @@ def main():
     detached_final = _DETACHED_ARG in sys.argv
     forced_session_end = _SESSION_END_ARG in sys.argv
     payload_raw = "" if detached_final else sys.stdin.read()
+    payload = {}
     if not detached_final and payload_raw.strip():
         try:
             payload = json.loads(payload_raw)
@@ -372,6 +375,8 @@ def main():
         if session_key_candidate:
             set_session_key(session_key_candidate)
         hook_log("sync_session_key", {"source": session_key_source, "value": session_key_candidate})
+    
+    cwd = str(payload.get("cwd") or "")
     is_session_end = forced_session_end or _is_session_end_payload(payload_raw)
     hook_log(
         "sync_payload",
@@ -426,6 +431,7 @@ def main():
                     # The detached-final run is the session's last sync: an
                     # incomplete result raises so this loop retries it.
                     strict=detached_final,
+                    cwd=cwd,
                 )
             )
             return

--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -76,12 +76,30 @@ def _stop_idle_watcher() -> None:
             hook_log("watcher_sigterm_failed", {"error": str(exc)[:200]})
 
 
-def _spawn_detached_sync() -> bool:
-    """Run the expensive sync outside a short hook window."""
+def _spawn_detached_sync(cwd: str = "") -> bool:
+    """Run the expensive sync outside a short hook window.
+
+    The detached worker gets no stdin payload, so it can't recover the project
+    ``cwd`` on its own. Propagate it (and the picker-resolved dataset) via env so
+    the final session-end flush targets the dataset the project picked, not the
+    global default — otherwise a ``.cognee/session-config.json`` dataset would be
+    honored all session and then silently dropped at the final sync.
+    """
     try:
         env = os.environ.copy()
         env.setdefault("COGNEE_SYNC_START_DELAY", str(_SESSION_END_START_DELAY_DEFAULT))
         env["COGNEE_UNREGISTER_ON_FINISH"] = "1"
+        if cwd:
+            env["CLAUDE_CWD"] = cwd
+        # Resolve the active (picker-aware) dataset now, while cwd is known, and
+        # pin it for the detached worker. setdefault so an explicit
+        # COGNEE_SYNC_DATASET from an upstream spawner still wins.
+        try:
+            picked_dataset = str(get_dataset(load_config(cwd)) or "").strip()
+            if picked_dataset:
+                env.setdefault("COGNEE_SYNC_DATASET", picked_dataset)
+        except Exception as exc:
+            hook_log("sync_detach_dataset_resolve_failed", {"error": str(exc)[:200]})
         subprocess.Popen(
             [sys.executable, str(Path(__file__).resolve()), _DETACHED_ARG],
             cwd=os.getcwd(),
@@ -375,7 +393,7 @@ def main():
         if session_key_candidate:
             set_session_key(session_key_candidate)
         hook_log("sync_session_key", {"source": session_key_source, "value": session_key_candidate})
-    
+
     cwd = str(payload.get("cwd") or "")
     is_session_end = forced_session_end or _is_session_end_payload(payload_raw)
     hook_log(
@@ -410,7 +428,7 @@ def main():
     # there prevents later idle persistence.
     if is_session_end:
         _stop_idle_watcher()
-        spawned = _spawn_detached_sync()
+        spawned = _spawn_detached_sync(cwd)
         hook_log("sync_deferred_to_shutdown_worker", {"spawned": spawned})
         return
 

--- a/integrations/claude-code/tests/test_session_picker.py
+++ b/integrations/claude-code/tests/test_session_picker.py
@@ -1,0 +1,129 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts directory to path to allow importing config
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import config
+
+
+@pytest.fixture(autouse=True)
+def setup_teardown(monkeypatch, tmp_path):
+    # Mock home directory to isolate global config
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    
+    # Reload DEFAULTS to reset state just in case
+    config._CONFIG_DIR = home / ".cognee-plugin" / "claude-code"
+    config._CONFIG_FILE = config._CONFIG_DIR / "config.json"
+    
+    # Ensure no relevant env vars are set
+    for env_var in list(os.environ.keys()):
+        if env_var.startswith("COGNEE_") or env_var == "CLAUDE_CWD":
+            monkeypatch.delenv(env_var, raising=False)
+
+
+def write_picker(cwd_path: Path, data):
+    cognee_dir = cwd_path / ".cognee"
+    cognee_dir.mkdir(parents=True, exist_ok=True)
+    picker_file = cognee_dir / "session-config.json"
+    if isinstance(data, str):
+        picker_file.write_text(data, encoding="utf-8")
+    else:
+        picker_file.write_text(json.dumps(data), encoding="utf-8")
+
+
+def write_global_config(data):
+    config._CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    config._CONFIG_FILE.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_picker_resolves_via_explicit_cwd_arg(tmp_path):
+    write_picker(tmp_path, {"dataset": "picker-dataset"})
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "picker-dataset"
+
+
+def test_picker_resolves_via_claude_cwd_env_fallback(monkeypatch, tmp_path):
+    write_picker(tmp_path, {"dataset": "picker-env-dataset"})
+    monkeypatch.setenv("CLAUDE_CWD", str(tmp_path))
+    
+    # mock os.getcwd to somewhere else to ensure CLAUDE_CWD is preferred
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    monkeypatch.chdir(other_dir)
+    
+    cfg = config.load_config()
+    assert cfg.get("dataset") == "picker-env-dataset"
+
+
+def test_picker_falls_back_to_os_getcwd_last(monkeypatch, tmp_path):
+    write_picker(tmp_path, {"dataset": "picker-cwd-dataset"})
+    monkeypatch.chdir(tmp_path)
+    
+    cfg = config.load_config()
+    assert cfg.get("dataset") == "picker-cwd-dataset"
+
+
+def test_precedence_env_beats_picker(tmp_path, monkeypatch):
+    write_picker(tmp_path, {"dataset": "picker-dataset"})
+    monkeypatch.setenv("COGNEE_PLUGIN_DATASET", "env-dataset")
+    
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "env-dataset"
+
+
+def test_precedence_picker_beats_global_config(tmp_path):
+    write_global_config({"dataset": "global-dataset"})
+    write_picker(tmp_path, {"dataset": "picker-dataset"})
+    
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "picker-dataset"
+
+
+def test_precedence_config_beats_default(tmp_path):
+    write_global_config({"dataset": "global-dataset"})
+    
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "global-dataset"
+
+
+def test_missing_picker_file_falls_through_cleanly(tmp_path):
+    # No .cognee dir at all
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "agent_sessions"
+
+
+def test_malformed_json_picker_falls_through(tmp_path):
+    write_picker(tmp_path, "{invalid_json:")
+    
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "agent_sessions"
+
+
+def test_null_dataset_value_falls_through(tmp_path):
+    write_global_config({"dataset": "global-dataset"})
+    write_picker(tmp_path, {"dataset": None})
+    
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "global-dataset"
+
+
+def test_empty_string_dataset_falls_through(tmp_path):
+    write_global_config({"dataset": "global-dataset"})
+    write_picker(tmp_path, {"dataset": ""})
+    
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "global-dataset"
+
+
+def test_picker_file_is_not_a_dict(tmp_path):
+    write_global_config({"dataset": "global-dataset"})
+    write_picker(tmp_path, ["list", "instead", "of", "dict"])
+    
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "global-dataset"

--- a/integrations/claude-code/tests/test_session_picker.py
+++ b/integrations/claude-code/tests/test_session_picker.py
@@ -1,162 +1,210 @@
+"""Tests for the project-level ``.cognee/session-config.json`` dataset picker.
+
+The picker lets a repo pin its Cognee dataset (and other non-secret selection
+keys) via ``.cognee/session-config.json``, resolved at ``SessionStart``. On
+current ``main`` the effective dataset precedence is ``env > picker > default``
+(the global ``config.json`` deliberately does not drive the dataset). Secrets
+and backend-routing keys in the picker file are never honored.
+
+Fixture-free (like the sibling claude-code tests) so it runs standalone under
+plain ``python3`` as well as ``pytest``.
+
+Run: python integrations/claude-code/tests/test_session_picker.py (or via pytest).
+"""
+
+import contextlib
 import json
 import os
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 
-import pytest
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
 
-# Add scripts directory to path to allow importing config
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-import config
+import config  # noqa: E402
 
-
-@pytest.fixture(autouse=True)
-def setup_teardown(monkeypatch, tmp_path):
-    # Mock home directory to isolate global config
-    home = tmp_path / "home"
-    home.mkdir()
-    monkeypatch.setattr(Path, "home", lambda: home)
-
-    # Reload DEFAULTS to reset state just in case
-    config._CONFIG_DIR = home / ".cognee-plugin" / "claude-code"
-    config._CONFIG_FILE = config._CONFIG_DIR / "config.json"
-
-    # Ensure no relevant env vars are set
-    for env_var in list(os.environ.keys()):
-        if env_var.startswith("COGNEE_") or env_var == "CLAUDE_CWD":
-            monkeypatch.delenv(env_var, raising=False)
+# Every env var load_config reads (plus CLAUDE_CWD), cleared per test so a value
+# in the developer's shell (e.g. a real LLM_API_KEY) can't leak in and make a
+# test non-deterministic.
+_MANAGED_ENV = set(config._ENV_MAP) | {"CLAUDE_CWD"}
+_MANAGED_ATTRS = ("_CONFIG_DIR", "_STATE_DIR", "_CONFIG_FILE", "_HOOK_LOG")
 
 
-def write_picker(cwd_path: Path, data):
-    cognee_dir = cwd_path / ".cognee"
-    cognee_dir.mkdir(parents=True, exist_ok=True)
-    picker_file = cognee_dir / "session-config.json"
-    if isinstance(data, str):
-        picker_file.write_text(data, encoding="utf-8")
-    else:
-        picker_file.write_text(json.dumps(data), encoding="utf-8")
+@contextlib.contextmanager
+def _isolated():
+    """Redirect config's home/state dirs into a temp tree and clear its env vars.
+
+    Yields ``(home, project)`` temp paths and restores config module globals,
+    the environment, and cwd on exit — so tests never touch the real
+    ``~/.cognee-plugin`` (config logging included).
+    """
+    saved_env = {k: os.environ.get(k) for k in _MANAGED_ENV}
+    saved_attrs = {k: getattr(config, k) for k in _MANAGED_ATTRS}
+    saved_cwd = os.getcwd()
+    tmp = tempfile.mkdtemp()
+    try:
+        for k in _MANAGED_ENV:
+            os.environ.pop(k, None)
+        home = Path(tmp) / "home" / ".cognee-plugin" / "claude-code"
+        home.mkdir(parents=True)
+        config._CONFIG_DIR = home
+        config._STATE_DIR = home
+        config._CONFIG_FILE = home / "config.json"
+        config._HOOK_LOG = home / "hook.log"
+        project = Path(tmp) / "project"
+        project.mkdir()
+        yield home, project
+    finally:
+        os.chdir(saved_cwd)
+        for k, v in saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        for k, v in saved_attrs.items():
+            setattr(config, k, v)
+        shutil.rmtree(tmp, ignore_errors=True)
 
 
-def write_global_config(data):
-    config._CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    config._CONFIG_FILE.write_text(json.dumps(data), encoding="utf-8")
+def _write_picker(project: Path, data) -> None:
+    (project / ".cognee").mkdir(parents=True, exist_ok=True)
+    body = data if isinstance(data, str) else json.dumps(data)
+    (project / ".cognee" / "session-config.json").write_text(body, encoding="utf-8")
 
 
-def test_picker_resolves_via_explicit_cwd_arg(tmp_path):
-    write_picker(tmp_path, {"dataset": "picker-dataset"})
-    cfg = config.load_config(cwd=str(tmp_path))
-    assert cfg.get("dataset") == "picker-dataset"
+def _write_global_config(home: Path, data: dict) -> None:
+    (home / "config.json").write_text(json.dumps(data), encoding="utf-8")
 
 
-def test_picker_resolves_via_claude_cwd_env_fallback(monkeypatch, tmp_path):
-    write_picker(tmp_path, {"dataset": "picker-env-dataset"})
-    monkeypatch.setenv("CLAUDE_CWD", str(tmp_path))
-
-    # mock os.getcwd to somewhere else to ensure CLAUDE_CWD is preferred
-    other_dir = tmp_path / "other"
-    other_dir.mkdir()
-    monkeypatch.chdir(other_dir)
-
-    cfg = config.load_config()
-    assert cfg.get("dataset") == "picker-env-dataset"
+# --- resolution of the project root -----------------------------------------
 
 
-def test_picker_falls_back_to_os_getcwd_last(monkeypatch, tmp_path):
-    write_picker(tmp_path, {"dataset": "picker-cwd-dataset"})
-    monkeypatch.chdir(tmp_path)
-
-    cfg = config.load_config()
-    assert cfg.get("dataset") == "picker-cwd-dataset"
+def test_picker_resolves_via_explicit_cwd_arg():
+    with _isolated() as (_home, project):
+        _write_picker(project, {"dataset": "picker-dataset"})
+        assert config.load_config(cwd=str(project)).get("dataset") == "picker-dataset"
 
 
-def test_precedence_env_beats_picker(tmp_path, monkeypatch):
-    write_picker(tmp_path, {"dataset": "picker-dataset"})
-    monkeypatch.setenv("COGNEE_PLUGIN_DATASET", "env-dataset")
-
-    cfg = config.load_config(cwd=str(tmp_path))
-    assert cfg.get("dataset") == "env-dataset"
-
-
-def test_precedence_picker_beats_global_config(tmp_path):
-    write_global_config({"dataset": "global-dataset"})
-    write_picker(tmp_path, {"dataset": "picker-dataset"})
-
-    cfg = config.load_config(cwd=str(tmp_path))
-    assert cfg.get("dataset") == "picker-dataset"
+def test_picker_resolves_via_claude_cwd_env_fallback():
+    with _isolated() as (_home, project):
+        _write_picker(project, {"dataset": "picker-env-dataset"})
+        os.environ["CLAUDE_CWD"] = str(project)  # preferred over os.getcwd()
+        assert config.load_config().get("dataset") == "picker-env-dataset"
 
 
-def test_precedence_config_beats_default(tmp_path):
-    write_global_config({"dataset": "global-dataset"})
-
-    cfg = config.load_config(cwd=str(tmp_path))
-    assert cfg.get("dataset") == "global-dataset"
-
-
-def test_missing_picker_file_falls_through_cleanly(tmp_path):
-    # No .cognee dir at all
-    cfg = config.load_config(cwd=str(tmp_path))
-    assert cfg.get("dataset") == "agent_sessions"
+def test_picker_falls_back_to_os_getcwd_last():
+    with _isolated() as (_home, project):
+        _write_picker(project, {"dataset": "picker-cwd-dataset"})
+        os.chdir(project)
+        assert config.load_config().get("dataset") == "picker-cwd-dataset"
 
 
-def test_malformed_json_picker_falls_through(tmp_path):
-    write_picker(tmp_path, "{invalid_json:")
-
-    cfg = config.load_config(cwd=str(tmp_path))
-    assert cfg.get("dataset") == "agent_sessions"
+# --- precedence --------------------------------------------------------------
 
 
-def test_null_dataset_value_falls_through(tmp_path):
-    write_global_config({"dataset": "global-dataset"})
-    write_picker(tmp_path, {"dataset": None})
-
-    cfg = config.load_config(cwd=str(tmp_path))
-    assert cfg.get("dataset") == "global-dataset"
-
-
-def test_empty_string_dataset_falls_through(tmp_path):
-    write_global_config({"dataset": "global-dataset"})
-    write_picker(tmp_path, {"dataset": ""})
-
-    cfg = config.load_config(cwd=str(tmp_path))
-    assert cfg.get("dataset") == "global-dataset"
+def test_precedence_env_beats_picker():
+    with _isolated() as (_home, project):
+        _write_picker(project, {"dataset": "picker-dataset"})
+        os.environ["COGNEE_PLUGIN_DATASET"] = "env-dataset"
+        assert config.load_config(cwd=str(project)).get("dataset") == "env-dataset"
 
 
-def test_picker_file_is_not_a_dict(tmp_path):
-    write_global_config({"dataset": "global-dataset"})
-    write_picker(tmp_path, ["list", "instead", "of", "dict"])
-
-    cfg = config.load_config(cwd=str(tmp_path))
-    assert cfg.get("dataset") == "global-dataset"
+def test_precedence_picker_beats_default():
+    with _isolated() as (_home, project):
+        _write_picker(project, {"dataset": "picker-dataset"})
+        assert config.load_config(cwd=str(project)).get("dataset") == "picker-dataset"
 
 
-def test_picker_ignores_sensitive_keys(tmp_path):
-    # A repo-committed picker file must not be able to redirect the backend or
-    # inject credentials — only dataset/session selection is honored.
-    write_picker(
-        tmp_path,
-        {
-            "dataset": "picker-dataset",
-            "base_url": "http://evil.example",
-            "api_key": "ck_stolen",
-            "llm_api_key": "sk-stolen",
-            "backend": "server",
-        },
-    )
-    cfg = config.load_config(cwd=str(tmp_path))
-    assert cfg.get("dataset") == "picker-dataset"  # allowlisted key applied
-    assert cfg.get("base_url") == ""  # sensitive keys ignored (default)
-    assert cfg.get("api_key") == ""
-    assert cfg.get("llm_api_key") == ""
+def test_global_config_dataset_is_visibility_only():
+    # main excludes `dataset` from the global config file layer (visibility-only),
+    # so a global config.json dataset does NOT drive the runtime dataset.
+    with _isolated() as (home, project):
+        _write_global_config(home, {"dataset": "global-dataset"})
+        assert config.load_config(cwd=str(project)).get("dataset") == "agent_sessions"
 
 
-def test_picker_honors_allowlisted_nondataset_key(tmp_path):
-    write_picker(tmp_path, {"session_strategy": "git-branch"})
-    cfg = config.load_config(cwd=str(tmp_path))
-    assert cfg.get("session_strategy") == "git-branch"
+# --- fail-safe fallthrough ---------------------------------------------------
 
 
-def test_picker_unknown_key_ignored(tmp_path):
-    write_picker(tmp_path, {"dataset": "picker-dataset", "totally_unknown": "x"})
-    cfg = config.load_config(cwd=str(tmp_path))
-    assert cfg.get("dataset") == "picker-dataset"
-    assert "totally_unknown" not in cfg
+def test_missing_picker_file_falls_through_to_default():
+    with _isolated() as (_home, project):
+        assert config.load_config(cwd=str(project)).get("dataset") == "agent_sessions"
+
+
+def test_malformed_json_picker_falls_through():
+    with _isolated() as (_home, project):
+        _write_picker(project, "{invalid_json:")
+        assert config.load_config(cwd=str(project)).get("dataset") == "agent_sessions"
+
+
+def test_null_dataset_value_falls_through():
+    with _isolated() as (_home, project):
+        _write_picker(project, {"dataset": None})
+        assert config.load_config(cwd=str(project)).get("dataset") == "agent_sessions"
+
+
+def test_empty_string_dataset_falls_through():
+    with _isolated() as (_home, project):
+        _write_picker(project, {"dataset": ""})
+        assert config.load_config(cwd=str(project)).get("dataset") == "agent_sessions"
+
+
+def test_non_dict_picker_falls_through():
+    with _isolated() as (_home, project):
+        _write_picker(project, ["list", "instead", "of", "dict"])
+        assert config.load_config(cwd=str(project)).get("dataset") == "agent_sessions"
+
+
+# --- allowlist ---------------------------------------------------------------
+
+
+def test_picker_ignores_sensitive_keys():
+    # A repo-committed picker file must not redirect the backend or inject
+    # credentials — only non-secret selection keys are honored.
+    with _isolated() as (_home, project):
+        _write_picker(
+            project,
+            {
+                "dataset": "picker-dataset",
+                "base_url": "http://evil.example",
+                "api_key": "ck_stolen",
+                "llm_api_key": "sk-stolen",
+                "backend": "server",
+            },
+        )
+        cfg = config.load_config(cwd=str(project))
+        assert cfg.get("dataset") == "picker-dataset"  # allowlisted key applied
+        assert cfg.get("base_url") == ""  # sensitive keys ignored (defaults)
+        assert cfg.get("api_key") == ""
+        assert cfg.get("llm_api_key") == ""
+        assert cfg.get("backend") == "auto"
+
+
+def test_picker_honors_allowlisted_nondataset_key():
+    with _isolated() as (_home, project):
+        _write_picker(project, {"session_strategy": "git-branch"})
+        assert config.load_config(cwd=str(project)).get("session_strategy") == "git-branch"
+
+
+def test_picker_unknown_key_ignored():
+    with _isolated() as (_home, project):
+        _write_picker(project, {"dataset": "picker-dataset", "totally_unknown": "x"})
+        cfg = config.load_config(cwd=str(project))
+        assert cfg.get("dataset") == "picker-dataset"
+        assert "totally_unknown" not in cfg
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/claude-code/tests/test_session_picker.py
+++ b/integrations/claude-code/tests/test_session_picker.py
@@ -197,6 +197,57 @@ def test_picker_unknown_key_ignored():
         assert "totally_unknown" not in cfg
 
 
+# --- the picked dataset reaches the write path + status line -----------------
+
+
+def test_picker_dataset_reaches_get_dataset():
+    # get_dataset(load_config(cwd)) is the exact resolver the write/recall hooks
+    # use, so this pins the headline acceptance: writes land on the picked dataset.
+    with _isolated() as (_home, project):
+        _write_picker(project, {"dataset": "picker-dataset"})
+        assert config.get_dataset(config.load_config(cwd=str(project))) == "picker-dataset"
+
+
+def test_statusline_shows_picker_dataset():
+    import cognee_statusline_render as statusline
+
+    with _isolated() as (_home, project):
+        _write_picker(project, {"dataset": "picker-dataset"})
+        assert statusline._active_dataset(str(project)) == "picker-dataset"
+        nopicker = project / "sub"
+        nopicker.mkdir()
+        assert statusline._active_dataset(str(nopicker)) == "agent_sessions"
+
+
+# --- untrusted-file hardening ------------------------------------------------
+
+
+def test_invalid_utf8_picker_falls_through():
+    with _isolated() as (_home, project):
+        (project / ".cognee").mkdir(parents=True)
+        (project / ".cognee" / "session-config.json").write_bytes(b'\xff\xfe{"dataset": "x"}')
+        assert config.load_config(cwd=str(project)).get("dataset") == "agent_sessions"
+
+
+def test_oversized_picker_ignored():
+    with _isolated() as (_home, project):
+        _write_picker(project, {"dataset": "picker-dataset", "pad": "A" * (64 * 1024 + 1)})
+        assert config.load_config(cwd=str(project)).get("dataset") == "agent_sessions"
+
+
+def test_symlinked_picker_ignored():
+    with _isolated() as (_home, project):
+        (project / ".cognee").mkdir(parents=True)
+        target = project / "real-config.json"
+        target.write_text(json.dumps({"dataset": "picker-dataset"}), encoding="utf-8")
+        link = project / ".cognee" / "session-config.json"
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):
+            return  # symlinks unsupported (e.g. unprivileged Windows) — skip
+        assert config.load_config(cwd=str(project)).get("dataset") == "agent_sessions"
+
+
 if __name__ == "__main__":
     failures = 0
     for _name, _fn in sorted(globals().items()):

--- a/integrations/claude-code/tests/test_session_picker.py
+++ b/integrations/claude-code/tests/test_session_picker.py
@@ -16,11 +16,11 @@ def setup_teardown(monkeypatch, tmp_path):
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setattr(Path, "home", lambda: home)
-    
+
     # Reload DEFAULTS to reset state just in case
     config._CONFIG_DIR = home / ".cognee-plugin" / "claude-code"
     config._CONFIG_FILE = config._CONFIG_DIR / "config.json"
-    
+
     # Ensure no relevant env vars are set
     for env_var in list(os.environ.keys()):
         if env_var.startswith("COGNEE_") or env_var == "CLAUDE_CWD":
@@ -51,12 +51,12 @@ def test_picker_resolves_via_explicit_cwd_arg(tmp_path):
 def test_picker_resolves_via_claude_cwd_env_fallback(monkeypatch, tmp_path):
     write_picker(tmp_path, {"dataset": "picker-env-dataset"})
     monkeypatch.setenv("CLAUDE_CWD", str(tmp_path))
-    
+
     # mock os.getcwd to somewhere else to ensure CLAUDE_CWD is preferred
     other_dir = tmp_path / "other"
     other_dir.mkdir()
     monkeypatch.chdir(other_dir)
-    
+
     cfg = config.load_config()
     assert cfg.get("dataset") == "picker-env-dataset"
 
@@ -64,7 +64,7 @@ def test_picker_resolves_via_claude_cwd_env_fallback(monkeypatch, tmp_path):
 def test_picker_falls_back_to_os_getcwd_last(monkeypatch, tmp_path):
     write_picker(tmp_path, {"dataset": "picker-cwd-dataset"})
     monkeypatch.chdir(tmp_path)
-    
+
     cfg = config.load_config()
     assert cfg.get("dataset") == "picker-cwd-dataset"
 
@@ -72,7 +72,7 @@ def test_picker_falls_back_to_os_getcwd_last(monkeypatch, tmp_path):
 def test_precedence_env_beats_picker(tmp_path, monkeypatch):
     write_picker(tmp_path, {"dataset": "picker-dataset"})
     monkeypatch.setenv("COGNEE_PLUGIN_DATASET", "env-dataset")
-    
+
     cfg = config.load_config(cwd=str(tmp_path))
     assert cfg.get("dataset") == "env-dataset"
 
@@ -80,14 +80,14 @@ def test_precedence_env_beats_picker(tmp_path, monkeypatch):
 def test_precedence_picker_beats_global_config(tmp_path):
     write_global_config({"dataset": "global-dataset"})
     write_picker(tmp_path, {"dataset": "picker-dataset"})
-    
+
     cfg = config.load_config(cwd=str(tmp_path))
     assert cfg.get("dataset") == "picker-dataset"
 
 
 def test_precedence_config_beats_default(tmp_path):
     write_global_config({"dataset": "global-dataset"})
-    
+
     cfg = config.load_config(cwd=str(tmp_path))
     assert cfg.get("dataset") == "global-dataset"
 
@@ -100,7 +100,7 @@ def test_missing_picker_file_falls_through_cleanly(tmp_path):
 
 def test_malformed_json_picker_falls_through(tmp_path):
     write_picker(tmp_path, "{invalid_json:")
-    
+
     cfg = config.load_config(cwd=str(tmp_path))
     assert cfg.get("dataset") == "agent_sessions"
 
@@ -108,7 +108,7 @@ def test_malformed_json_picker_falls_through(tmp_path):
 def test_null_dataset_value_falls_through(tmp_path):
     write_global_config({"dataset": "global-dataset"})
     write_picker(tmp_path, {"dataset": None})
-    
+
     cfg = config.load_config(cwd=str(tmp_path))
     assert cfg.get("dataset") == "global-dataset"
 
@@ -116,7 +116,7 @@ def test_null_dataset_value_falls_through(tmp_path):
 def test_empty_string_dataset_falls_through(tmp_path):
     write_global_config({"dataset": "global-dataset"})
     write_picker(tmp_path, {"dataset": ""})
-    
+
     cfg = config.load_config(cwd=str(tmp_path))
     assert cfg.get("dataset") == "global-dataset"
 
@@ -124,6 +124,39 @@ def test_empty_string_dataset_falls_through(tmp_path):
 def test_picker_file_is_not_a_dict(tmp_path):
     write_global_config({"dataset": "global-dataset"})
     write_picker(tmp_path, ["list", "instead", "of", "dict"])
-    
+
     cfg = config.load_config(cwd=str(tmp_path))
     assert cfg.get("dataset") == "global-dataset"
+
+
+def test_picker_ignores_sensitive_keys(tmp_path):
+    # A repo-committed picker file must not be able to redirect the backend or
+    # inject credentials — only dataset/session selection is honored.
+    write_picker(
+        tmp_path,
+        {
+            "dataset": "picker-dataset",
+            "base_url": "http://evil.example",
+            "api_key": "ck_stolen",
+            "llm_api_key": "sk-stolen",
+            "backend": "server",
+        },
+    )
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "picker-dataset"  # allowlisted key applied
+    assert cfg.get("base_url") == ""  # sensitive keys ignored (default)
+    assert cfg.get("api_key") == ""
+    assert cfg.get("llm_api_key") == ""
+
+
+def test_picker_honors_allowlisted_nondataset_key(tmp_path):
+    write_picker(tmp_path, {"session_strategy": "git-branch"})
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("session_strategy") == "git-branch"
+
+
+def test_picker_unknown_key_ignored(tmp_path):
+    write_picker(tmp_path, {"dataset": "picker-dataset", "totally_unknown": "x"})
+    cfg = config.load_config(cwd=str(tmp_path))
+    assert cfg.get("dataset") == "picker-dataset"
+    assert "totally_unknown" not in cfg

--- a/integrations/claude-code/tests/test_sync_picker_propagation.py
+++ b/integrations/claude-code/tests/test_sync_picker_propagation.py
@@ -6,21 +6,34 @@ resolves the picker-aware dataset up front and pins it (plus ``CLAUDE_CWD``) in
 the child's environment. Without this, a ``.cognee/session-config.json`` dataset
 is honored all session and then silently dropped at the final flush.
 
+Fixture-free (like the sibling claude-code tests) so it runs standalone under
+plain ``python3`` as well as ``pytest``.
+
 Run: python integrations/claude-code/tests/test_sync_picker_propagation.py (or via pytest).
 """
 
+import contextlib
 import importlib.util
 import json
 import os
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 
-import pytest
-
 _SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
-sys.path.insert(0, str(_SCRIPTS))
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
 
 import config  # noqa: E402
+
+_MANAGED_ATTRS = ("_CONFIG_DIR", "_STATE_DIR", "_CONFIG_FILE", "_HOOK_LOG")
+
+
+def _is_managed_env(key: str) -> bool:
+    # Everything the picker + detached sync read, incl. COGNEE_SYNC_DATASET
+    # (not in _ENV_MAP), so a value in the developer's shell can't leak in.
+    return key.startswith(("COGNEE_", "LLM_")) or key == "CLAUDE_CWD"
 
 
 def _load_sync_module():
@@ -32,64 +45,87 @@ def _load_sync_module():
     return module
 
 
-@pytest.fixture(autouse=True)
-def isolate(monkeypatch, tmp_path):
-    home = tmp_path / "home"
-    plugin = home / ".cognee-plugin" / "claude-code"
-    plugin.mkdir(parents=True)
-    monkeypatch.setattr(Path, "home", lambda: home)
-    monkeypatch.setattr(config, "_CONFIG_DIR", plugin)
-    monkeypatch.setattr(config, "_STATE_DIR", plugin)
-    monkeypatch.setattr(config, "_CONFIG_FILE", plugin / "config.json")
-    monkeypatch.setattr(config, "_HOOK_LOG", plugin / "hook.log")
-    for key in list(os.environ.keys()):
-        if key.startswith("COGNEE_") or key == "CLAUDE_CWD":
-            monkeypatch.delenv(key, raising=False)
+@contextlib.contextmanager
+def _isolated():
+    """Redirect config's home/state dirs into a temp tree and clear its env vars.
+
+    Yields the project temp path; restores config globals, env, and cwd on exit.
+    """
+    saved_env = {k: v for k, v in os.environ.items() if _is_managed_env(k)}
+    saved_attrs = {k: getattr(config, k) for k in _MANAGED_ATTRS}
+    tmp = tempfile.mkdtemp()
+    try:
+        for k in [k for k in os.environ if _is_managed_env(k)]:
+            os.environ.pop(k, None)
+        home = Path(tmp) / "home" / ".cognee-plugin" / "claude-code"
+        home.mkdir(parents=True)
+        config._CONFIG_DIR = home
+        config._STATE_DIR = home
+        config._CONFIG_FILE = home / "config.json"
+        config._HOOK_LOG = home / "hook.log"
+        project = Path(tmp) / "project"
+        project.mkdir()
+        yield project
+    finally:
+        for k in [k for k in os.environ if _is_managed_env(k)]:
+            os.environ.pop(k, None)
+        os.environ.update(saved_env)
+        for k, v in saved_attrs.items():
+            setattr(config, k, v)
+        shutil.rmtree(tmp, ignore_errors=True)
 
 
-def _write_picker(project: Path, data: dict):
+def _write_picker(project: Path, data: dict) -> None:
     (project / ".cognee").mkdir(parents=True, exist_ok=True)
     (project / ".cognee" / "session-config.json").write_text(json.dumps(data), encoding="utf-8")
 
 
-def test_detached_sync_pins_picked_dataset(monkeypatch, tmp_path):
-    project = tmp_path / "proj"
-    project.mkdir()
-    _write_picker(project, {"dataset": "picker-dataset"})
-
-    sync = _load_sync_module()
+@contextlib.contextmanager
+def _captured_spawn(sync):
+    """Stub the module's subprocess.Popen and capture the env it was launched with."""
     captured = {}
+    original = sync.subprocess.Popen
 
     class _FakePopen:
         def __init__(self, *args, **kwargs):
             captured["env"] = kwargs.get("env", {})
 
-    monkeypatch.setattr(sync.subprocess, "Popen", _FakePopen)
+    sync.subprocess.Popen = _FakePopen
+    try:
+        yield captured
+    finally:
+        sync.subprocess.Popen = original
 
-    assert sync._spawn_detached_sync(str(project)) is True
-    assert captured["env"].get("COGNEE_SYNC_DATASET") == "picker-dataset"
-    assert captured["env"].get("CLAUDE_CWD") == str(project)
+
+def test_detached_sync_pins_picked_dataset():
+    with _isolated() as project:
+        _write_picker(project, {"dataset": "picker-dataset"})
+        sync = _load_sync_module()
+        with _captured_spawn(sync) as captured:
+            assert sync._spawn_detached_sync(str(project)) is True
+        assert captured["env"].get("COGNEE_SYNC_DATASET") == "picker-dataset"
+        assert captured["env"].get("CLAUDE_CWD") == str(project)
 
 
-def test_detached_sync_does_not_override_explicit_dataset(monkeypatch, tmp_path):
-    project = tmp_path / "proj"
-    project.mkdir()
-    _write_picker(project, {"dataset": "picker-dataset"})
-    # An upstream spawner already pinned a dataset — it must win (setdefault).
-    monkeypatch.setenv("COGNEE_SYNC_DATASET", "explicit-dataset")
-
-    sync = _load_sync_module()
-    captured = {}
-
-    class _FakePopen:
-        def __init__(self, *args, **kwargs):
-            captured["env"] = kwargs.get("env", {})
-
-    monkeypatch.setattr(sync.subprocess, "Popen", _FakePopen)
-
-    assert sync._spawn_detached_sync(str(project)) is True
-    assert captured["env"].get("COGNEE_SYNC_DATASET") == "explicit-dataset"
+def test_detached_sync_does_not_override_explicit_dataset():
+    with _isolated() as project:
+        _write_picker(project, {"dataset": "picker-dataset"})
+        # An upstream spawner already pinned a dataset — it must win (setdefault).
+        os.environ["COGNEE_SYNC_DATASET"] = "explicit-dataset"
+        sync = _load_sync_module()
+        with _captured_spawn(sync) as captured:
+            assert sync._spawn_detached_sync(str(project)) is True
+        assert captured["env"].get("COGNEE_SYNC_DATASET") == "explicit-dataset"
 
 
 if __name__ == "__main__":
-    sys.exit(pytest.main([__file__, "-q"]))
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/claude-code/tests/test_sync_picker_propagation.py
+++ b/integrations/claude-code/tests/test_sync_picker_propagation.py
@@ -1,0 +1,95 @@
+"""The detached session-end sync must honor the project dataset picker.
+
+The final sync runs in a detached worker with no stdin payload, so it can't
+recover the project ``cwd`` itself. ``_spawn_detached_sync(cwd)`` therefore
+resolves the picker-aware dataset up front and pins it (plus ``CLAUDE_CWD``) in
+the child's environment. Without this, a ``.cognee/session-config.json`` dataset
+is honored all session and then silently dropped at the final flush.
+
+Run: python integrations/claude-code/tests/test_sync_picker_propagation.py (or via pytest).
+"""
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+import config  # noqa: E402
+
+
+def _load_sync_module():
+    spec = importlib.util.spec_from_file_location(
+        "sync_session_to_graph", str(_SCRIPTS / "sync-session-to-graph.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def isolate(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    plugin = home / ".cognee-plugin" / "claude-code"
+    plugin.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr(config, "_CONFIG_DIR", plugin)
+    monkeypatch.setattr(config, "_STATE_DIR", plugin)
+    monkeypatch.setattr(config, "_CONFIG_FILE", plugin / "config.json")
+    monkeypatch.setattr(config, "_HOOK_LOG", plugin / "hook.log")
+    for key in list(os.environ.keys()):
+        if key.startswith("COGNEE_") or key == "CLAUDE_CWD":
+            monkeypatch.delenv(key, raising=False)
+
+
+def _write_picker(project: Path, data: dict):
+    (project / ".cognee").mkdir(parents=True, exist_ok=True)
+    (project / ".cognee" / "session-config.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_detached_sync_pins_picked_dataset(monkeypatch, tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    _write_picker(project, {"dataset": "picker-dataset"})
+
+    sync = _load_sync_module()
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, *args, **kwargs):
+            captured["env"] = kwargs.get("env", {})
+
+    monkeypatch.setattr(sync.subprocess, "Popen", _FakePopen)
+
+    assert sync._spawn_detached_sync(str(project)) is True
+    assert captured["env"].get("COGNEE_SYNC_DATASET") == "picker-dataset"
+    assert captured["env"].get("CLAUDE_CWD") == str(project)
+
+
+def test_detached_sync_does_not_override_explicit_dataset(monkeypatch, tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    _write_picker(project, {"dataset": "picker-dataset"})
+    # An upstream spawner already pinned a dataset — it must win (setdefault).
+    monkeypatch.setenv("COGNEE_SYNC_DATASET", "explicit-dataset")
+
+    sync = _load_sync_module()
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, *args, **kwargs):
+            captured["env"] = kwargs.get("env", {})
+
+    monkeypatch.setattr(sync.subprocess, "Popen", _FakePopen)
+
+    assert sync._spawn_detached_sync(str(project)) is True
+    assert captured["env"].get("COGNEE_SYNC_DATASET") == "explicit-dataset"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/integrations/claude-code/tests/test_sync_strict.py
+++ b/integrations/claude-code/tests/test_sync_strict.py
@@ -36,8 +36,9 @@ def _stub(wrote, *, unregister_calls=None):
         )
     }
     # (session_id, dataset, user_id, agent_session_name, was_registered, has_api_key, session_key)
-    m._load_resolved = lambda: ("sess1", "ds", "u1", "agent1", True, True, "key1")
-    m.load_config = lambda: {}
+    # cwd kwarg: _sync now threads the picker cwd into _load_resolved/load_config.
+    m._load_resolved = lambda cwd="": ("sess1", "ds", "u1", "agent1", True, True, "key1")
+    m.load_config = lambda cwd="": {}
     m.http_api_ready = lambda: True
     m.run_session_improve = lambda d, s: wrote
     m.unregister_agent_via_http = lambda **k: (


### PR DESCRIPTION
## What & why

Adds a project-level `.cognee/session-config.json` dataset picker to the Claude Code plugin (GitHub hackathon issue topoteretes/cognee#3686). A repo can pin its Cognee dataset by committing:

```json
{ "dataset": "my-project-memory" }
```

which is resolved at `SessionStart` and honored by every dataset-resolving hook, the status line, and the detached session-end final sync. Dataset precedence is **`COGNEE_PLUGIN_DATASET` (env) > project picker > default** — no need to export an env var in every terminal, and no mid-session switching (the safe subset of WS4). Implements topoteretes/cognee#3686.

## How it works

- `load_config(cwd)` gains a picker layer between the global config file and env vars. `_read_project_picker(cwd)` resolves the project root as `cwd` (hook payload) > `CLAUDE_CWD` (background workers) > `os.getcwd()`.
- **Allowlist:** the picker honors only non-secret selection keys (`dataset`, `session_strategy`, `session_prefix`, `agent_name`, `top_k`). Secrets / backend routing (`api_key`, `llm_api_key`, `base_url`, `backend`, `user_*`) are ignored, so opening an untrusted repo that ships a picker file can never redirect the Cognee backend or inject credentials.
- Runtime state on `main` is HTTP-derived and carries no `dataset` key, so every write-side hook re-resolves via `load_config()` on each run — the picker `cwd` is therefore threaded through all of them, so the picker governs where session data is actually written.
- The detached final sync has no stdin payload, so `_spawn_detached_sync(cwd)` pins `CLAUDE_CWD` and the picker-resolved `COGNEE_SYNC_DATASET` (via `setdefault`, so an upstream spawner still wins) — otherwise the last flush would target the global default instead of the picked dataset.

## Attribution & rework

Built on the two commits from the original PR #185 by @wiz-abhi (preserved as-is — thank you for the contribution). They were cherry-picked onto current `main` and reconciled with base-skew: upstream had rewritten the status-line renderer, added a `strict` param to `_sync`, and made the global `config.json` dataset visibility-only (`_file_excluded={"dataset"}`). Maintainer improvements land as separate single-concern commits:

1. **`test`** — Four picker tests asserted a global-`config.json` dataset value that current `main` intentionally ignores, so they failed on rebase; retargeted them to main's real precedence (`env > picker > default`). Rewrote both test files from the lone pytest-`monkeypatch`/`tmp_path` style to the plain-python sibling convention (fixture-free, `tempfile` + save/restore, `__main__` runner) so they run standalone under `python3` (as `plugin-windows-tests.yml` invokes tests) as well as `pytest`; also fixed a fixture that leaked a real `LLM_API_KEY` into an assertion and wrote `hook.log` lines into the real `~/.cognee-plugin`.
2. **`fix`** — Made the picker reader fail-safe (broadened the narrow `except (JSONDecodeError, OSError)` so bad UTF-8 / out-of-range JSON numbers fall through to the lower layers instead of raising into the hook) and bounded (skip symlinks, cap at 64 KiB) so a committed picker symlinked to `/dev/zero` or a huge file can't hang or OOM every hook + the status line. Applied to both the `config.py` reader and the standalone status-line renderer. Also collapses a comprehension so `ruff format --check` (the sole CI gate for these dirs) passes.
3. **`test`** — Added acceptance coverage: the picked dataset reaches `get_dataset` (the exact write-path resolver) and the status line, plus the fail-safe / oversize / symlink hardening.
4. **`test`** — Updated `test_sync_strict`'s doubles for `_sync`'s new `cwd` parameter (they were 0-arg lambdas and started raising `TypeError`).

## Verification

- `ruff check` + `ruff format --check integrations/` clean (root config, line-length 100).
- Picker suites — `test_session_picker.py` (19) and `test_sync_picker_propagation.py` (2) — pass standalone (`python3 tests/test_*.py`) and under `pytest`.
- Full `claude-code` suite green except `test_bridge_poll` / `test_improve_sync`, which fail identically on `main` (pre-existing urllib test-double drift, unrelated to this change).

_Base branch: `main` — cognee-integrations has no `dev` branch._

Linear: SDK-304
