### PR TITLE
fix: reduce update check interval

### DIFF
--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -16,6 +16,12 @@ project adheres to [Semantic Versioning](https://semver.org/).
 - **Pinned cognee version is now `1.4.0`** (was `1.2.2.dev3`). The plugin installs
   this into its own managed venv on session start, so existing installs pick it up
   on the next session.
+- **Update check now runs at most hourly instead of daily.**
+  `COGNEE_UPDATE_CHECK_INTERVAL` defaults to `3600` (was `86400`). The check is a
+  conditional `If-None-Match` request, so the steady state is a 304 with an empty
+  body — cheap enough that a published release gets noticed within the hour rather
+  than after up to a day. Still bounded regardless of how often the idle watcher
+  relaunches, and still opt-out via `COGNEE_UPDATE_CHECK=off`.
 
 ## [1.1.0]
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -373,7 +373,7 @@ skips local-path (dev) installs. Turn it off with `COGNEE_UPDATE_CHECK=false`.
 | Env var | Default | Effect |
 |---|---|---|
 | `COGNEE_UPDATE_CHECK` | `true` | Background "update available" check + status-line/SessionStart nudges |
-| `COGNEE_UPDATE_CHECK_INTERVAL` | `86400` | Minimum seconds between checks |
+| `COGNEE_UPDATE_CHECK_INTERVAL` | `3600` | Minimum seconds between checks |
 
 ## Remove
 

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1570,14 +1570,14 @@ def server_ready_hint(service_url: str = "") -> bool:
 
 
 # --- Plugin update check (Phase 2) -------------------------------------------
-# A background, once-a-day check comparing the installed plugin version against
+# A background, hourly-guarded check comparing the installed plugin version against
 # the version published on the marketplace's git ref. The network call runs only
 # here (in the background idle watcher); the hot path (SessionStart message,
 # status line) merely READS the marker file this writes — never the network.
 # Talks only to raw.githubusercontent (CDN, no API rate limit) over the shared
 # certifi TLS context. Opt out with COGNEE_UPDATE_CHECK=off.
 _UPDATE_CHECK_FILE = _PLUGIN_DIR / "update-check.json"
-_UPDATE_CHECK_INTERVAL_DEFAULT = 86400.0
+_UPDATE_CHECK_INTERVAL_DEFAULT = 3600.0
 _UPDATE_DEFAULT_REPO = "topoteretes/cognee-integrations"
 _UPDATE_DEFAULT_REF = "main"
 _UPDATE_PLUGIN_ENTRY = "cognee-memory"
@@ -1678,7 +1678,7 @@ def _fetch_published_version(repo: str, ref: str, etag: str) -> tuple:
 
 
 def maybe_check_for_update() -> None:
-    """Background, ≤once-a-day update check. Writes the marker. Never raises.
+    """Background, ≤hourly update check. Writes the marker. Never raises.
 
     Call from a background process (the idle watcher) — never a synchronous hook,
     since it may make a network call (bounded to 5s, ≤ once per interval).

--- a/integrations/claude-code/scripts/idle-watcher.py
+++ b/integrations/claude-code/scripts/idle-watcher.py
@@ -155,7 +155,7 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
 
 
 def _run_update_check() -> None:
-    """Fire the background, daily-guarded plugin update check (best-effort)."""
+    """Fire the background, interval-guarded plugin update check (best-effort)."""
     try:
         sys.path.insert(0, os.path.dirname(__file__))
         from _plugin_common import maybe_check_for_update  # type: ignore

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -263,7 +263,7 @@ off with `COGNEE_UPDATE_CHECK=false`.
 | Env var | Default | Effect |
 |---|---|---|
 | `COGNEE_UPDATE_CHECK` | `true` | Background "update available" check + status/SessionStart nudges |
-| `COGNEE_UPDATE_CHECK_INTERVAL` | `86400` | Minimum seconds between checks |
+| `COGNEE_UPDATE_CHECK_INTERVAL` | `3600` | Minimum seconds between checks |
 
 ## Remove
 

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -16,6 +16,12 @@ project adheres to [Semantic Versioning](https://semver.org/).
 - **Pinned cognee version is now `1.4.0`** (was `1.2.2.dev3`). The plugin installs
   this into its own managed venv on session start, so existing installs pick it up
   on the next session.
+- **Update check now runs at most hourly instead of daily.**
+  `COGNEE_UPDATE_CHECK_INTERVAL` defaults to `3600` (was `86400`). The check is a
+  conditional `If-None-Match` request, so the steady state is a 304 with an empty
+  body — cheap enough that a published release gets noticed within the hour rather
+  than after up to a day. Still bounded regardless of how often the idle watcher
+  relaunches, and still opt-out via `COGNEE_UPDATE_CHECK=off`.
 
 ## [1.2.0]
 

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -1494,7 +1494,7 @@ def server_ready_hint(service_url: str = "") -> bool:
 
 
 # --- Plugin update check (Phase 2) -------------------------------------------
-# Background, once-a-day check comparing the installed plugin version against the
+# Background, hourly-guarded check comparing the installed plugin version against the
 # version published on the tracked git ref. The network call runs only here (in
 # the background idle watcher); the hot path (in-context status via
 # render_status_for_host, SessionStart nudge) merely READS the marker this
@@ -1503,7 +1503,7 @@ def server_ready_hint(service_url: str = "") -> bool:
 # version to the installed one. Talks only to raw.githubusercontent over the
 # shared certifi TLS context. Opt out with COGNEE_UPDATE_CHECK=off.
 _UPDATE_CHECK_FILE = _PLUGIN_DIR / "update-check.json"
-_UPDATE_CHECK_INTERVAL_DEFAULT = 86400.0
+_UPDATE_CHECK_INTERVAL_DEFAULT = 3600.0
 _UPDATE_DEFAULT_REPO = "topoteretes/cognee-integrations"
 _UPDATE_DEFAULT_REF = "main"
 _UPDATE_MANIFEST_PATH = "integrations/codex/plugins/cognee/.codex-plugin/plugin.json"
@@ -1588,7 +1588,7 @@ def _fetch_published_version(repo: str, ref: str, etag: str) -> tuple:
 
 
 def maybe_check_for_update() -> None:
-    """Background, ≤once-a-day update check. Writes the marker. Never raises.
+    """Background, ≤hourly update check. Writes the marker. Never raises.
 
     Call from a background process (the idle watcher) — never a synchronous hook,
     since it may make a network call (bounded to 5s, ≤ once per interval).

--- a/integrations/codex/plugins/cognee/scripts/idle-watcher.py
+++ b/integrations/codex/plugins/cognee/scripts/idle-watcher.py
@@ -155,7 +155,7 @@ async def _improve_once(session_id: str, dataset: str, config: dict) -> bool:
 
 
 def _run_update_check() -> None:
-    """Fire the background, daily-guarded plugin update check (best-effort)."""
+    """Fire the background, interval-guarded plugin update check (best-effort)."""
     try:
         sys.path.insert(0, os.path.dirname(__file__))
         from _plugin_common import maybe_check_for_update  # type: ignore


### PR DESCRIPTION
This PR reduces the default Claude and Codex update interval from 1 day to 1 hour.