### PR TITLE
feat(claude-code): passive stuck-pipeline glyph in the statusline

### DIFF
--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -13,6 +13,7 @@ import json
 import os
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -21,7 +22,18 @@ _CONFIG_PATH = _SHARED_ROOT / "claude-code" / "config.json"
 _SERVER_READY_PATH = _SHARED_ROOT / "server-ready.json"
 _BREAKER_PATH = _SHARED_ROOT / "recall-breaker.json"
 _UPDATE_CHECK_PATH = _SHARED_ROOT / "claude-code" / "update-check.json"
+_PIPELINE_HEALTH_PATH = _SHARED_ROOT / "pipeline-health.json"
 _DEFAULT_DATASET = "agent_sessions"
+
+# Passive, app-closed-safe mitigation for the pipeline-health sweep (Layer 1, a
+# Windows Scheduled Task) -- PushNotification (Layer 2) only fires while the app
+# is open, so this is what lets Mike see a stuck-pipeline finding the INSTANT he
+# next opens any terminal running the plugin, even after a period the app was
+# closed. Older than this many seconds, treat the file as stale/unknown rather
+# than showing a possibly-outdated warning -- the sweep runs every 2-5 minutes,
+# so anything older than that means the sweep itself has stopped, which is its
+# own separate (unmonitored-by-this-glyph) problem, not something to imply here.
+_PIPELINE_HEALTH_STALE_SECONDS = 30 * 60
 
 # Self-eviction: when the plugin is uninstalled/disabled but its files still
 # linger in the version cache (Claude Code does not remove the statusLine key we
@@ -100,6 +112,40 @@ def _update_segment() -> str:
     if not (installed and latest):
         return ""
     return f"   \033[1;33m⬆ Cognee update available {installed}→{latest}\033[0m"
+
+
+def _pipeline_health_glyph() -> str:
+    """"⚠ N " when the pipeline sweep (scripts/pipeline_sweep.py) has a fresh,
+    non-stale finding of one or more stuck runs or a down server; "" otherwise
+    (no file yet, stale, or everything's clean). See
+    docs/KB/pipeline-monitor-notify-policy.md for the full monitoring design this
+    is one small passive piece of.
+    """
+    try:
+        raw = json.loads(_PIPELINE_HEALTH_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    if not isinstance(raw, dict):
+        return ""
+    try:
+        generated_at = datetime.fromisoformat(str(raw.get("generated_at", "")))
+        age_seconds = (datetime.now(timezone.utc) - generated_at).total_seconds()
+        if age_seconds > _PIPELINE_HEALTH_STALE_SECONDS:
+            return ""
+    except (ValueError, TypeError):
+        return ""
+    server = raw.get("server") or {}
+    if server.get("up") is False:
+        return "⚠ server-down "
+    summary = raw.get("summary") or {}
+    total_open = int(summary.get("total_open") or 0)
+    worst = str(summary.get("worst_classification") or "ok")
+    flagged = sum((summary.get("by_classification") or {}).values()) if isinstance(
+        summary.get("by_classification"), dict
+    ) else 0
+    if worst in ("alert", "critical") and flagged > 0:
+        return f"⚠ {flagged} pipeline(s) stuck "
+    return ""
 
 
 def _read_json(path: Path) -> dict:
@@ -193,7 +239,7 @@ def main() -> None:
         return
 
     sys.stdout.write(
-        f"{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}{_update_segment()}"
+        f"{_pipeline_health_glyph()}{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}{_update_segment()}"
     )
 
 

--- a/integrations/claude-code/tests/test_statusline_pipeline_health.py
+++ b/integrations/claude-code/tests/test_statusline_pipeline_health.py
@@ -1,0 +1,202 @@
+"""Tests for `_pipeline_health_glyph` (cognee_statusline_render.py) -- the
+passive, app-closed-safe mitigation for the pipeline-health sweep (Layer 1):
+PushNotification (Layer 2) only fires while Claude Code is open, so this glyph
+is what lets a human see a stuck-pipeline finding the instant they next open
+any terminal running the plugin. See
+docs/KB/pipeline-monitor-notify-policy.md (total_recall/thessary repo) for the
+full monitoring design this is one small piece of.
+
+No unittest.mock, matching this test directory's existing convention: the
+module-level _PIPELINE_HEALTH_PATH constant is reassigned directly to a tmp
+path and restored in `finally`.
+
+Run: python integrations/claude-code/tests/test_statusline_pipeline_health.py
+(or via pytest).
+"""
+
+import json
+import pathlib
+import shutil
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import cognee_statusline_render as sl  # noqa: E402
+
+
+def _tmp_path():
+    return pathlib.Path(tempfile.mkdtemp()) / "pipeline-health.json"
+
+
+def _iso(delta_seconds=0):
+    return (datetime.now(timezone.utc) - timedelta(seconds=delta_seconds)).isoformat()
+
+
+def _write(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# ── no file / malformed file → silently empty, never raises ─────────────────
+
+def test_no_file_returns_empty_string():
+    tmp = _tmp_path()  # never written
+    orig = sl._PIPELINE_HEALTH_PATH
+    try:
+        sl._PIPELINE_HEALTH_PATH = tmp
+        assert sl._pipeline_health_glyph() == ""
+    finally:
+        sl._PIPELINE_HEALTH_PATH = orig
+        shutil.rmtree(tmp.parent, ignore_errors=True)
+
+
+def test_malformed_json_returns_empty_string():
+    tmp = _tmp_path()
+    tmp.parent.mkdir(parents=True, exist_ok=True)
+    tmp.write_text("not json{{{", encoding="utf-8")
+    orig = sl._PIPELINE_HEALTH_PATH
+    try:
+        sl._PIPELINE_HEALTH_PATH = tmp
+        assert sl._pipeline_health_glyph() == ""
+    finally:
+        sl._PIPELINE_HEALTH_PATH = orig
+        shutil.rmtree(tmp.parent, ignore_errors=True)
+
+
+# ── staleness gate ────────────────────────────────────────────────────────
+
+def test_stale_file_returns_empty_even_if_it_would_otherwise_warn():
+    tmp = _tmp_path()
+    _write(tmp, {
+        "generated_at": _iso(delta_seconds=sl._PIPELINE_HEALTH_STALE_SECONDS + 60),
+        "server": {"up": True},
+        "summary": {"total_open": 1, "worst_classification": "critical",
+                    "by_classification": {"warn": 0, "alert": 0, "critical": 1}},
+    })
+    orig = sl._PIPELINE_HEALTH_PATH
+    try:
+        sl._PIPELINE_HEALTH_PATH = tmp
+        assert sl._pipeline_health_glyph() == ""
+    finally:
+        sl._PIPELINE_HEALTH_PATH = orig
+        shutil.rmtree(tmp.parent, ignore_errors=True)
+
+
+def test_missing_generated_at_returns_empty():
+    tmp = _tmp_path()
+    _write(tmp, {"server": {"up": True}, "summary": {}})
+    orig = sl._PIPELINE_HEALTH_PATH
+    try:
+        sl._PIPELINE_HEALTH_PATH = tmp
+        assert sl._pipeline_health_glyph() == ""
+    finally:
+        sl._PIPELINE_HEALTH_PATH = orig
+        shutil.rmtree(tmp.parent, ignore_errors=True)
+
+
+# ── clean state → empty ──────────────────────────────────────────────────
+
+def test_fresh_clean_state_returns_empty():
+    tmp = _tmp_path()
+    _write(tmp, {
+        "generated_at": _iso(),
+        "server": {"up": True},
+        "summary": {"total_open": 3, "worst_classification": "ok",
+                    "by_classification": {"warn": 0, "alert": 0, "critical": 0}},
+    })
+    orig = sl._PIPELINE_HEALTH_PATH
+    try:
+        sl._PIPELINE_HEALTH_PATH = tmp
+        assert sl._pipeline_health_glyph() == ""
+    finally:
+        sl._PIPELINE_HEALTH_PATH = orig
+        shutil.rmtree(tmp.parent, ignore_errors=True)
+
+
+def test_warn_only_returns_empty_never_pushed_never_shown():
+    """Matches the notify-policy doc: bare warn is tracked, never surfaced."""
+    tmp = _tmp_path()
+    _write(tmp, {
+        "generated_at": _iso(),
+        "server": {"up": True},
+        "summary": {"total_open": 1, "worst_classification": "warn",
+                    "by_classification": {"warn": 1, "alert": 0, "critical": 0}},
+    })
+    orig = sl._PIPELINE_HEALTH_PATH
+    try:
+        sl._PIPELINE_HEALTH_PATH = tmp
+        assert sl._pipeline_health_glyph() == ""
+    finally:
+        sl._PIPELINE_HEALTH_PATH = orig
+        shutil.rmtree(tmp.parent, ignore_errors=True)
+
+
+# ── real findings → glyph shown ──────────────────────────────────────────
+
+def test_server_down_takes_priority_and_shows_its_own_glyph():
+    tmp = _tmp_path()
+    _write(tmp, {
+        "generated_at": _iso(),
+        "server": {"up": False},
+        "summary": {"total_open": 0, "worst_classification": "ok",
+                    "by_classification": {"warn": 0, "alert": 0, "critical": 0}},
+    })
+    orig = sl._PIPELINE_HEALTH_PATH
+    try:
+        sl._PIPELINE_HEALTH_PATH = tmp
+        assert sl._pipeline_health_glyph() == "⚠ server-down "
+    finally:
+        sl._PIPELINE_HEALTH_PATH = orig
+        shutil.rmtree(tmp.parent, ignore_errors=True)
+
+
+def test_alert_classification_shows_stuck_count():
+    tmp = _tmp_path()
+    _write(tmp, {
+        "generated_at": _iso(),
+        "server": {"up": True},
+        "summary": {"total_open": 5, "worst_classification": "alert",
+                    "by_classification": {"warn": 1, "alert": 2, "critical": 0}},
+    })
+    orig = sl._PIPELINE_HEALTH_PATH
+    try:
+        sl._PIPELINE_HEALTH_PATH = tmp
+        assert sl._pipeline_health_glyph() == "⚠ 3 pipeline(s) stuck "
+    finally:
+        sl._PIPELINE_HEALTH_PATH = orig
+        shutil.rmtree(tmp.parent, ignore_errors=True)
+
+
+def test_critical_classification_shows_stuck_count():
+    tmp = _tmp_path()
+    _write(tmp, {
+        "generated_at": _iso(),
+        "server": {"up": True},
+        "summary": {"total_open": 2, "worst_classification": "critical",
+                    "by_classification": {"warn": 0, "alert": 0, "critical": 1}},
+    })
+    orig = sl._PIPELINE_HEALTH_PATH
+    try:
+        sl._PIPELINE_HEALTH_PATH = tmp
+        assert sl._pipeline_health_glyph() == "⚠ 1 pipeline(s) stuck "
+    finally:
+        sl._PIPELINE_HEALTH_PATH = orig
+        shutil.rmtree(tmp.parent, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print(f"PASS {_name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {_name}: {exc}")
+    print(f"\n{'ALL PASSED' if not failures else f'{failures} FAILED'}")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
Split of #237 per the request to break it into focused PRs.

Adds a passive `"⚠ N pipeline(s) stuck"` / `"⚠ server-down"` glyph in the statusline, read from a status file a background sweep writes every ~2 minutes — the app-closed-safe complement to a push-notification layer that only fires while Claude Code is open. Renders nothing on missing/malformed/stale (>30min) data. 9 new tests, all green.

Note: this needed manual resolution against `main`'s own recently-merged update-check statusline segment — both segments now coexist (order: pipeline glyph → health prefix → `cognee: …` → update segment). Flagging in case you'd prefer a different combination or order.
