### PR TITLE
Extend default timeouts to 120 seconds for Claude Code and integrations

### DIFF
--- a/integrations/aider/README.md
+++ b/integrations/aider/README.md
@@ -51,9 +51,11 @@ from cognee_integration_aider import get_sessionized_cognee_tools
 
 remember, recall = get_sessionized_cognee_tools("my-project")
 
+
 async def main():
     await remember("We decided to use PostgreSQL with pgvector.")
     print(await recall("What database did we choose?"))
+
 
 asyncio.run(main())
 ```

--- a/integrations/chat-memory/README.md
+++ b/integrations/chat-memory/README.md
@@ -45,7 +45,10 @@ install the extra: `pip install -e ".[sdk]"`.
 
 ```python
 from cognee_integration_chat_memory import (
-    ChatMemoryAdapter, Conversation, Message, per_channel_scope,
+    ChatMemoryAdapter,
+    Conversation,
+    Message,
+    per_channel_scope,
 )
 
 # Default backend talks to a running cognee server (COGNEE_BASE_URL / COGNEE_API_KEY).
@@ -53,8 +56,9 @@ adapter = ChatMemoryAdapter(scope=per_channel_scope)
 
 convo = Conversation(platform="slack", workspace="T1", channel="C1", user="U1")
 adapter.set_consent("U1", True)
-await adapter.ingest(convo, Message(text="We ship on Friday.", user="U1",
-                                    permalink="https://slack/archives/C1/p1"))
+await adapter.ingest(
+    convo, Message(text="We ship on Friday.", user="U1", permalink="https://slack/archives/C1/p1")
+)
 answer = await adapter.answer(convo, "when do we ship?")
 print(answer.text)
 for c in answer.citations:

--- a/integrations/chat-memory/cognee_integration_chat_memory/backend.py
+++ b/integrations/chat-memory/cognee_integration_chat_memory/backend.py
@@ -269,7 +269,7 @@ class CogneeHttpMemoryBackend:
         api_key: Optional[str] = None,
         *,
         client: Any = None,
-        timeout: float = 60.0,
+        timeout: float = 120.0,
         search_type: str = "GRAPH_COMPLETION",
     ) -> None:
         self._base_url = (base_url or os.getenv("COGNEE_BASE_URL", "http://localhost:8000")).rstrip(

--- a/integrations/claude-agent-sdk/README.md
+++ b/integrations/claude-agent-sdk/README.md
@@ -60,45 +60,43 @@ from cognee_integration_claude import cognee_tools
 
 load_dotenv()
 
+
 async def main():
     # Clean up memory to start fresh (Optional)
     await cognee.forget(everything=True)
-    
+
     # Create an MCP server with Cognee tools
-    server = create_sdk_mcp_server(
-        name="cognee-tools",
-        version="1.0.0",
-        tools=cognee_tools()
-    )
-    
+    server = create_sdk_mcp_server(name="cognee-tools", version="1.0.0", tools=cognee_tools())
+
     # Configure the agent
     options = ClaudeAgentOptions(
         mcp_servers={"tools": server},
         allowed_tools=["mcp__tools__remember", "mcp__tools__recall"],
     )
-    
+
     # Use the agent to store information
     async with ClaudeSDKClient(options=options) as client:
         await client.query(
             "Remember that our company signed a contract with HealthBridge Systems "
             "in the healthcare industry, starting Feb 2023, ending Jan 2026, worth £2.4M"
         )
-        
+
         async for msg in client.receive_response():
             if isinstance(msg, AssistantMessage):
                 for block in msg.content:
                     if isinstance(block, TextBlock):
                         print(f"Claude: {block.text}")
-    
+
     # Query the stored information (new agent instance)
     async with ClaudeSDKClient(options=options) as client:
         await client.query("What contracts do we have in the healthcare industry?")
-        
+
         async for msg in client.receive_response():
             if isinstance(msg, AssistantMessage):
                 for block in msg.content:
                     if isinstance(block, TextBlock):
                         print(f"Claude: {block.text}")
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -180,7 +178,7 @@ from cognee_integration_claude import cognee_tools
 server = create_sdk_mcp_server(
     name="memory-tools",
     version="1.0.0",
-    tools=cognee_tools(),                  # or cognee_tools(session_id="user-123")
+    tools=cognee_tools(),  # or cognee_tools(session_id="user-123")
 )
 
 options = ClaudeAgentOptions(
@@ -206,7 +204,7 @@ defaults. Returns cognee's `RememberResult`.
 ```python
 from cognee_integration_claude import remember
 
-await remember("Einstein was born in Ulm.")                       # cognee defaults
+await remember("Einstein was born in Ulm.")  # cognee defaults
 ```
 
 ### `recall(query_text, **kwargs)`
@@ -221,7 +219,9 @@ use `render_results(...)` to flatten it to plain strings.
 import cognee
 from cognee_integration_claude import recall, render_results
 
-results = await recall("healthcare contracts", query_type=cognee.SearchType.GRAPH_COMPLETION, top_k=20)
+results = await recall(
+    "healthcare contracts", query_type=cognee.SearchType.GRAPH_COMPLETION, top_k=20
+)
 texts = render_results(results)
 ```
 
@@ -265,13 +265,9 @@ You can customize Cognee's data and system directories:
 from cognee.api.v1.config import config
 import os
 
-config.data_root_directory(
-    os.path.join(os.path.dirname(__file__), ".cognee/data_storage")
-)
+config.data_root_directory(os.path.join(os.path.dirname(__file__), ".cognee/data_storage"))
 
-config.system_root_directory(
-    os.path.join(os.path.dirname(__file__), ".cognee/system")
-)
+config.system_root_directory(os.path.join(os.path.dirname(__file__), ".cognee/system"))
 ```
 
 ## Examples
@@ -302,33 +298,31 @@ from claude_agent_sdk import (
 )
 from cognee_integration_claude import cognee_tools
 
+
 async def main():
     # Pre-load data directly into Cognee. cognee.remember extracts entities and
     # relationships and persists them — no separate cognify() step needed.
     await cognee.remember("Important company information here...")
     await cognee.remember("More data to remember...")
-    
+
     # Now create an agent that can search this data
-    server = create_sdk_mcp_server(
-        name="cognee-tools",
-        version="1.0.0",
-        tools=cognee_tools()
-    )
-    
+    server = create_sdk_mcp_server(name="cognee-tools", version="1.0.0", tools=cognee_tools())
+
     # Allow only recall if you want a read-only agent
     options = ClaudeAgentOptions(
         mcp_servers={"tools": server},
         allowed_tools=["mcp__tools__recall"],
     )
-    
+
     async with ClaudeSDKClient(options=options) as client:
         await client.query("What information do we have?")
-        
+
         async for msg in client.receive_response():
             if isinstance(msg, AssistantMessage):
                 for block in msg.content:
                     if isinstance(block, TextBlock):
                         print(block.text)
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -340,9 +334,11 @@ if __name__ == "__main__":
 import asyncio
 import cognee
 
+
 async def reset_knowledge_base():
     """Clear all data and reset the knowledge base"""
     await cognee.forget(everything=True)
+
 
 async def visualize_knowledge_graph():
     """Render the knowledge graph.
@@ -367,9 +363,21 @@ options = ClaudeAgentOptions(
     mcp_servers={"tools": server},
     allowed_tools=["mcp__tools__remember", "mcp__tools__recall"],
     disallowed_tools=[
-        "Task", "Bash", "Glob", "Grep", "ExitPlanMode",
-        "Read", "Edit", "Write", "NotebookEdit", "WebFetch",
-        "TodoWrite", "WebSearch", "BashOutput", "KillShell", "SlashCommand",
+        "Task",
+        "Bash",
+        "Glob",
+        "Grep",
+        "ExitPlanMode",
+        "Read",
+        "Edit",
+        "Write",
+        "NotebookEdit",
+        "WebFetch",
+        "TodoWrite",
+        "WebSearch",
+        "BashOutput",
+        "KillShell",
+        "SlashCommand",
     ],
 )
 ```

--- a/integrations/claude-code/hooks/hooks.json
+++ b/integrations/claude-code/hooks/hooks.json
@@ -6,7 +6,7 @@
           {
             "type": "command",
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/session-start.py",
-            "timeout": 15,
+            "timeout": 120,
             "statusMessage": "Initializing Cognee memory..."
           }
         ]
@@ -18,7 +18,7 @@
           {
             "type": "command",
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/session-context-lookup.py",
-            "timeout": 90,
+            "timeout": 120,
             "statusMessage": "Searching session memory..."
           },
           {
@@ -64,7 +64,7 @@
           {
             "type": "command",
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.py",
-            "timeout": 15,
+            "timeout": 120,
             "statusMessage": "Building memory anchor..."
           }
         ]

--- a/integrations/claude-code/scripts/_cognee_client.py
+++ b/integrations/claude-code/scripts/_cognee_client.py
@@ -26,7 +26,7 @@ from _recall_http import UNREACHABLE, _error, do_recall
 # Tunables (mirror Hermes's provider defaults).
 _THRESHOLD = int(os.environ.get("COGNEE_BREAKER_THRESHOLD", "5"))
 _COOLDOWN = float(os.environ.get("COGNEE_BREAKER_COOLDOWN", "120"))
-_RECALL_TIMEOUT = float(os.environ.get("COGNEE_RECALL_TIMEOUT", "20"))
+_RECALL_TIMEOUT = float(os.environ.get("COGNEE_RECALL_TIMEOUT", "120"))
 
 
 def _state_path():

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -618,7 +618,9 @@ def append_http_bridge_entry(
         return
     if not (question or answer or trace):
         return
-    question, answer, trace = _strip_surrogates(question), _strip_surrogates(answer), _strip_surrogates(trace)
+    question = _strip_surrogates(question)
+    answer = _strip_surrogates(answer)
+    trace = _strip_surrogates(trace)
 
     with _buffer_lock():
         cache = _load_json_file(_bridge_file(session_id))

--- a/integrations/claude-code/scripts/_recall_http.py
+++ b/integrations/claude-code/scripts/_recall_http.py
@@ -107,7 +107,7 @@ def do_recall(
     context_profile="",
     *,
     opener=None,
-    timeout=20.0,
+    timeout=120.0,
 ):
     """Query the server. Return results (list), an error envelope (dict), or ``UNREACHABLE``."""
     url = service_url.rstrip("/") + "/api/v1/recall"

--- a/integrations/claude-code/scripts/_remember_http.py
+++ b/integrations/claude-code/scripts/_remember_http.py
@@ -171,7 +171,7 @@ def do_remember(
     node_set,
     *,
     opener=urllib.request.urlopen,
-    timeout=60.0,
+    timeout=120.0,
 ):
     """POST content to the server. Return {"ok": true}, an error envelope, or UNREACHABLE."""
     url = service_url.rstrip("/") + "/api/v1/remember"

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -115,7 +115,7 @@ def _update_segment() -> str:
 
 
 def _pipeline_health_glyph() -> str:
-    """"⚠ N " when the pipeline sweep (scripts/pipeline_sweep.py) has a fresh,
+    """ "⚠ N " when the pipeline sweep (scripts/pipeline_sweep.py) has a fresh,
     non-stale finding of one or more stuck runs or a down server; "" otherwise
     (no file yet, stale, or everything's clean). See
     docs/KB/pipeline-monitor-notify-policy.md for the full monitoring design this
@@ -138,11 +138,12 @@ def _pipeline_health_glyph() -> str:
     if server.get("up") is False:
         return "⚠ server-down "
     summary = raw.get("summary") or {}
-    total_open = int(summary.get("total_open") or 0)
     worst = str(summary.get("worst_classification") or "ok")
-    flagged = sum((summary.get("by_classification") or {}).values()) if isinstance(
-        summary.get("by_classification"), dict
-    ) else 0
+    flagged = (
+        sum((summary.get("by_classification") or {}).values())
+        if isinstance(summary.get("by_classification"), dict)
+        else 0
+    )
     if worst in ("alert", "critical") and flagged > 0:
         return f"⚠ {flagged} pipeline(s) stuck "
     return ""
@@ -239,7 +240,8 @@ def main() -> None:
         return
 
     sys.stdout.write(
-        f"{_pipeline_health_glyph()}{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}{_update_segment()}"
+        f"{_pipeline_health_glyph()}{_health_prefix()}"
+        f"cognee: {_active_dataset()} · {_active_mode()}{_update_segment()}"
     )
 
 

--- a/integrations/claude-code/tests/test_statusline_pipeline_health.py
+++ b/integrations/claude-code/tests/test_statusline_pipeline_health.py
@@ -43,6 +43,7 @@ def _write(path, payload):
 
 # ── no file / malformed file → silently empty, never raises ─────────────────
 
+
 def test_no_file_returns_empty_string():
     tmp = _tmp_path()  # never written
     orig = sl._PIPELINE_HEALTH_PATH
@@ -69,14 +70,21 @@ def test_malformed_json_returns_empty_string():
 
 # ── staleness gate ────────────────────────────────────────────────────────
 
+
 def test_stale_file_returns_empty_even_if_it_would_otherwise_warn():
     tmp = _tmp_path()
-    _write(tmp, {
-        "generated_at": _iso(delta_seconds=sl._PIPELINE_HEALTH_STALE_SECONDS + 60),
-        "server": {"up": True},
-        "summary": {"total_open": 1, "worst_classification": "critical",
-                    "by_classification": {"warn": 0, "alert": 0, "critical": 1}},
-    })
+    _write(
+        tmp,
+        {
+            "generated_at": _iso(delta_seconds=sl._PIPELINE_HEALTH_STALE_SECONDS + 60),
+            "server": {"up": True},
+            "summary": {
+                "total_open": 1,
+                "worst_classification": "critical",
+                "by_classification": {"warn": 0, "alert": 0, "critical": 1},
+            },
+        },
+    )
     orig = sl._PIPELINE_HEALTH_PATH
     try:
         sl._PIPELINE_HEALTH_PATH = tmp
@@ -100,14 +108,21 @@ def test_missing_generated_at_returns_empty():
 
 # ── clean state → empty ──────────────────────────────────────────────────
 
+
 def test_fresh_clean_state_returns_empty():
     tmp = _tmp_path()
-    _write(tmp, {
-        "generated_at": _iso(),
-        "server": {"up": True},
-        "summary": {"total_open": 3, "worst_classification": "ok",
-                    "by_classification": {"warn": 0, "alert": 0, "critical": 0}},
-    })
+    _write(
+        tmp,
+        {
+            "generated_at": _iso(),
+            "server": {"up": True},
+            "summary": {
+                "total_open": 3,
+                "worst_classification": "ok",
+                "by_classification": {"warn": 0, "alert": 0, "critical": 0},
+            },
+        },
+    )
     orig = sl._PIPELINE_HEALTH_PATH
     try:
         sl._PIPELINE_HEALTH_PATH = tmp
@@ -120,12 +135,18 @@ def test_fresh_clean_state_returns_empty():
 def test_warn_only_returns_empty_never_pushed_never_shown():
     """Matches the notify-policy doc: bare warn is tracked, never surfaced."""
     tmp = _tmp_path()
-    _write(tmp, {
-        "generated_at": _iso(),
-        "server": {"up": True},
-        "summary": {"total_open": 1, "worst_classification": "warn",
-                    "by_classification": {"warn": 1, "alert": 0, "critical": 0}},
-    })
+    _write(
+        tmp,
+        {
+            "generated_at": _iso(),
+            "server": {"up": True},
+            "summary": {
+                "total_open": 1,
+                "worst_classification": "warn",
+                "by_classification": {"warn": 1, "alert": 0, "critical": 0},
+            },
+        },
+    )
     orig = sl._PIPELINE_HEALTH_PATH
     try:
         sl._PIPELINE_HEALTH_PATH = tmp
@@ -137,14 +158,21 @@ def test_warn_only_returns_empty_never_pushed_never_shown():
 
 # ── real findings → glyph shown ──────────────────────────────────────────
 
+
 def test_server_down_takes_priority_and_shows_its_own_glyph():
     tmp = _tmp_path()
-    _write(tmp, {
-        "generated_at": _iso(),
-        "server": {"up": False},
-        "summary": {"total_open": 0, "worst_classification": "ok",
-                    "by_classification": {"warn": 0, "alert": 0, "critical": 0}},
-    })
+    _write(
+        tmp,
+        {
+            "generated_at": _iso(),
+            "server": {"up": False},
+            "summary": {
+                "total_open": 0,
+                "worst_classification": "ok",
+                "by_classification": {"warn": 0, "alert": 0, "critical": 0},
+            },
+        },
+    )
     orig = sl._PIPELINE_HEALTH_PATH
     try:
         sl._PIPELINE_HEALTH_PATH = tmp
@@ -156,12 +184,18 @@ def test_server_down_takes_priority_and_shows_its_own_glyph():
 
 def test_alert_classification_shows_stuck_count():
     tmp = _tmp_path()
-    _write(tmp, {
-        "generated_at": _iso(),
-        "server": {"up": True},
-        "summary": {"total_open": 5, "worst_classification": "alert",
-                    "by_classification": {"warn": 1, "alert": 2, "critical": 0}},
-    })
+    _write(
+        tmp,
+        {
+            "generated_at": _iso(),
+            "server": {"up": True},
+            "summary": {
+                "total_open": 5,
+                "worst_classification": "alert",
+                "by_classification": {"warn": 1, "alert": 2, "critical": 0},
+            },
+        },
+    )
     orig = sl._PIPELINE_HEALTH_PATH
     try:
         sl._PIPELINE_HEALTH_PATH = tmp
@@ -173,12 +207,18 @@ def test_alert_classification_shows_stuck_count():
 
 def test_critical_classification_shows_stuck_count():
     tmp = _tmp_path()
-    _write(tmp, {
-        "generated_at": _iso(),
-        "server": {"up": True},
-        "summary": {"total_open": 2, "worst_classification": "critical",
-                    "by_classification": {"warn": 0, "alert": 0, "critical": 1}},
-    })
+    _write(
+        tmp,
+        {
+            "generated_at": _iso(),
+            "server": {"up": True},
+            "summary": {
+                "total_open": 2,
+                "worst_classification": "critical",
+                "by_classification": {"warn": 0, "alert": 0, "critical": 1},
+            },
+        },
+    )
     orig = sl._PIPELINE_HEALTH_PATH
     try:
         sl._PIPELINE_HEALTH_PATH = tmp

--- a/integrations/codex/plugins/cognee/hooks.json
+++ b/integrations/codex/plugins/cognee/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "python3 \"${PLUGIN_ROOT}/scripts/session-start.py\"",
-            "timeout": 15,
+            "timeout": 120,
             "statusMessage": "Initializing Cognee memory..."
           }
         ]
@@ -19,13 +19,13 @@
           {
             "type": "command",
             "command": "python3 \"${PLUGIN_ROOT}/scripts/session-context-lookup.py\"",
-            "timeout": 15,
+            "timeout": 120,
             "statusMessage": "Searching session memory..."
           },
           {
             "type": "command",
             "command": "python3 \"${PLUGIN_ROOT}/scripts/store-user-prompt.py\"",
-            "timeout": 15,
+            "timeout": 120,
             "statusMessage": "Saving user prompt..."
           }
         ]
@@ -38,7 +38,7 @@
           {
             "type": "command",
             "command": "python3 \"${PLUGIN_ROOT}/scripts/store-to-session.py\"",
-            "timeout": 15,
+            "timeout": 120,
             "statusMessage": "Saving tool trace..."
           }
         ]
@@ -50,7 +50,7 @@
           {
             "type": "command",
             "command": "python3 \"${PLUGIN_ROOT}/scripts/store-to-session.py\" --stop",
-            "timeout": 15,
+            "timeout": 120,
             "statusMessage": "Saving assistant response..."
           }
         ]
@@ -62,7 +62,7 @@
           {
             "type": "command",
             "command": "python3 \"${PLUGIN_ROOT}/scripts/pre-compact.py\"",
-            "timeout": 15,
+            "timeout": 120,
             "statusMessage": "Building memory anchor..."
           }
         ]
@@ -74,7 +74,7 @@
           {
             "type": "command",
             "command": "python3 \"${PLUGIN_ROOT}/scripts/sync-session-to-graph.py\" --session-end",
-            "timeout": 15,
+            "timeout": 120,
             "statusMessage": "Syncing session memory..."
           }
         ]

--- a/integrations/codex/plugins/cognee/scripts/_cognee_client.py
+++ b/integrations/codex/plugins/cognee/scripts/_cognee_client.py
@@ -26,7 +26,7 @@ from _recall_http import UNREACHABLE, _error, do_recall
 # Tunables (mirror Hermes's provider defaults).
 _THRESHOLD = int(os.environ.get("COGNEE_BREAKER_THRESHOLD", "5"))
 _COOLDOWN = float(os.environ.get("COGNEE_BREAKER_COOLDOWN", "120"))
-_RECALL_TIMEOUT = float(os.environ.get("COGNEE_RECALL_TIMEOUT", "20"))
+_RECALL_TIMEOUT = float(os.environ.get("COGNEE_RECALL_TIMEOUT", "120"))
 
 
 def _state_path():

--- a/integrations/codex/plugins/cognee/scripts/_recall_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_recall_http.py
@@ -107,7 +107,7 @@ def do_recall(
     context_profile="",
     *,
     opener=None,
-    timeout=20.0,
+    timeout=120.0,
 ):
     """Query the server. Return results (list), an error envelope (dict), or ``UNREACHABLE``."""
     url = service_url.rstrip("/") + "/api/v1/recall"

--- a/integrations/codex/plugins/cognee/scripts/_remember_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_remember_http.py
@@ -94,7 +94,7 @@ def do_remember(
     node_set,
     *,
     opener=urllib.request.urlopen,
-    timeout=60.0,
+    timeout=120.0,
 ):
     """POST content to the server. Return {"ok": true}, an error envelope, or UNREACHABLE."""
     url = service_url.rstrip("/") + "/api/v1/remember"

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -455,7 +455,7 @@ async def _run(prompt: str) -> dict | None:
         "hookSpecificOutput": {
             "hookEventName": "UserPromptSubmit",
             "additionalContext": full_context,
-        }
+        },
     }
     return output
 
@@ -494,9 +494,14 @@ def main():
 
 
 if __name__ == "__main__":
-    print(json.dumps(main() or {
-        "hookSpecificOutput": {
-            "hookEventName": "UserPromptSubmit",
-            "additionalContext": "",
-        }
-    }))
+    print(
+        json.dumps(
+            main()
+            or {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": "",
+                }
+            }
+        )
+    )

--- a/integrations/codex/plugins/cognee/scripts/store-user-prompt.py
+++ b/integrations/codex/plugins/cognee/scripts/store-user-prompt.py
@@ -190,9 +190,13 @@ def main():
 
 if __name__ == "__main__":
     main()
-    print(json.dumps({
-        "hookSpecificOutput": {
-            "hookEventName": "UserPromptSubmit",
-            "additionalContext": "",
-        }
-    }))
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": "",
+                }
+            }
+        )
+    )

--- a/integrations/crewai/README.md
+++ b/integrations/crewai/README.md
@@ -32,32 +32,32 @@ from cognee_integration_crewai import add_tool, search_tool
 
 load_dotenv()
 
+
 async def main():
     # Initialize Cognee (optional - for data management)
     await cognee.prune.prune_data()
     await cognee.prune.prune_system(metadata=True)
-    
+
     # Create an agent with memory capabilities
     agent = Agent(
         role="Research Analyst",
         goal="Find and analyze information using the knowledge base",
         backstory="You are an expert analyst with access to a comprehensive knowledge base.",
         tools=[add_tool, search_tool],
-        verbose=True
+        verbose=True,
     )
-    
+
     # Use the agent to store information
     response = agent.kickoff(
         "Remember that our company signed a contract with HealthBridge Systems "
         "in the healthcare industry, starting Feb 2023, ending Jan 2026, worth £2.4M"
     )
     print(response.raw)
-    
+
     # Query the stored information
-    response = agent.kickoff(
-        "What contracts do we have in the healthcare industry?"
-    )
+    response = agent.kickoff("What contracts do we have in the healthcare industry?")
     print(response.raw)
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -97,29 +97,31 @@ import asyncio
 from crewai import Agent
 from cognee_integration_crewai import get_sessionized_cognee_tools
 
+
 async def main():
     # Each user gets their own isolated session
     user1_add, user1_search = get_sessionized_cognee_tools("user-123")
     user2_add, user2_search = get_sessionized_cognee_tools("user-456")
-    
+
     # Create separate agents for each user
     agent1 = Agent(
         role="Assistant",
         goal="Help user 1",
         backstory="You are a helpful assistant.",
-        tools=[user1_add, user1_search]
+        tools=[user1_add, user1_search],
     )
-    
+
     agent2 = Agent(
         role="Assistant",
         goal="Help user 2",
         backstory="You are a helpful assistant.",
-        tools=[user2_add, user2_search]
+        tools=[user2_add, user2_search],
     )
-    
+
     # Each agent works with isolated data
     response1 = agent1.kickoff("Remember: I like pizza")
     response2 = agent2.kickoff("Remember: I like sushi")
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -143,12 +145,10 @@ agent = Agent(
     role="Data Manager",
     goal="Store important information",
     backstory="You manage our knowledge base.",
-    tools=[add_tool]
+    tools=[add_tool],
 )
 
-response = agent.kickoff(
-    "Store this: Our Q4 revenue was $2.5M with 15% growth"
-)
+response = agent.kickoff("Store this: Our Q4 revenue was $2.5M with 15% growth")
 ```
 
 ### `search_tool(query_text: str)`
@@ -166,12 +166,10 @@ agent = Agent(
     role="Research Assistant",
     goal="Find information from our knowledge base",
     backstory="You help users find information quickly.",
-    tools=[search_tool]
+    tools=[search_tool],
 )
 
-response = agent.kickoff(
-    "What was our Q4 revenue?"
-)
+response = agent.kickoff("What was our Q4 revenue?")
 ```
 
 ### `get_sessionized_cognee_tools(session_id: Optional[str] = None)`
@@ -217,13 +215,9 @@ You can customize Cognee's data and system directories:
 from cognee.api.v1.config import config
 import os
 
-config.data_root_directory(
-    os.path.join(os.path.dirname(__file__), ".cognee/data_storage")
-)
+config.data_root_directory(os.path.join(os.path.dirname(__file__), ".cognee/data_storage"))
 
-config.system_root_directory(
-    os.path.join(os.path.dirname(__file__), ".cognee/system")
-)
+config.system_root_directory(os.path.join(os.path.dirname(__file__), ".cognee/system"))
 ```
 
 ## Examples
@@ -245,22 +239,24 @@ import cognee
 from cognee_integration_crewai import search_tool
 from crewai import Agent
 
+
 async def main():
     # Pre-load data
     await cognee.add("Important company information here...")
     await cognee.add("More data to remember...")
     await cognee.cognify()  # Process and index the data
-    
+
     # Now create an agent that can search this data
     agent = Agent(
         role="Analyst",
         goal="Answer questions using pre-loaded data",
         backstory="You have access to our company knowledge base.",
-        tools=[search_tool]
+        tools=[search_tool],
     )
-    
+
     response = agent.kickoff("What information do we have?")
     print(response.raw)
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -272,10 +268,12 @@ if __name__ == "__main__":
 import asyncio
 import cognee
 
+
 async def reset_knowledge_base():
     """Clear all data and reset the knowledge base"""
     await cognee.prune.prune_data()
     await cognee.prune.prune_system(metadata=True)
+
 
 async def visualize_knowledge_graph():
     """Generate a visualization of the knowledge graph"""

--- a/integrations/dify/tools/add_data.py
+++ b/integrations/dify/tools/add_data.py
@@ -42,7 +42,7 @@ class AddDataTool(Tool):
                     "X-Api-Key": api_key,
                     "Content-Type": "application/json",
                 },
-                timeout=60,
+                timeout=120,
             )
             response.raise_for_status()
             result = response.json()

--- a/integrations/dify/tools/create_dataset.py
+++ b/integrations/dify/tools/create_dataset.py
@@ -21,7 +21,7 @@ class CreateDatasetTool(Tool):
                     "X-Api-Key": api_key,
                     "Content-Type": "application/json",
                 },
-                timeout=60,
+                timeout=120,
             )
             response.raise_for_status()
             result = response.json()

--- a/integrations/dify/tools/delete_data.py
+++ b/integrations/dify/tools/delete_data.py
@@ -18,7 +18,7 @@ class DeleteDataTool(Tool):
             response = httpx.delete(
                 f"{base_url}/datasets/{dataset_id}/data/{data_id}",
                 headers={"X-Api-Key": api_key},
-                timeout=30,
+                timeout=120,
             )
             response.raise_for_status()
 

--- a/integrations/dify/tools/delete_dataset.py
+++ b/integrations/dify/tools/delete_dataset.py
@@ -17,7 +17,7 @@ class DeleteDatasetTool(Tool):
             response = httpx.delete(
                 f"{base_url}/datasets/{dataset_id}",
                 headers={"X-Api-Key": api_key},
-                timeout=30,
+                timeout=120,
             )
             response.raise_for_status()
 

--- a/integrations/dify/tools/get_dataset_data.py
+++ b/integrations/dify/tools/get_dataset_data.py
@@ -20,7 +20,7 @@ class GetDatasetDataTool(Tool):
                     "X-Api-Key": api_key,
                     "Content-Type": "application/json",
                 },
-                timeout=60,
+                timeout=120,
             )
             response.raise_for_status()
             result = response.json()

--- a/integrations/dify/tools/get_datasets.py
+++ b/integrations/dify/tools/get_datasets.py
@@ -18,7 +18,7 @@ class GetDatasetsTool(Tool):
                     "X-Api-Key": api_key,
                     "Content-Type": "application/json",
                 },
-                timeout=60,
+                timeout=120,
             )
             response.raise_for_status()
             result = response.json()

--- a/integrations/google-adk/README.md
+++ b/integrations/google-adk/README.md
@@ -34,11 +34,12 @@ from cognee_integration_google_adk import add_tool, search_tool
 
 load_dotenv()
 
+
 async def main():
     # Initialize Cognee (optional - for data management)
     await cognee.prune.prune_data()
     await cognee.prune.prune_system(metadata=True)
-    
+
     # Create an agent with memory capabilities
     agent = Agent(
         model="gemini-2.5-flash",
@@ -47,32 +48,31 @@ async def main():
         instruction="You are an expert research analyst with access to a comprehensive knowledge base.",
         tools=[add_tool, search_tool],
     )
-    
+
     runner = InMemoryRunner(agent=agent)
-    
+
     # Use the agent to store information
     events = await runner.run_debug(
         "Remember that our company signed a contract with HealthBridge Systems "
         "in the healthcare industry, starting Feb 2023, ending Jan 2026, worth £2.4M"
     )
-    
+
     # Print agent response
     for event in events:
         if event.is_final_response() and event.content:
             for part in event.content.parts:
                 if part.text:
                     print(part.text)
-    
+
     # Query the stored information
-    events = await runner.run_debug(
-        "What contracts do we have in the healthcare industry?"
-    )
-    
+    events = await runner.run_debug("What contracts do we have in the healthcare industry?")
+
     for event in events:
         if event.is_final_response() and event.content:
             for part in event.content.parts:
                 if part.text:
                     print(part.text)
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -113,34 +113,36 @@ from google.adk.agents import Agent
 from google.adk.runners import InMemoryRunner
 from cognee_integration_google_adk import get_sessionized_cognee_tools
 
+
 async def main():
     # Each user gets their own isolated session
     user1_add, user1_search = get_sessionized_cognee_tools("user-123")
     user2_add, user2_search = get_sessionized_cognee_tools("user-456")
-    
+
     # Create separate agents for each user
     agent1 = Agent(
         model="gemini-2.5-flash",
         name="assistant_1",
         description="Assistant for user 1",
         instruction="You are a helpful assistant.",
-        tools=[user1_add, user1_search]
+        tools=[user1_add, user1_search],
     )
-    
+
     agent2 = Agent(
         model="gemini-2.5-flash",
         name="assistant_2",
         description="Assistant for user 2",
         instruction="You are a helpful assistant.",
-        tools=[user2_add, user2_search]
+        tools=[user2_add, user2_search],
     )
-    
+
     runner1 = InMemoryRunner(agent=agent1)
     runner2 = InMemoryRunner(agent=agent2)
-    
+
     # Each agent works with isolated data
     await runner1.run_debug("Remember: I like pizza")
     await runner2.run_debug("Remember: I like sushi")
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -165,13 +167,11 @@ agent = Agent(
     name="data_manager",
     description="Data management specialist",
     instruction="You manage our knowledge base.",
-    tools=[add_tool]
+    tools=[add_tool],
 )
 
 runner = InMemoryRunner(agent=agent)
-await runner.run_debug(
-    "Store this: Our Q4 revenue was $2.5M with 15% growth"
-)
+await runner.run_debug("Store this: Our Q4 revenue was $2.5M with 15% growth")
 ```
 
 ### `search_tool(query_text: str, node_set: Optional[List[str]] = None)`
@@ -191,7 +191,7 @@ agent = Agent(
     name="research_assistant",
     description="Research specialist",
     instruction="You help users find information quickly.",
-    tools=[search_tool]
+    tools=[search_tool],
 )
 
 runner = InMemoryRunner(agent=agent)
@@ -238,13 +238,9 @@ You can customize Cognee's data and system directories:
 from cognee.api.v1.config import config
 import os
 
-config.data_root_directory(
-    os.path.join(os.path.dirname(__file__), ".cognee/data_storage")
-)
+config.data_root_directory(os.path.join(os.path.dirname(__file__), ".cognee/data_storage"))
 
-config.system_root_directory(
-    os.path.join(os.path.dirname(__file__), ".cognee/system")
-)
+config.system_root_directory(os.path.join(os.path.dirname(__file__), ".cognee/system"))
 ```
 
 ## Examples
@@ -267,29 +263,31 @@ from cognee_integration_google_adk import search_tool
 from google.adk.agents import Agent
 from google.adk.runners import InMemoryRunner
 
+
 async def main():
     # Pre-load data
     await cognee.add("Important company information here...")
     await cognee.add("More data to remember...")
     await cognee.cognify()  # Process and index the data
-    
+
     # Now create an agent that can search this data
     agent = Agent(
         model="gemini-2.5-flash",
         name="analyst",
         description="Analyst with access to company knowledge base",
         instruction="You have access to our company knowledge base.",
-        tools=[search_tool]
+        tools=[search_tool],
     )
-    
+
     runner = InMemoryRunner(agent=agent)
     events = await runner.run_debug("What information do we have?")
-    
+
     for event in events:
         if event.is_final_response() and event.content:
             for part in event.content.parts:
                 if part.text:
                     print(part.text)
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -301,10 +299,12 @@ if __name__ == "__main__":
 import asyncio
 import cognee
 
+
 async def reset_knowledge_base():
     """Clear all data and reset the knowledge base"""
     await cognee.prune.prune_data()
     await cognee.prune.prune_system(metadata=True)
+
 
 async def visualize_knowledge_graph():
     """Generate a visualization of the knowledge graph"""
@@ -319,6 +319,7 @@ from google.adk.agents import Agent
 from google.adk.runners import InMemoryRunner
 from cognee_integration_google_adk import add_tool, search_tool
 
+
 async def main():
     # Create a data entry agent
     data_agent = Agent(
@@ -326,36 +327,35 @@ async def main():
         name="data_collector",
         description="Collects and stores information",
         instruction="You collect and store important information.",
-        tools=[add_tool]
+        tools=[add_tool],
     )
-    
+
     # Create a research agent
     research_agent = Agent(
         model="gemini-2.5-flash",
         name="researcher",
         description="Searches and analyzes stored information",
         instruction="You search and analyze information from the knowledge base.",
-        tools=[search_tool]
+        tools=[search_tool],
     )
-    
+
     data_runner = InMemoryRunner(agent=data_agent)
     research_runner = InMemoryRunner(agent=research_agent)
-    
+
     # Store data
-    await data_runner.run_debug(
-        "Store this: Project Alpha launched in Q1 2024 with $5M budget"
-    )
-    
+    await data_runner.run_debug("Store this: Project Alpha launched in Q1 2024 with $5M budget")
+
     # Search data
     events = await research_runner.run_debug(
         "When did Project Alpha launch and what was the budget?"
     )
-    
+
     for event in events:
         if event.is_final_response() and event.content:
             for part in event.content.parts:
                 if part.text:
                     print(part.text)
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/integrations/hermes-agent/cognee_integration_hermes/config.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/config.py
@@ -79,7 +79,7 @@ def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
             "COGNEE_HERMES_USER_PASSWORD",
             DEFAULT_IDENTITY_PASSWORD,
         ),
-        "recall_timeout": str_to_int(os.environ.get("COGNEE_RECALL_TIMEOUT"), 60),
+        "recall_timeout": str_to_int(os.environ.get("COGNEE_RECALL_TIMEOUT"), 120),
         "write_timeout": str_to_int(os.environ.get("COGNEE_WRITE_TIMEOUT"), 120),
         "improve_timeout": str_to_int(os.environ.get("COGNEE_IMPROVE_TIMEOUT"), 300),
     }
@@ -96,7 +96,7 @@ def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
             pass
 
     config["top_k"] = max(1, str_to_int(config.get("top_k"), 5))
-    config["recall_timeout"] = max(1, str_to_int(config.get("recall_timeout"), 60))
+    config["recall_timeout"] = max(1, str_to_int(config.get("recall_timeout"), 120))
     config["write_timeout"] = max(1, str_to_int(config.get("write_timeout"), 120))
     config["improve_timeout"] = max(1, str_to_int(config.get("improve_timeout"), 300))
     config["local_port"] = min(65535, max(1, str_to_int(config.get("local_port"), 8000)))

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -384,7 +384,7 @@ class CogneeMemoryProvider(MemoryProvider):
             try:
                 results = self._bridge.run(
                     self._do_recall(query, None, min(self._top_k, 5), "auto", cognee_session_id),
-                    timeout=float(self._config.get("recall_timeout", 60)),
+                    timeout=float(self._config.get("recall_timeout", 120)),
                 )
                 lines = self._format_recall_lines(results, limit=5)
                 if lines:
@@ -726,7 +726,7 @@ class CogneeMemoryProvider(MemoryProvider):
         try:
             results = self._bridge.run(
                 self._do_recall(query, search_type, top_k, scope, self._session_cognee_id),
-                timeout=float(self._config.get("recall_timeout", 60)),
+                timeout=float(self._config.get("recall_timeout", 120)),
             )
             self._record_success()
             items = [self._normalize_recall_item(item) for item in results]

--- a/integrations/langgraph/README.md
+++ b/integrations/langgraph/README.md
@@ -37,27 +37,27 @@ from langchain_core.messages import HumanMessage
 from cognee_integration_langgraph import get_sessionized_cognee_tools
 import cognee
 
-async def main():  
+
+async def main():
     # Get sessionized tools with a custom session ID
     add_tool, search_tool = get_sessionized_cognee_tools("user-123")
-    
+
     # Or get regular tools without sessionization (auto-generates a session ID)
     # add_tool, search_tool = get_sessionized_cognee_tools()
-    
+
     # Create an agent with memory capabilities
     agent = create_agent(
         "openai:gpt-4o-mini",
         tools=[add_tool, search_tool],
     )
-    
+
     # Use the agent (note: must use await with .ainvoke())
-    response = await agent.ainvoke({
-        "messages": [
-            HumanMessage(content="Remember: I like pizza and coding in Python")
-        ]
-    })
-    
+    response = await agent.ainvoke(
+        {"messages": [HumanMessage(content="Remember: I like pizza and coding in Python")]}
+    )
+
     print(response["messages"][-1].content)
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -97,15 +97,16 @@ import asyncio
 from cognee_integration_langgraph import get_sessionized_cognee_tools
 from langchain.agents import create_agent
 
+
 async def main():
     # Each user gets their own isolated session
     user1_add, user1_search = get_sessionized_cognee_tools("user-123")
     user2_add, user2_search = get_sessionized_cognee_tools("user-456")
-    
+
     # Create separate agents for each user
     agent1 = create_agent("openai:gpt-4o-mini", tools=[user1_add, user1_search])
     agent2 = create_agent("openai:gpt-4o-mini", tools=[user2_add, user2_search])
-    
+
     # Each agent works with isolated data
     await agent1.ainvoke({"messages": [...]})
     await agent2.ainvoke({"messages": [...]})

--- a/integrations/openclaw-skills/README.md
+++ b/integrations/openclaw-skills/README.md
@@ -83,7 +83,7 @@ All options live under the plugin's `config` key:
 | `autoAmendify` | boolean | `false` | Auto-fix failing skills after runs |
 | `amendifyMinRuns` | number | `3` | Failed runs required before amendify triggers |
 | `amendifyScoreThreshold` | number | `0.5` | Runs scoring below this count as failures |
-| `requestTimeoutMs` | number | `60000` | API request timeout (ms) -- raise to 300000 for LLM calls |
+| `requestTimeoutMs` | number | `120000` | API request timeout (ms) -- raise to 300000 for LLM calls |
 | `ingestionTimeoutMs` | number | `300000` | Skill ingestion timeout (ms) |
 
 ## CLI

--- a/integrations/openclaw-skills/index.ts
+++ b/integrations/openclaw-skills/index.ts
@@ -97,7 +97,7 @@ const DEFAULT_AUTO_OBSERVE = true;
 const DEFAULT_AUTO_AMENDIFY = false;
 const DEFAULT_AMENDIFY_MIN_RUNS = 3;
 const DEFAULT_AMENDIFY_SCORE_THRESHOLD = 0.5;
-const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
 const DEFAULT_INGESTION_TIMEOUT_MS = 300_000;
 
 const STATE_PATH = join(homedir(), ".openclaw", "skills", "cognee", "state.json");

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -385,7 +385,7 @@ This lets the agent distinguish between personal context, shared knowledge, and 
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `requestTimeoutMs` | number | `60000` | HTTP timeout for Cognee requests |
+| `requestTimeoutMs` | number | `120000` | HTTP timeout for Cognee requests |
 | `ingestionTimeoutMs` | number | `300000` | HTTP timeout for add/update requests |
 
 ### Recall budget & circuit breaker

--- a/integrations/openclaw/src/client.ts
+++ b/integrations/openclaw/src/client.ts
@@ -15,7 +15,7 @@ import type {
 
 const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY_MS = 3_000;
-const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_INGESTION_TIMEOUT_MS = 300_000;
 
 // ---------------------------------------------------------------------------

--- a/integrations/openclaw/src/config.ts
+++ b/integrations/openclaw/src/config.ts
@@ -17,7 +17,7 @@ export const DEFAULT_AUTO_INDEX = true;
 export const DEFAULT_AUTO_COGNIFY = true;
 export const DEFAULT_AUTO_MEMIFY = false;
 export const DEFAULT_IMPROVE_ON_SESSION_END = true;
-export const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+export const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
 export const DEFAULT_INGESTION_TIMEOUT_MS = 300_000;
 
 // Recall hot path — same defaults as the claude-code/codex integrations

--- a/integrations/opencode/src/client.ts
+++ b/integrations/opencode/src/client.ts
@@ -10,7 +10,7 @@ import type {
 
 const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY_MS = 3_000;
-const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_INGESTION_TIMEOUT_MS = 300_000;
 
 export class CogneeHttpClient {

--- a/integrations/opencode/src/plugin.ts
+++ b/integrations/opencode/src/plugin.ts
@@ -21,7 +21,7 @@ function resolveConfig(customConfig?: Partial<CogneePluginConfig>): Required<Cog
     maxTokens: customConfig?.maxTokens || 1000,
     autoRecall: customConfig?.autoRecall !== false,
     improveOnSessionEnd: customConfig?.improveOnSessionEnd !== false,
-    requestTimeoutMs: customConfig?.requestTimeoutMs || 60000,
+    requestTimeoutMs: customConfig?.requestTimeoutMs || 120000,
     ingestionTimeoutMs: customConfig?.ingestionTimeoutMs || 300000,
   };
 }

--- a/integrations/second-brain/cognee_integration_second_brain/http_client.py
+++ b/integrations/second-brain/cognee_integration_second_brain/http_client.py
@@ -28,7 +28,7 @@ class CogneeHttpClient:
         api_key: Optional[str] = None,
         *,
         client: Any = None,
-        timeout: float = 60.0,
+        timeout: float = 120.0,
     ) -> None:
         self.base_url = (base_url or os.getenv("COGNEE_BASE_URL", "http://localhost:8000")).rstrip(
             "/"

--- a/integrations/telegram/cognee_integration_telegram/http_client.py
+++ b/integrations/telegram/cognee_integration_telegram/http_client.py
@@ -27,7 +27,7 @@ class CogneeHttpClient:
         api_key: Optional[str] = None,
         *,
         client: Any = None,
-        timeout: float = 60.0,
+        timeout: float = 120.0,
     ) -> None:
         self.base_url = (base_url or os.getenv("COGNEE_BASE_URL", "http://localhost:8000")).rstrip(
             "/"

--- a/integrations/vellum-assistant/src/cognee-client.ts
+++ b/integrations/vellum-assistant/src/cognee-client.ts
@@ -101,7 +101,7 @@ export async function doRecall(
   topK: number,
   dataset = "",
   contextProfile = "",
-  timeoutMs = 20_000,
+  timeoutMs = 120_000,
 ): Promise<RecallResult> {
   const url = `${baseUrl.replace(/\/+$/, "")}/api/v1/recall`;
   const body: Record<string, unknown> = {
@@ -226,7 +226,7 @@ export async function doRemember(
   content: string,
   dataset: string,
   nodeSet: string,
-  timeoutMs = 30_000,
+  timeoutMs = 120_000,
 ): Promise<Record<string, unknown> | typeof UNREACHABLE> {
   const url = `${baseUrl.replace(/\/+$/, "")}/api/v1/remember`;
   const boundary = `----cognee-plugin${Date.now()}`;

--- a/integrations/web-widget/cognee_integration_web_widget/http_client.py
+++ b/integrations/web-widget/cognee_integration_web_widget/http_client.py
@@ -31,7 +31,7 @@ class CogneeHttpClient:
         api_key: Optional[str] = None,
         *,
         client: Any = None,
-        timeout: float = 60.0,
+        timeout: float = 120.0,
     ) -> None:
         self.base_url = (base_url or os.getenv("COGNEE_BASE_URL", "http://localhost:8000")).rstrip(
             "/"


### PR DESCRIPTION
## Summary

Implements [SDK-266](https://linear.app/cognee/issue/SDK-266/extend-timeout-to-120-seconds-for-claude-code-and-integrations): raises the default timeouts for cognee data operations (recall, remember, dataset CRUD) to 120 seconds across the integrations.

**Changed defaults (previous → 120s):**
- **claude-code plugin**: hook timeouts in `hooks.json` (15s/90s), `do_recall` (20s), `do_remember` (60s), `COGNEE_RECALL_TIMEOUT` breaker default (20s)
- **codex plugin**: same set as claude-code (all hook timeouts were 15s)
- **openclaw / openclaw-skills / opencode**: `DEFAULT_REQUEST_TIMEOUT_MS` / `DEFAULT_TIMEOUT_MS` (60s) plus the opencode `resolveConfig` fallback; README config tables updated
- **vellum-assistant**: `doRecall` (20s), `doRemember` (30s)
- **web-widget / telegram / second-brain / chat-memory**: Python HTTP client `timeout` default (60s)
- **hermes-agent**: `recall_timeout` default (60s) in config and provider fallbacks
- **dify tools**: add/create/get/delete operations (30–60s)

**Intentionally unchanged:** health/readiness probes, login calls, the in-hook 2.5s recall fast-path budget (`session-context-lookup`), and anything already ≥ 120s (slack 120s, vscode 300s, n8n 300–600s, ingestion timeouts).

All values remain overridable via existing env vars / config options.

## Testing

- `claude-code` and `codex` pytest suites: no new failures (the 9 failures in `test_improve_sync.py` / `test_bridge_poll.py` are pre-existing on main, verified via stash).
- Verified no tests assert the old default values (TS tests pass timeouts explicitly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)