### PR TITLE
fix(codex): honor config endpoint in hot hooks

### DIFF
--- a/.github/workflows/plugin-windows-tests.yml
+++ b/.github/workflows/plugin-windows-tests.yml
@@ -54,3 +54,6 @@ jobs:
 
       - name: codex status-line renderer tests
         run: python integrations/codex/tests/test_statusline_render.py
+
+      - name: codex endpoint and doctor tests
+        run: python integrations/codex/plugins/cognee/tests/test_doctor.py

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -74,7 +74,8 @@ At startup (`SessionStart`):
 - otherwise → `integration_local` (local API bootstrap)
 
 At hook runtime:
-- hooks resolve mode through runtime endpoint auth (env + `api_key.json`), not only config intent
+- hooks resolve the endpoint from env, then `config.json`, with localhost as the default
+- hooks resolve auth from env, then the URL-scoped `api_key.json` cache
 - `http` mode skips local SDK initialization
 
 The hooks emit `mode_decision` logs with `mode`, `service_url`, `url_source`, `key_source`, `api_key_present`.

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -1100,13 +1100,35 @@ def sync_lock(owner: str):
                 hook_log("sync_lock_release_failed", {"owner": owner, "error": str(exc)[:200]})
 
 
+def _local_api_url_with_source() -> tuple[str, str]:
+    """Resolve the runtime endpoint without assuming hook env propagation."""
+    local_env = str(os.environ.get("COGNEE_LOCAL_API_URL", "") or "").strip()
+    if local_env:
+        return local_env, "env_local_api_url"
+    service_env = str(os.environ.get("COGNEE_BASE_URL", "") or "").strip()
+    if service_env:
+        return service_env, "env_service_url"
+
+    # SessionStart and hot hooks run in separate processes. SessionStart can
+    # resolve config.json and set its own environment, but those mutations do
+    # not propagate back to later hook processes. Read the shared config as the
+    # documented fallback, while leaving API-key resolution in _api_key().
+    try:
+        from config import load_config  # type: ignore
+
+        configured = str(load_config().get("base_url") or "").strip()
+        if configured:
+            return configured, "config_base_url"
+    except Exception:
+        # load_config already logs malformed files; endpoint resolution must
+        # remain fail-safe on the hot path.
+        pass
+
+    return _DEFAULT_LOCAL_SERVICE_URL, "default_local"
+
+
 def _local_api_url() -> str:
-    direct = (
-        os.environ.get("COGNEE_LOCAL_API_URL") or os.environ.get("COGNEE_BASE_URL") or ""
-    ).strip()
-    if direct:
-        return direct
-    return _DEFAULT_LOCAL_SERVICE_URL
+    return _local_api_url_with_source()[0]
 
 
 def _normalize_service_url(value: str) -> str:
@@ -1167,8 +1189,8 @@ def _api_key() -> str:
 def resolved_http_endpoint_auth() -> tuple[str, str]:
     """Return (service_url, api_key) for runtime HTTP calls.
 
-    Service URL always falls back to localhost. API key is the single principal
-    key: env first, then the single cached key.
+    Service URL falls back through plugin config before localhost. API key is
+    the single principal key: env first, then the single cached key.
     """
     service_url = _normalize_service_url(_local_api_url())
     api_key = _api_key().strip()

--- a/integrations/codex/plugins/cognee/scripts/doctor.py
+++ b/integrations/codex/plugins/cognee/scripts/doctor.py
@@ -77,20 +77,15 @@ def _resolve_mode() -> str:
     return "Cloud"
 
 
-_DEFAULT_LOCAL_SERVICE_URL = "http://localhost:8011"
-
-
 def _resolve_server_url() -> tuple:
     """Return (display_url, raw_url).
 
-    Codex's _plugin_common does not expose _local_api_url_with_source,
-    so we inline the same resolution logic here (env → default).
-    In local mode the display value is "-".
+    In local mode the display value is "-", while the raw URL remains
+    available for the health probe.
     """
-    raw_url = (
-        os.environ.get("COGNEE_LOCAL_API_URL") or os.environ.get("COGNEE_BASE_URL") or ""
-    ).strip() or _DEFAULT_LOCAL_SERVICE_URL
+    from _plugin_common import _local_api_url_with_source
 
+    raw_url, _source = _local_api_url_with_source()
     mode = _resolve_mode()
     display = "-" if mode == "Local" else raw_url
     return display, raw_url

--- a/integrations/codex/plugins/cognee/tests/test_doctor.py
+++ b/integrations/codex/plugins/cognee/tests/test_doctor.py
@@ -27,7 +27,12 @@ _TMP = tempfile.mkdtemp(prefix="cognee-doctor-codex-test-")
 os.environ["COGNEE_PLUGIN_STATE_DIR"] = _TMP
 
 import _plugin_common  # noqa: E402
+import config  # noqa: E402
 import doctor  # noqa: E402
+
+_CONFIG_FILE = pathlib.Path(_TMP) / "config.json"
+config._CONFIG_FILE = _CONFIG_FILE
+config._HOOK_LOG = pathlib.Path(_TMP) / "config-hook.log"
 
 
 def _reset_env(*keys):
@@ -40,6 +45,15 @@ def _reset_breaker():
     p = pathlib.Path(_TMP) / "recall-breaker.json"
     if p.exists():
         p.unlink()
+
+
+def _write_config(data):
+    _CONFIG_FILE.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _reset_config():
+    if _CONFIG_FILE.exists():
+        _CONFIG_FILE.unlink()
 
 
 class _FakeResponse:
@@ -141,6 +155,67 @@ def test_server_url_shown_in_server_mode():
         _reset_env("COGNEE_BASE_URL")
 
 
+def test_server_url_falls_back_to_config_file():
+    _reset_env(
+        "COGNEE_BASE_URL",
+        "COGNEE_LOCAL_API_URL",
+        "COGNEE_CODEX_BACKEND",
+        "COGNEE_API_KEY",
+    )
+    configured_url = "http://managed-cognee.internal:8012"
+    _write_config({"base_url": configured_url})
+    try:
+        url, source = _plugin_common._local_api_url_with_source()
+        display, raw = doctor._resolve_server_url()
+        assert (url, source) == (configured_url, "config_base_url")
+        assert (display, raw) == (configured_url, configured_url)
+    finally:
+        _reset_config()
+
+
+def test_endpoint_env_vars_keep_precedence_over_config():
+    _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "COGNEE_CODEX_BACKEND")
+    _write_config({"backend": "http", "base_url": "http://from-config:8012"})
+    os.environ["COGNEE_BASE_URL"] = "http://from-base-env:8013"
+    try:
+        assert _plugin_common._local_api_url_with_source() == (
+            "http://from-base-env:8013",
+            "env_service_url",
+        )
+        os.environ["COGNEE_LOCAL_API_URL"] = "http://from-local-env:8014"
+        assert _plugin_common._local_api_url_with_source() == (
+            "http://from-local-env:8014",
+            "env_local_api_url",
+        )
+    finally:
+        _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL")
+        _reset_config()
+
+
+def test_local_backend_ignores_stale_config_endpoint():
+    _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "COGNEE_CODEX_BACKEND")
+    _write_config({"backend": "local", "base_url": "http://stale-managed:8012"})
+    try:
+        assert _plugin_common._local_api_url_with_source() == (
+            "http://localhost:8011",
+            "default_local",
+        )
+    finally:
+        _reset_config()
+
+
+def test_malformed_config_falls_back_to_localhost():
+    _reset_env("COGNEE_BASE_URL", "COGNEE_LOCAL_API_URL", "COGNEE_CODEX_BACKEND")
+    _CONFIG_FILE.write_text("{not-json", encoding="utf-8")
+    try:
+        assert _plugin_common._local_api_url_with_source() == (
+            "http://localhost:8011",
+            "default_local",
+        )
+    finally:
+        _reset_config()
+
+
 # API key source
 
 
@@ -164,6 +239,40 @@ def test_api_key_source_config():
     finally:
         doctor._API_KEY_CACHE = original
         _reset_env("COGNEE_API_KEY")
+
+
+def test_cached_api_key_remains_scoped_to_config_endpoint():
+    _reset_env(
+        "COGNEE_BASE_URL",
+        "COGNEE_LOCAL_API_URL",
+        "COGNEE_CODEX_BACKEND",
+        "COGNEE_API_KEY",
+    )
+    configured_url = "http://managed-cognee.internal:8012"
+    _write_config({"base_url": configured_url})
+    original = _plugin_common._API_KEY_CACHE
+    cache_file = pathlib.Path(_TMP) / "runtime-api-key.json"
+    _plugin_common._API_KEY_CACHE = cache_file
+    try:
+        cache_file.write_text(
+            json.dumps({"api_key": "matching-key", "base_url": configured_url}),
+            encoding="utf-8",
+        )
+        assert _plugin_common.resolved_http_endpoint_auth() == (
+            configured_url,
+            "matching-key",
+        )
+
+        _reset_env("COGNEE_BASE_URL", "COGNEE_API_KEY")
+        cache_file.write_text(
+            json.dumps({"api_key": "wrong-key", "base_url": "http://other:8012"}),
+            encoding="utf-8",
+        )
+        assert _plugin_common.resolved_http_endpoint_auth() == (configured_url, "")
+    finally:
+        _plugin_common._API_KEY_CACHE = original
+        _reset_env("COGNEE_BASE_URL", "COGNEE_API_KEY")
+        _reset_config()
 
 
 # Health check


### PR DESCRIPTION
## Summary

- Resolve the Codex hot-hook endpoint in this order:
  `COGNEE_LOCAL_API_URL` → `COGNEE_BASE_URL` → `config.json.base_url` → `localhost:8011`.
- Make `cognee doctor` use the same shared resolver as runtime hooks.
- Preserve the existing auth boundary: API keys are still resolved separately and cached keys remain scoped to an exact endpoint URL.
- Add hermetic plain-Python regression coverage and run it in the plugin Windows workflow.

## Root cause

Codex launches `SessionStart` and later hot hooks as separate processes. `SessionStart`
already reads `~/.cognee-plugin/config.json`, but setting `COGNEE_BASE_URL` inside that
process cannot update the environment of later hook processes. Those hooks only checked
their inherited environment and otherwise silently fell back to `localhost:8011`.

As a result, the documented config-only setup could start against one endpoint while
recall and write hooks contacted another. The URL-scoped cached API key would also be
correctly rejected for that unintended fallback URL.

## Safety

- Environment precedence is unchanged.
- The fallback uses the existing `load_config()` path, so backend semantics such as
  `backend=local` clearing a stale remote URL remain intact.
- Only `base_url` is read here. This change does not read or copy API keys from
  `config.json`.
- Missing or malformed config remains fail-safe and falls back to the existing local
  default without adding hot-path log noise.

## Verification

- `python3 integrations/codex/plugins/cognee/tests/test_doctor.py` - 25/25 passed.
- Existing Codex process, status-line, and UserPromptSubmit contract tests passed.
- Ruff 0.16.0 format check and lint passed.
- Live end-to-end validation against a self-managed Docker endpoint on a non-default
  port stored a unique marker, found it with exact `CHUNKS` recall, and recorded no
  later hot-hook attempts to `localhost:8011`.

## Scope

This PR intentionally covers the Codex hot hooks and doctor. The standalone shell
helpers and the equivalent Claude Code config fallback can be handled separately.
