### PR TITLE
fix(claude-code): quote ${CLAUDE_PLUGIN_ROOT} in hooks for paths with spaces

### DIFF
--- a/integrations/claude-code/hooks/hooks.json
+++ b/integrations/claude-code/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/session-start.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.py\"",
             "timeout": 120,
             "statusMessage": "Initializing Cognee memory..."
           }
@@ -17,13 +17,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/session-context-lookup.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/session-context-lookup.py\"",
             "timeout": 120,
             "statusMessage": "Searching session memory..."
           },
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/store-user-prompt.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/store-user-prompt.py\"",
             "async": true
           }
         ]
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/store-to-session.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/store-to-session.py\"",
             "async": true
           }
         ]
@@ -46,12 +46,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/store-to-session.py --stop",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/store-to-session.py\" --stop",
             "async": true
           },
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/clear-transcript-context.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/clear-transcript-context.py\"",
             "timeout": 5,
             "statusMessage": "Clearing Claude context..."
           }
@@ -63,7 +63,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-compact.py\"",
             "timeout": 120,
             "statusMessage": "Building memory anchor..."
           }
@@ -75,7 +75,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/sync-session-to-graph.py --session-end"
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/sync-session-to-graph.py\" --session-end"
           }
         ]
       }


### PR DESCRIPTION
## Problem

All 8 hook commands in `integrations/claude-code/hooks/hooks.json` pass the script path unquoted:

    "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/session-start.py"

When `CLAUDE_PLUGIN_ROOT` contains a space — common on Windows, e.g. `C:\Users\User 1\.claude\plugins\...` — the shell splits the argument and Python receives a truncated path:

    python.exe: can't open file 'C:\Users\User': [Errno 2] No such file or directory

The failure is non-fatal, so **every** hook silently no-ops: SessionStart, UserPromptSubmit (x2), PostToolUse, Stop (x2), PreCompact, SessionEnd. Session capture, context lookup, compaction anchoring, and graph sync all stop working for any user whose profile path contains a space.

## Fix

Quote the path; trailing args (`--stop`, `--session-end`) stay outside the quotes:

    "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start.py\""

Matches the quoting already used in `integrations/codex/plugins/cognee/hooks.json`. Same class of Windows bug as #258 and #275.
