### PR TITLE
Fix urlopen test doubles to accept the context keyword

### DIFF
--- a/integrations/claude-code/tests/test_bridge_poll.py
+++ b/integrations/claude-code/tests/test_bridge_poll.py
@@ -43,7 +43,7 @@ def test_post_remember_document_background_and_parses_ids():
     captured = {}
     orig = urllib.request.urlopen
 
-    def _fake(req, timeout=None):
+    def _fake(req, timeout=None, context=None):
         captured["req"] = req
         return _Resp(b'{"status":"running","dataset_id":"d1","pipeline_run_id":"p1"}')
 
@@ -166,7 +166,7 @@ def test_post_remember_document_http_error_returns_not_ok():
     # {"ok": False} (graceful) rather than letting it crash the bridge.
     orig = urllib.request.urlopen
 
-    def _raise(req, timeout=None):
+    def _raise(req, timeout=None, context=None):
         raise urllib.error.HTTPError("http://x", 503, "Service Unavailable", {}, None)
 
     urllib.request.urlopen = _raise
@@ -183,7 +183,7 @@ def test_post_remember_document_parse_error_flag():
     # 2xx with an unparseable body (e.g. a proxy error page) flags parse_error.
     orig = urllib.request.urlopen
 
-    def _bad_json(req, timeout=None):
+    def _bad_json(req, timeout=None, context=None):
         return _Resp(b"<html>502 Bad Gateway</html>")
 
     urllib.request.urlopen = _bad_json
@@ -203,7 +203,7 @@ def test_post_remember_document_network_error_returns_not_ok():
     # abort the whole bridge via the caller's outer handler.
     orig = urllib.request.urlopen
 
-    def _raise(req, timeout=None):
+    def _raise(req, timeout=None, context=None):
         raise urllib.error.URLError("connection timed out")
 
     urllib.request.urlopen = _raise

--- a/integrations/claude-code/tests/test_improve_sync.py
+++ b/integrations/claude-code/tests/test_improve_sync.py
@@ -55,7 +55,7 @@ def test_improve_posts_expected_json_payload():
     captured = {}
     orig = urllib.request.urlopen
 
-    def _fake(req, timeout=None):
+    def _fake(req, timeout=None, context=None):
         captured["req"] = req
         captured["timeout"] = timeout
         return _Resp(b'{"status":"running"}')
@@ -81,7 +81,7 @@ def test_improve_404_marks_unsupported():
     marker_writes = {}
     orig = urllib.request.urlopen
 
-    def _raise(req, timeout=None):
+    def _raise(req, timeout=None, context=None):
         raise urllib.error.HTTPError("http://x", 404, "Not Found", {}, None)
 
     urllib.request.urlopen = _raise
@@ -104,7 +104,7 @@ def test_improve_404_marks_unsupported():
 def test_improve_network_error_is_graceful():
     orig = urllib.request.urlopen
 
-    def _raise(req, timeout=None):
+    def _raise(req, timeout=None, context=None):
         raise urllib.error.URLError("connection refused")
 
     urllib.request.urlopen = _raise
@@ -124,7 +124,7 @@ def test_improve_polls_when_dataset_id_present():
     polled = []
     orig = urllib.request.urlopen
 
-    def _fake(req, timeout=None):
+    def _fake(req, timeout=None, context=None):
         return _Resp(b'{"status":"running","dataset_id":"d1"}')
 
     def _wait(dataset_id, *, deadline_seconds, **kw):
@@ -216,7 +216,7 @@ def test_improve_lock_skip_reports_busy():
     # must surface that as busy, never as success.
     orig = urllib.request.urlopen
 
-    def _fake(req, timeout=None):
+    def _fake(req, timeout=None, context=None):
         return _Resp(b"{}")
 
     urllib.request.urlopen = _fake


### PR DESCRIPTION
## Summary

The full Claude Code suite currently fails on `main` with nine errors of the form:

```
TypeError: _fake() got an unexpected keyword argument 'context'
```

The production HTTP helpers in `integrations/claude-code/scripts/_plugin_common.py` pass `context=_https_context()` to `urllib.request.urlopen`, but the monkeypatched `urlopen` fakes in `tests/test_bridge_poll.py` (4) and `tests/test_improve_sync.py` (5) still had the old `(req, timeout=None)` signature.

This was reported in a comment on #275 as the reason a contributor stepped back from that issue; this PR validates that report (exactly nine failures, all this TypeError) and fixes it by adding `context=None` to each fake's signature.

## Test plan

- `python3 -m pytest integrations/claude-code/tests/` — was `9 failed, 129 passed` on main, now `138 passed`.

Unblocks the capture-side fix for #275 (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)