### PR TITLE
Fix ruff lint failures on main and pin ruff version in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install ruff
-        run: uv tool install ruff
+        run: uv tool install ruff==0.16.0
 
       - name: Check formatting
         run: ruff format --check integrations/

--- a/integrations/aider/README.md
+++ b/integrations/aider/README.md
@@ -51,9 +51,11 @@ from cognee_integration_aider import get_sessionized_cognee_tools
 
 remember, recall = get_sessionized_cognee_tools("my-project")
 
+
 async def main():
     await remember("We decided to use PostgreSQL with pgvector.")
     print(await recall("What database did we choose?"))
+
 
 asyncio.run(main())
 ```

--- a/integrations/chat-memory/README.md
+++ b/integrations/chat-memory/README.md
@@ -45,7 +45,10 @@ install the extra: `pip install -e ".[sdk]"`.
 
 ```python
 from cognee_integration_chat_memory import (
-    ChatMemoryAdapter, Conversation, Message, per_channel_scope,
+    ChatMemoryAdapter,
+    Conversation,
+    Message,
+    per_channel_scope,
 )
 
 # Default backend talks to a running cognee server (COGNEE_BASE_URL / COGNEE_API_KEY).
@@ -53,8 +56,9 @@ adapter = ChatMemoryAdapter(scope=per_channel_scope)
 
 convo = Conversation(platform="slack", workspace="T1", channel="C1", user="U1")
 adapter.set_consent("U1", True)
-await adapter.ingest(convo, Message(text="We ship on Friday.", user="U1",
-                                    permalink="https://slack/archives/C1/p1"))
+await adapter.ingest(
+    convo, Message(text="We ship on Friday.", user="U1", permalink="https://slack/archives/C1/p1")
+)
 answer = await adapter.answer(convo, "when do we ship?")
 print(answer.text)
 for c in answer.citations:

--- a/integrations/claude-agent-sdk/README.md
+++ b/integrations/claude-agent-sdk/README.md
@@ -60,45 +60,43 @@ from cognee_integration_claude import cognee_tools
 
 load_dotenv()
 
+
 async def main():
     # Clean up memory to start fresh (Optional)
     await cognee.forget(everything=True)
-    
+
     # Create an MCP server with Cognee tools
-    server = create_sdk_mcp_server(
-        name="cognee-tools",
-        version="1.0.0",
-        tools=cognee_tools()
-    )
-    
+    server = create_sdk_mcp_server(name="cognee-tools", version="1.0.0", tools=cognee_tools())
+
     # Configure the agent
     options = ClaudeAgentOptions(
         mcp_servers={"tools": server},
         allowed_tools=["mcp__tools__remember", "mcp__tools__recall"],
     )
-    
+
     # Use the agent to store information
     async with ClaudeSDKClient(options=options) as client:
         await client.query(
             "Remember that our company signed a contract with HealthBridge Systems "
             "in the healthcare industry, starting Feb 2023, ending Jan 2026, worth £2.4M"
         )
-        
+
         async for msg in client.receive_response():
             if isinstance(msg, AssistantMessage):
                 for block in msg.content:
                     if isinstance(block, TextBlock):
                         print(f"Claude: {block.text}")
-    
+
     # Query the stored information (new agent instance)
     async with ClaudeSDKClient(options=options) as client:
         await client.query("What contracts do we have in the healthcare industry?")
-        
+
         async for msg in client.receive_response():
             if isinstance(msg, AssistantMessage):
                 for block in msg.content:
                     if isinstance(block, TextBlock):
                         print(f"Claude: {block.text}")
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -180,7 +178,7 @@ from cognee_integration_claude import cognee_tools
 server = create_sdk_mcp_server(
     name="memory-tools",
     version="1.0.0",
-    tools=cognee_tools(),                  # or cognee_tools(session_id="user-123")
+    tools=cognee_tools(),  # or cognee_tools(session_id="user-123")
 )
 
 options = ClaudeAgentOptions(
@@ -206,7 +204,7 @@ defaults. Returns cognee's `RememberResult`.
 ```python
 from cognee_integration_claude import remember
 
-await remember("Einstein was born in Ulm.")                       # cognee defaults
+await remember("Einstein was born in Ulm.")  # cognee defaults
 ```
 
 ### `recall(query_text, **kwargs)`
@@ -221,7 +219,9 @@ use `render_results(...)` to flatten it to plain strings.
 import cognee
 from cognee_integration_claude import recall, render_results
 
-results = await recall("healthcare contracts", query_type=cognee.SearchType.GRAPH_COMPLETION, top_k=20)
+results = await recall(
+    "healthcare contracts", query_type=cognee.SearchType.GRAPH_COMPLETION, top_k=20
+)
 texts = render_results(results)
 ```
 
@@ -265,13 +265,9 @@ You can customize Cognee's data and system directories:
 from cognee.api.v1.config import config
 import os
 
-config.data_root_directory(
-    os.path.join(os.path.dirname(__file__), ".cognee/data_storage")
-)
+config.data_root_directory(os.path.join(os.path.dirname(__file__), ".cognee/data_storage"))
 
-config.system_root_directory(
-    os.path.join(os.path.dirname(__file__), ".cognee/system")
-)
+config.system_root_directory(os.path.join(os.path.dirname(__file__), ".cognee/system"))
 ```
 
 ## Examples
@@ -302,33 +298,31 @@ from claude_agent_sdk import (
 )
 from cognee_integration_claude import cognee_tools
 
+
 async def main():
     # Pre-load data directly into Cognee. cognee.remember extracts entities and
     # relationships and persists them — no separate cognify() step needed.
     await cognee.remember("Important company information here...")
     await cognee.remember("More data to remember...")
-    
+
     # Now create an agent that can search this data
-    server = create_sdk_mcp_server(
-        name="cognee-tools",
-        version="1.0.0",
-        tools=cognee_tools()
-    )
-    
+    server = create_sdk_mcp_server(name="cognee-tools", version="1.0.0", tools=cognee_tools())
+
     # Allow only recall if you want a read-only agent
     options = ClaudeAgentOptions(
         mcp_servers={"tools": server},
         allowed_tools=["mcp__tools__recall"],
     )
-    
+
     async with ClaudeSDKClient(options=options) as client:
         await client.query("What information do we have?")
-        
+
         async for msg in client.receive_response():
             if isinstance(msg, AssistantMessage):
                 for block in msg.content:
                     if isinstance(block, TextBlock):
                         print(block.text)
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -340,9 +334,11 @@ if __name__ == "__main__":
 import asyncio
 import cognee
 
+
 async def reset_knowledge_base():
     """Clear all data and reset the knowledge base"""
     await cognee.forget(everything=True)
+
 
 async def visualize_knowledge_graph():
     """Render the knowledge graph.
@@ -367,9 +363,21 @@ options = ClaudeAgentOptions(
     mcp_servers={"tools": server},
     allowed_tools=["mcp__tools__remember", "mcp__tools__recall"],
     disallowed_tools=[
-        "Task", "Bash", "Glob", "Grep", "ExitPlanMode",
-        "Read", "Edit", "Write", "NotebookEdit", "WebFetch",
-        "TodoWrite", "WebSearch", "BashOutput", "KillShell", "SlashCommand",
+        "Task",
+        "Bash",
+        "Glob",
+        "Grep",
+        "ExitPlanMode",
+        "Read",
+        "Edit",
+        "Write",
+        "NotebookEdit",
+        "WebFetch",
+        "TodoWrite",
+        "WebSearch",
+        "BashOutput",
+        "KillShell",
+        "SlashCommand",
     ],
 )
 ```

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -618,7 +618,9 @@ def append_http_bridge_entry(
         return
     if not (question or answer or trace):
         return
-    question, answer, trace = _strip_surrogates(question), _strip_surrogates(answer), _strip_surrogates(trace)
+    question = _strip_surrogates(question)
+    answer = _strip_surrogates(answer)
+    trace = _strip_surrogates(trace)
 
     with _buffer_lock():
         cache = _load_json_file(_bridge_file(session_id))

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -115,7 +115,7 @@ def _update_segment() -> str:
 
 
 def _pipeline_health_glyph() -> str:
-    """"⚠ N " when the pipeline sweep (scripts/pipeline_sweep.py) has a fresh,
+    """ "⚠ N " when the pipeline sweep (scripts/pipeline_sweep.py) has a fresh,
     non-stale finding of one or more stuck runs or a down server; "" otherwise
     (no file yet, stale, or everything's clean). See
     docs/KB/pipeline-monitor-notify-policy.md for the full monitoring design this
@@ -138,11 +138,12 @@ def _pipeline_health_glyph() -> str:
     if server.get("up") is False:
         return "⚠ server-down "
     summary = raw.get("summary") or {}
-    total_open = int(summary.get("total_open") or 0)
     worst = str(summary.get("worst_classification") or "ok")
-    flagged = sum((summary.get("by_classification") or {}).values()) if isinstance(
-        summary.get("by_classification"), dict
-    ) else 0
+    flagged = (
+        sum((summary.get("by_classification") or {}).values())
+        if isinstance(summary.get("by_classification"), dict)
+        else 0
+    )
     if worst in ("alert", "critical") and flagged > 0:
         return f"⚠ {flagged} pipeline(s) stuck "
     return ""
@@ -239,7 +240,8 @@ def main() -> None:
         return
 
     sys.stdout.write(
-        f"{_pipeline_health_glyph()}{_health_prefix()}cognee: {_active_dataset()} · {_active_mode()}{_update_segment()}"
+        f"{_pipeline_health_glyph()}{_health_prefix()}"
+        f"cognee: {_active_dataset()} · {_active_mode()}{_update_segment()}"
     )
 
 

--- a/integrations/claude-code/tests/test_statusline_pipeline_health.py
+++ b/integrations/claude-code/tests/test_statusline_pipeline_health.py
@@ -43,6 +43,7 @@ def _write(path, payload):
 
 # ── no file / malformed file → silently empty, never raises ─────────────────
 
+
 def test_no_file_returns_empty_string():
     tmp = _tmp_path()  # never written
     orig = sl._PIPELINE_HEALTH_PATH
@@ -69,14 +70,21 @@ def test_malformed_json_returns_empty_string():
 
 # ── staleness gate ────────────────────────────────────────────────────────
 
+
 def test_stale_file_returns_empty_even_if_it_would_otherwise_warn():
     tmp = _tmp_path()
-    _write(tmp, {
-        "generated_at": _iso(delta_seconds=sl._PIPELINE_HEALTH_STALE_SECONDS + 60),
-        "server": {"up": True},
-        "summary": {"total_open": 1, "worst_classification": "critical",
-                    "by_classification": {"warn": 0, "alert": 0, "critical": 1}},
-    })
+    _write(
+        tmp,
+        {
+            "generated_at": _iso(delta_seconds=sl._PIPELINE_HEALTH_STALE_SECONDS + 60),
+            "server": {"up": True},
+            "summary": {
+                "total_open": 1,
+                "worst_classification": "critical",
+                "by_classification": {"warn": 0, "alert": 0, "critical": 1},
+            },
+        },
+    )
     orig = sl._PIPELINE_HEALTH_PATH
     try:
         sl._PIPELINE_HEALTH_PATH = tmp
@@ -100,14 +108,21 @@ def test_missing_generated_at_returns_empty():
 
 # ── clean state → empty ──────────────────────────────────────────────────
 
+
 def test_fresh_clean_state_returns_empty():
     tmp = _tmp_path()
-    _write(tmp, {
-        "generated_at": _iso(),
-        "server": {"up": True},
-        "summary": {"total_open": 3, "worst_classification": "ok",
-                    "by_classification": {"warn": 0, "alert": 0, "critical": 0}},
-    })
+    _write(
+        tmp,
+        {
+            "generated_at": _iso(),
+            "server": {"up": True},
+            "summary": {
+                "total_open": 3,
+                "worst_classification": "ok",
+                "by_classification": {"warn": 0, "alert": 0, "critical": 0},
+            },
+        },
+    )
     orig = sl._PIPELINE_HEALTH_PATH
     try:
         sl._PIPELINE_HEALTH_PATH = tmp
@@ -120,12 +135,18 @@ def test_fresh_clean_state_returns_empty():
 def test_warn_only_returns_empty_never_pushed_never_shown():
     """Matches the notify-policy doc: bare warn is tracked, never surfaced."""
     tmp = _tmp_path()
-    _write(tmp, {
-        "generated_at": _iso(),
-        "server": {"up": True},
-        "summary": {"total_open": 1, "worst_classification": "warn",
-                    "by_classification": {"warn": 1, "alert": 0, "critical": 0}},
-    })
+    _write(
+        tmp,
+        {
+            "generated_at": _iso(),
+            "server": {"up": True},
+            "summary": {
+                "total_open": 1,
+                "worst_classification": "warn",
+                "by_classification": {"warn": 1, "alert": 0, "critical": 0},
+            },
+        },
+    )
     orig = sl._PIPELINE_HEALTH_PATH
     try:
         sl._PIPELINE_HEALTH_PATH = tmp
@@ -137,14 +158,21 @@ def test_warn_only_returns_empty_never_pushed_never_shown():
 
 # ── real findings → glyph shown ──────────────────────────────────────────
 
+
 def test_server_down_takes_priority_and_shows_its_own_glyph():
     tmp = _tmp_path()
-    _write(tmp, {
-        "generated_at": _iso(),
-        "server": {"up": False},
-        "summary": {"total_open": 0, "worst_classification": "ok",
-                    "by_classification": {"warn": 0, "alert": 0, "critical": 0}},
-    })
+    _write(
+        tmp,
+        {
+            "generated_at": _iso(),
+            "server": {"up": False},
+            "summary": {
+                "total_open": 0,
+                "worst_classification": "ok",
+                "by_classification": {"warn": 0, "alert": 0, "critical": 0},
+            },
+        },
+    )
     orig = sl._PIPELINE_HEALTH_PATH
     try:
         sl._PIPELINE_HEALTH_PATH = tmp
@@ -156,12 +184,18 @@ def test_server_down_takes_priority_and_shows_its_own_glyph():
 
 def test_alert_classification_shows_stuck_count():
     tmp = _tmp_path()
-    _write(tmp, {
-        "generated_at": _iso(),
-        "server": {"up": True},
-        "summary": {"total_open": 5, "worst_classification": "alert",
-                    "by_classification": {"warn": 1, "alert": 2, "critical": 0}},
-    })
+    _write(
+        tmp,
+        {
+            "generated_at": _iso(),
+            "server": {"up": True},
+            "summary": {
+                "total_open": 5,
+                "worst_classification": "alert",
+                "by_classification": {"warn": 1, "alert": 2, "critical": 0},
+            },
+        },
+    )
     orig = sl._PIPELINE_HEALTH_PATH
     try:
         sl._PIPELINE_HEALTH_PATH = tmp
@@ -173,12 +207,18 @@ def test_alert_classification_shows_stuck_count():
 
 def test_critical_classification_shows_stuck_count():
     tmp = _tmp_path()
-    _write(tmp, {
-        "generated_at": _iso(),
-        "server": {"up": True},
-        "summary": {"total_open": 2, "worst_classification": "critical",
-                    "by_classification": {"warn": 0, "alert": 0, "critical": 1}},
-    })
+    _write(
+        tmp,
+        {
+            "generated_at": _iso(),
+            "server": {"up": True},
+            "summary": {
+                "total_open": 2,
+                "worst_classification": "critical",
+                "by_classification": {"warn": 0, "alert": 0, "critical": 1},
+            },
+        },
+    )
     orig = sl._PIPELINE_HEALTH_PATH
     try:
         sl._PIPELINE_HEALTH_PATH = tmp

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -455,7 +455,7 @@ async def _run(prompt: str) -> dict | None:
         "hookSpecificOutput": {
             "hookEventName": "UserPromptSubmit",
             "additionalContext": full_context,
-        }
+        },
     }
     return output
 
@@ -494,9 +494,14 @@ def main():
 
 
 if __name__ == "__main__":
-    print(json.dumps(main() or {
-        "hookSpecificOutput": {
-            "hookEventName": "UserPromptSubmit",
-            "additionalContext": "",
-        }
-    }))
+    print(
+        json.dumps(
+            main()
+            or {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": "",
+                }
+            }
+        )
+    )

--- a/integrations/codex/plugins/cognee/scripts/store-user-prompt.py
+++ b/integrations/codex/plugins/cognee/scripts/store-user-prompt.py
@@ -190,9 +190,13 @@ def main():
 
 if __name__ == "__main__":
     main()
-    print(json.dumps({
-        "hookSpecificOutput": {
-            "hookEventName": "UserPromptSubmit",
-            "additionalContext": "",
-        }
-    }))
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": "",
+                }
+            }
+        )
+    )

--- a/integrations/crewai/README.md
+++ b/integrations/crewai/README.md
@@ -32,32 +32,32 @@ from cognee_integration_crewai import add_tool, search_tool
 
 load_dotenv()
 
+
 async def main():
     # Initialize Cognee (optional - for data management)
     await cognee.prune.prune_data()
     await cognee.prune.prune_system(metadata=True)
-    
+
     # Create an agent with memory capabilities
     agent = Agent(
         role="Research Analyst",
         goal="Find and analyze information using the knowledge base",
         backstory="You are an expert analyst with access to a comprehensive knowledge base.",
         tools=[add_tool, search_tool],
-        verbose=True
+        verbose=True,
     )
-    
+
     # Use the agent to store information
     response = agent.kickoff(
         "Remember that our company signed a contract with HealthBridge Systems "
         "in the healthcare industry, starting Feb 2023, ending Jan 2026, worth £2.4M"
     )
     print(response.raw)
-    
+
     # Query the stored information
-    response = agent.kickoff(
-        "What contracts do we have in the healthcare industry?"
-    )
+    response = agent.kickoff("What contracts do we have in the healthcare industry?")
     print(response.raw)
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -97,29 +97,31 @@ import asyncio
 from crewai import Agent
 from cognee_integration_crewai import get_sessionized_cognee_tools
 
+
 async def main():
     # Each user gets their own isolated session
     user1_add, user1_search = get_sessionized_cognee_tools("user-123")
     user2_add, user2_search = get_sessionized_cognee_tools("user-456")
-    
+
     # Create separate agents for each user
     agent1 = Agent(
         role="Assistant",
         goal="Help user 1",
         backstory="You are a helpful assistant.",
-        tools=[user1_add, user1_search]
+        tools=[user1_add, user1_search],
     )
-    
+
     agent2 = Agent(
         role="Assistant",
         goal="Help user 2",
         backstory="You are a helpful assistant.",
-        tools=[user2_add, user2_search]
+        tools=[user2_add, user2_search],
     )
-    
+
     # Each agent works with isolated data
     response1 = agent1.kickoff("Remember: I like pizza")
     response2 = agent2.kickoff("Remember: I like sushi")
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -143,12 +145,10 @@ agent = Agent(
     role="Data Manager",
     goal="Store important information",
     backstory="You manage our knowledge base.",
-    tools=[add_tool]
+    tools=[add_tool],
 )
 
-response = agent.kickoff(
-    "Store this: Our Q4 revenue was $2.5M with 15% growth"
-)
+response = agent.kickoff("Store this: Our Q4 revenue was $2.5M with 15% growth")
 ```
 
 ### `search_tool(query_text: str)`
@@ -166,12 +166,10 @@ agent = Agent(
     role="Research Assistant",
     goal="Find information from our knowledge base",
     backstory="You help users find information quickly.",
-    tools=[search_tool]
+    tools=[search_tool],
 )
 
-response = agent.kickoff(
-    "What was our Q4 revenue?"
-)
+response = agent.kickoff("What was our Q4 revenue?")
 ```
 
 ### `get_sessionized_cognee_tools(session_id: Optional[str] = None)`
@@ -217,13 +215,9 @@ You can customize Cognee's data and system directories:
 from cognee.api.v1.config import config
 import os
 
-config.data_root_directory(
-    os.path.join(os.path.dirname(__file__), ".cognee/data_storage")
-)
+config.data_root_directory(os.path.join(os.path.dirname(__file__), ".cognee/data_storage"))
 
-config.system_root_directory(
-    os.path.join(os.path.dirname(__file__), ".cognee/system")
-)
+config.system_root_directory(os.path.join(os.path.dirname(__file__), ".cognee/system"))
 ```
 
 ## Examples
@@ -245,22 +239,24 @@ import cognee
 from cognee_integration_crewai import search_tool
 from crewai import Agent
 
+
 async def main():
     # Pre-load data
     await cognee.add("Important company information here...")
     await cognee.add("More data to remember...")
     await cognee.cognify()  # Process and index the data
-    
+
     # Now create an agent that can search this data
     agent = Agent(
         role="Analyst",
         goal="Answer questions using pre-loaded data",
         backstory="You have access to our company knowledge base.",
-        tools=[search_tool]
+        tools=[search_tool],
     )
-    
+
     response = agent.kickoff("What information do we have?")
     print(response.raw)
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -272,10 +268,12 @@ if __name__ == "__main__":
 import asyncio
 import cognee
 
+
 async def reset_knowledge_base():
     """Clear all data and reset the knowledge base"""
     await cognee.prune.prune_data()
     await cognee.prune.prune_system(metadata=True)
+
 
 async def visualize_knowledge_graph():
     """Generate a visualization of the knowledge graph"""

--- a/integrations/google-adk/README.md
+++ b/integrations/google-adk/README.md
@@ -34,11 +34,12 @@ from cognee_integration_google_adk import add_tool, search_tool
 
 load_dotenv()
 
+
 async def main():
     # Initialize Cognee (optional - for data management)
     await cognee.prune.prune_data()
     await cognee.prune.prune_system(metadata=True)
-    
+
     # Create an agent with memory capabilities
     agent = Agent(
         model="gemini-2.5-flash",
@@ -47,32 +48,31 @@ async def main():
         instruction="You are an expert research analyst with access to a comprehensive knowledge base.",
         tools=[add_tool, search_tool],
     )
-    
+
     runner = InMemoryRunner(agent=agent)
-    
+
     # Use the agent to store information
     events = await runner.run_debug(
         "Remember that our company signed a contract with HealthBridge Systems "
         "in the healthcare industry, starting Feb 2023, ending Jan 2026, worth £2.4M"
     )
-    
+
     # Print agent response
     for event in events:
         if event.is_final_response() and event.content:
             for part in event.content.parts:
                 if part.text:
                     print(part.text)
-    
+
     # Query the stored information
-    events = await runner.run_debug(
-        "What contracts do we have in the healthcare industry?"
-    )
-    
+    events = await runner.run_debug("What contracts do we have in the healthcare industry?")
+
     for event in events:
         if event.is_final_response() and event.content:
             for part in event.content.parts:
                 if part.text:
                     print(part.text)
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -113,34 +113,36 @@ from google.adk.agents import Agent
 from google.adk.runners import InMemoryRunner
 from cognee_integration_google_adk import get_sessionized_cognee_tools
 
+
 async def main():
     # Each user gets their own isolated session
     user1_add, user1_search = get_sessionized_cognee_tools("user-123")
     user2_add, user2_search = get_sessionized_cognee_tools("user-456")
-    
+
     # Create separate agents for each user
     agent1 = Agent(
         model="gemini-2.5-flash",
         name="assistant_1",
         description="Assistant for user 1",
         instruction="You are a helpful assistant.",
-        tools=[user1_add, user1_search]
+        tools=[user1_add, user1_search],
     )
-    
+
     agent2 = Agent(
         model="gemini-2.5-flash",
         name="assistant_2",
         description="Assistant for user 2",
         instruction="You are a helpful assistant.",
-        tools=[user2_add, user2_search]
+        tools=[user2_add, user2_search],
     )
-    
+
     runner1 = InMemoryRunner(agent=agent1)
     runner2 = InMemoryRunner(agent=agent2)
-    
+
     # Each agent works with isolated data
     await runner1.run_debug("Remember: I like pizza")
     await runner2.run_debug("Remember: I like sushi")
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -165,13 +167,11 @@ agent = Agent(
     name="data_manager",
     description="Data management specialist",
     instruction="You manage our knowledge base.",
-    tools=[add_tool]
+    tools=[add_tool],
 )
 
 runner = InMemoryRunner(agent=agent)
-await runner.run_debug(
-    "Store this: Our Q4 revenue was $2.5M with 15% growth"
-)
+await runner.run_debug("Store this: Our Q4 revenue was $2.5M with 15% growth")
 ```
 
 ### `search_tool(query_text: str, node_set: Optional[List[str]] = None)`
@@ -191,7 +191,7 @@ agent = Agent(
     name="research_assistant",
     description="Research specialist",
     instruction="You help users find information quickly.",
-    tools=[search_tool]
+    tools=[search_tool],
 )
 
 runner = InMemoryRunner(agent=agent)
@@ -238,13 +238,9 @@ You can customize Cognee's data and system directories:
 from cognee.api.v1.config import config
 import os
 
-config.data_root_directory(
-    os.path.join(os.path.dirname(__file__), ".cognee/data_storage")
-)
+config.data_root_directory(os.path.join(os.path.dirname(__file__), ".cognee/data_storage"))
 
-config.system_root_directory(
-    os.path.join(os.path.dirname(__file__), ".cognee/system")
-)
+config.system_root_directory(os.path.join(os.path.dirname(__file__), ".cognee/system"))
 ```
 
 ## Examples
@@ -267,29 +263,31 @@ from cognee_integration_google_adk import search_tool
 from google.adk.agents import Agent
 from google.adk.runners import InMemoryRunner
 
+
 async def main():
     # Pre-load data
     await cognee.add("Important company information here...")
     await cognee.add("More data to remember...")
     await cognee.cognify()  # Process and index the data
-    
+
     # Now create an agent that can search this data
     agent = Agent(
         model="gemini-2.5-flash",
         name="analyst",
         description="Analyst with access to company knowledge base",
         instruction="You have access to our company knowledge base.",
-        tools=[search_tool]
+        tools=[search_tool],
     )
-    
+
     runner = InMemoryRunner(agent=agent)
     events = await runner.run_debug("What information do we have?")
-    
+
     for event in events:
         if event.is_final_response() and event.content:
             for part in event.content.parts:
                 if part.text:
                     print(part.text)
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -301,10 +299,12 @@ if __name__ == "__main__":
 import asyncio
 import cognee
 
+
 async def reset_knowledge_base():
     """Clear all data and reset the knowledge base"""
     await cognee.prune.prune_data()
     await cognee.prune.prune_system(metadata=True)
+
 
 async def visualize_knowledge_graph():
     """Generate a visualization of the knowledge graph"""
@@ -319,6 +319,7 @@ from google.adk.agents import Agent
 from google.adk.runners import InMemoryRunner
 from cognee_integration_google_adk import add_tool, search_tool
 
+
 async def main():
     # Create a data entry agent
     data_agent = Agent(
@@ -326,36 +327,35 @@ async def main():
         name="data_collector",
         description="Collects and stores information",
         instruction="You collect and store important information.",
-        tools=[add_tool]
+        tools=[add_tool],
     )
-    
+
     # Create a research agent
     research_agent = Agent(
         model="gemini-2.5-flash",
         name="researcher",
         description="Searches and analyzes stored information",
         instruction="You search and analyze information from the knowledge base.",
-        tools=[search_tool]
+        tools=[search_tool],
     )
-    
+
     data_runner = InMemoryRunner(agent=data_agent)
     research_runner = InMemoryRunner(agent=research_agent)
-    
+
     # Store data
-    await data_runner.run_debug(
-        "Store this: Project Alpha launched in Q1 2024 with $5M budget"
-    )
-    
+    await data_runner.run_debug("Store this: Project Alpha launched in Q1 2024 with $5M budget")
+
     # Search data
     events = await research_runner.run_debug(
         "When did Project Alpha launch and what was the budget?"
     )
-    
+
     for event in events:
         if event.is_final_response() and event.content:
             for part in event.content.parts:
                 if part.text:
                     print(part.text)
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/integrations/langgraph/README.md
+++ b/integrations/langgraph/README.md
@@ -37,27 +37,27 @@ from langchain_core.messages import HumanMessage
 from cognee_integration_langgraph import get_sessionized_cognee_tools
 import cognee
 
-async def main():  
+
+async def main():
     # Get sessionized tools with a custom session ID
     add_tool, search_tool = get_sessionized_cognee_tools("user-123")
-    
+
     # Or get regular tools without sessionization (auto-generates a session ID)
     # add_tool, search_tool = get_sessionized_cognee_tools()
-    
+
     # Create an agent with memory capabilities
     agent = create_agent(
         "openai:gpt-4o-mini",
         tools=[add_tool, search_tool],
     )
-    
+
     # Use the agent (note: must use await with .ainvoke())
-    response = await agent.ainvoke({
-        "messages": [
-            HumanMessage(content="Remember: I like pizza and coding in Python")
-        ]
-    })
-    
+    response = await agent.ainvoke(
+        {"messages": [HumanMessage(content="Remember: I like pizza and coding in Python")]}
+    )
+
     print(response["messages"][-1].content)
+
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -97,15 +97,16 @@ import asyncio
 from cognee_integration_langgraph import get_sessionized_cognee_tools
 from langchain.agents import create_agent
 
+
 async def main():
     # Each user gets their own isolated session
     user1_add, user1_search = get_sessionized_cognee_tools("user-123")
     user2_add, user2_search = get_sessionized_cognee_tools("user-456")
-    
+
     # Create separate agents for each user
     agent1 = create_agent("openai:gpt-4o-mini", tools=[user1_add, user1_search])
     agent2 = create_agent("openai:gpt-4o-mini", tools=[user2_add, user2_search])
-    
+
     # Each agent works with isolated data
     await agent1.ainvoke({"messages": [...]})
     await agent2.ainvoke({"messages": [...]})


### PR DESCRIPTION
## Summary

Main currently fails the ruff lint workflow (it only triggers on PRs, so this landed unnoticed via recent merges). Every open PR that touches a Python file inherits the failure. This PR fixes the violations and pins the linter version so it can't recur silently.

**Lint/format fixes** (no behavior changes):
- `ruff format` on five files: claude-code's `_plugin_common.py`, `cognee_statusline_render.py` and its pipeline-health test, and codex's `session-context-lookup.py` / `store-user-prompt.py`
- `_plugin_common.py`: split an overlong `_strip_surrogates` triple assignment (E501)
- `cognee_statusline_render.py`: remove unused `total_open` variable (F841) and wrap an overlong statusline f-string (E501)
- Reformat Python code blocks in six READMEs (aider, chat-memory, claude-agent-sdk, crewai, google-adk, langgraph) — ruff 0.16 now formats Markdown code blocks

**CI hardening:**
- Pin `uv tool install ruff==0.16.0` in `lint.yml`. The unpinned install meant the ruff 0.16 release started failing PRs overnight with rules the code was never formatted against. Future bumps should be deliberate, paired with the reformat they require.

## Testing

- `ruff format --check integrations/` and `ruff check integrations/` pass with ruff 0.16.0 (the pinned CI version)
- claude-code, codex, and statusline pytest suites show no new failures

These commits are also on #294 (they were needed to unblock its lint run); merging either first is fine — the changes are identical and merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)