### PR TITLE
Sanitize lone Unicode surrogates in capture hooks (fixes #275)

### DIFF
--- a/integrations/claude-code/scripts/store-to-session.py
+++ b/integrations/claude-code/scripts/store-to-session.py
@@ -89,13 +89,19 @@ async def _fire_improve_background(dataset: str, session_id: str, user, reason: 
 
 
 def _truncate_str(value, cap: int) -> str:
-    """Coerce to string and cap at ``cap`` bytes (utf-8), appending ``...`` if truncated."""
+    """Coerce to string and cap at ``cap`` bytes (utf-8), appending ``...`` if truncated.
+
+    Always round-trips through utf-8 with errors="replace": hook payloads can
+    carry lone surrogates (binary tool output rendered into the transcript),
+    and one stored surrogate 500s the session-detail endpoint and wedges the
+    improve pipeline server-side.
+    """
     if value is None:
         return ""
     text = value if isinstance(value, str) else json.dumps(value, default=str, ensure_ascii=False)
     encoded = text.encode("utf-8", errors="replace")
     if len(encoded) <= cap:
-        return text
+        return encoded.decode("utf-8")
     return encoded[: cap - 3].decode("utf-8", errors="ignore") + "..."
 
 

--- a/integrations/claude-code/scripts/store-user-prompt.py
+++ b/integrations/claude-code/scripts/store-user-prompt.py
@@ -158,9 +158,13 @@ async def _store(prompt: str, payload: dict):
         except Exception as exc:
             hook_log("prompt_prepare_warning", {"error": str(exc)[:200]})
 
+    # Round-trip through utf-8 with errors="replace": prompts pasted from
+    # transcripts can carry lone surrogates, and one stored surrogate 500s
+    # the session-detail endpoint and wedges the improve pipeline server-side.
+    safe_prompt = prompt[:MAX_TEXT].encode("utf-8", errors="replace").decode("utf-8")
     remember_pending_prompt(
         session_id,
-        prompt[:MAX_TEXT],
+        safe_prompt,
         turn_id=str(payload.get("turn_id") or ""),
         context=_prompt_context(payload),
     )

--- a/integrations/claude-code/tests/test_surrogate_sanitization.py
+++ b/integrations/claude-code/tests/test_surrogate_sanitization.py
@@ -1,0 +1,131 @@
+"""Regression tests for lone-Unicode-surrogate sanitization in the capture hooks.
+
+Claude Code transcripts / hook payloads can legitimately contain lone
+surrogates (e.g. U+DC88 from binary tool output rendered into the
+transcript): json.loads accepts "\\udc88" escapes and yields a str with an
+unpaired surrogate. If such a string reaches the session cache unmodified,
+GET /api/v1/sessions/{id} 500s with UnicodeEncodeError during response
+encoding and the improve pipeline retries forever on the same character.
+
+These tests pin the capture-side fix: every stored text field must survive
+str.encode("utf-8") after passing through the hooks.
+
+Run: python -m pytest integrations/claude-code/tests/test_surrogate_sanitization.py
+"""
+
+import asyncio
+import importlib.util
+import json
+import pathlib
+import sys
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+
+def _load(module_name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(module_name, _SCRIPTS / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+store_session = _load("store_to_session_mod", "store-to-session.py")
+store_prompt = _load("store_user_prompt_mod", "store-user-prompt.py")
+
+# What json.loads produces for a hook payload carrying a lone surrogate.
+SURROGATE_TEXT = json.loads('{"v": "binary \\udc88 output"}')["v"]
+
+
+def test_payload_surrogate_reproduces_encode_error():
+    # Sanity-check the failure mode this suite guards against.
+    try:
+        SURROGATE_TEXT.encode("utf-8")
+    except UnicodeEncodeError:
+        pass
+    else:
+        raise AssertionError("expected lone surrogate to be un-encodable")
+
+
+def test_truncate_str_sanitizes_untruncated_text():
+    # The common case: text under the cap must NOT be returned verbatim.
+    out = store_session._truncate_str(SURROGATE_TEXT, 4000)
+    out.encode("utf-8")  # must not raise
+    assert "\udc88" not in out
+    assert out == "binary ? output"
+
+
+def test_truncate_str_sanitizes_truncated_text():
+    long_text = SURROGATE_TEXT * 500
+    out = store_session._truncate_str(long_text, 100)
+    out.encode("utf-8")  # must not raise
+    assert out.endswith("...")
+    assert "\udc88" not in out
+
+
+def test_truncate_str_sanitizes_non_string_values():
+    out = store_session._truncate_str({"nested": SURROGATE_TEXT}, 4000)
+    out.encode("utf-8")  # must not raise
+    assert "\udc88" not in out
+
+
+def test_truncate_str_none_and_plain_text_unchanged():
+    assert store_session._truncate_str(None, 100) == ""
+    assert store_session._truncate_str("plain ascii", 100) == "plain ascii"
+    assert store_session._truncate_str("émoji ✨", 100) == "émoji ✨"
+
+
+def test_infer_status_error_message_sanitized():
+    payload = {"tool_response": {"is_error": True, "error": SURROGATE_TEXT}}
+    status, err = store_session._infer_status(payload)
+    assert status == "error"
+    err.encode("utf-8")  # must not raise
+
+
+def test_store_user_prompt_sanitizes_pending_prompt():
+    # Drive _store with all module seams patched; the prompt handed to
+    # remember_pending_prompt must be strictly valid UTF-8.
+    captured = {}
+    saved = {
+        k: getattr(store_prompt, k)
+        for k in (
+            "_load_session",
+            "load_config",
+            "touch_activity",
+            "_ensure_idle_watcher",
+            "resolve_runtime_mode",
+            "server_ready_hint",
+            "remember_pending_prompt",
+            "hook_log",
+            "notify",
+            "bump_save_counter",
+        )
+    }
+    store_prompt._load_session = lambda: ("sess1", "ds", "u1")
+    store_prompt.load_config = lambda: {}
+    store_prompt.touch_activity = lambda: None
+    store_prompt._ensure_idle_watcher = lambda *a, **kw: None
+    store_prompt.resolve_runtime_mode = lambda: {"mode": "http", "base_url": "http://x"}
+    store_prompt.server_ready_hint = lambda base_url: True
+    store_prompt.remember_pending_prompt = lambda session_id, prompt, **kw: captured.update(
+        {"prompt": prompt, "context": kw.get("context", "")}
+    )
+    store_prompt.hook_log = lambda *a, **kw: None
+    store_prompt.notify = lambda *a, **kw: None
+    store_prompt.bump_save_counter = lambda *a, **kw: None
+    try:
+        asyncio.run(store_prompt._store(SURROGATE_TEXT, {"turn_id": "t1"}))
+    finally:
+        for k, v in saved.items():
+            setattr(store_prompt, k, v)
+
+    captured["prompt"].encode("utf-8")  # must not raise
+    assert "\udc88" not in captured["prompt"]
+    assert captured["prompt"] == "binary ? output"
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok {name}")


### PR DESCRIPTION
## Summary

Fixes #275.

Claude Code hook payloads can legitimately contain lone Unicode surrogates (e.g. `U+DC88` from binary tool output rendered into the transcript) — `json.loads` accepts `"\udc88"` escapes and yields a `str` with an unpaired surrogate. The capture hooks stored that text verbatim, and one poisoned session-cache entry then:

1. 500s `GET /api/v1/sessions/{session_id}` (`UnicodeEncodeError: surrogates not allowed` during response encoding), and
2. wedges the improve/cognify pipeline in an infinite litellm retry loop.

## Fix (capture-side, as proposed in the issue)

- **`scripts/store-to-session.py` — `_truncate_str()`**: the string was already encoded with `errors="replace"` for the byte-length check, but the untruncated (common) path returned the raw original, surrogates included. It now returns the sanitized round-trip (`encoded.decode("utf-8")`), so `method_params`, `method_return_value`, `error_message`, and the Stop-hook answer are always strictly valid UTF-8.
- **`scripts/store-user-prompt.py`**: the pending prompt is round-tripped through `encode("utf-8", errors="replace").decode("utf-8")` before storage.

Lone surrogates carry no recoverable information (they are artifacts of binary data forced through JSON), so replacing them loses nothing while keeping the cache strictly valid UTF-8.

## Tests

New `tests/test_surrogate_sanitization.py` (7 tests):
- reproduces the failure mode (`str.encode("utf-8")` raises on the payload text),
- pins sanitization of untruncated, truncated, and non-string values through `_truncate_str`,
- pins that plain ASCII / real Unicode text passes through unchanged,
- pins the `_infer_status` error-message path,
- drives `store-user-prompt._store` end-to-end (seams patched) and asserts the stored prompt is valid UTF-8.

`python3 -m pytest integrations/claude-code/tests/` — the 9 remaining failures on this branch are the pre-existing `urlopen ... unexpected keyword argument 'context'` failures on `main`, fixed separately in #295. With #295's test-double fix applied locally, the combined suite is fully green: **145 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)