### PR TITLE
fix(claude-code): preserve sync errors during cleanup

### DIFF
--- a/integrations/claude-code/scripts/sync-session-to-graph.py
+++ b/integrations/claude-code/scripts/sync-session-to-graph.py
@@ -344,19 +344,19 @@ async def _sync(stop_watcher: bool, unregister_on_finish: bool = False, strict: 
                         "agent_unregister_skipped_no_session_name",
                         {"session": session_id, "dataset": dataset},
                     )
-                    return
-                ok, active = unregister_agent_via_http(agent_session_name=unregister_name)
-                hook_log(
-                    "agent_unregister_result",
-                    {
-                        "session": session_id,
-                        "dataset": dataset,
-                        "agent_session_name": unregister_name,
-                        "ok": ok,
-                        "active_agents": active,
-                        "cached_registered": was_registered,
-                    },
-                )
+                else:
+                    ok, active = unregister_agent_via_http(agent_session_name=unregister_name)
+                    hook_log(
+                        "agent_unregister_result",
+                        {
+                            "session": session_id,
+                            "dataset": dataset,
+                            "agent_session_name": unregister_name,
+                            "ok": ok,
+                            "active_agents": active,
+                            "cached_registered": was_registered,
+                        },
+                    )
 
 
 def main():

--- a/integrations/claude-code/tests/test_sync_strict.py
+++ b/integrations/claude-code/tests/test_sync_strict.py
@@ -96,6 +96,19 @@ def test_unregister_still_runs_when_strict_raises():
         restore()
 
 
+def test_missing_unregister_name_does_not_swallow_strict_error():
+    restore = _stub(wrote=False)
+    m._load_resolved = lambda: ("sess1", "ds", "u1", "", True, True, "")
+    try:
+        try:
+            asyncio.run(m._sync(stop_watcher=False, unregister_on_finish=True, strict=True))
+            raise AssertionError("expected RuntimeError for incomplete strict sync")
+        except RuntimeError:
+            pass
+    finally:
+        restore()
+
+
 if __name__ == "__main__":
     failures = 0
     for _name, _fn in sorted(globals().items()):


### PR DESCRIPTION
Fixes #276

## Summary

- avoid returning from the final-sync cleanup path when no unregister name is available
- preserve strict-sync exceptions while still logging that unregister was skipped
- add regression coverage for the missing-name cleanup path

## Tests

- `python3 -m pytest integrations/claude-code/tests/test_sync_strict.py -q`
- `python3 -W error::SyntaxWarning -m py_compile integrations/claude-code/scripts/sync-session-to-graph.py integrations/claude-code/tests/test_sync_strict.py`
- `ruff format --check integrations/claude-code/scripts/sync-session-to-graph.py integrations/claude-code/tests/test_sync_strict.py`
- `ruff check integrations/claude-code/scripts/sync-session-to-graph.py integrations/claude-code/tests/test_sync_strict.py`
