### PR TITLE
fix: remove update message after plugin update

### DIFF
--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -12,6 +12,17 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.1.1]
 
+### Fixed
+- **The "update available" nudge now clears as soon as the update is applied.** The
+  marker is a snapshot from the background check, and nothing rewrote it when the
+  plugin actually updated — so the status line kept advertising an update that was
+  already installed until the next check. Both surfaces now compare the marker's
+  `installed_version` against the version *running* and suppress the nudge on a
+  mismatch, so the status line clears on its next refresh (~2s) instead of up to an
+  interval later. The comparison is against the running version, not the newest copy
+  on disk, so a background auto-update that a session has not reloaded yet correctly
+  keeps nudging.
+
 ### Changed
 - **Pinned cognee version is now `1.4.0`** (was `1.2.2.dev3`). The plugin installs
   this into its own managed venv on session start, so existing installs pick it up

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1733,18 +1733,32 @@ def read_update_status() -> dict:
     Returns the marker dict only when an update is genuinely available; {} when
     disabled, absent, or already current (so callers can treat truthiness as
     "should nudge").
+
+    The marker is a snapshot from the last background check, so it goes stale the
+    moment the plugin is updated — it would keep claiming an update is available
+    until the next check (≤ an hour later). Guard against that here, at read time:
+    the snapshot is only trustworthy while its ``installed_version`` is still the
+    version actually running. A mismatch means the update already landed, so the
+    nudge is suppressed immediately rather than after the next network check.
+    Note this compares against the RUNNING version, not the newest on disk — an
+    auto-update that a session has not reloaded yet correctly keeps nudging.
     """
     if not _update_check_enabled():
         return {}
     marker = _load_json_file(_UPDATE_CHECK_FILE)
-    if (
+    if not (
         isinstance(marker, dict)
         and marker.get("update_available")
         and marker.get("installed_version")
         and marker.get("latest_version")
     ):
-        return marker
-    return {}
+        return {}
+    # An undeterminable running version falls back to trusting the marker, so a
+    # missing/unreadable plugin.json degrades to the previous behaviour.
+    running = _installed_plugin_version()
+    if running and running != marker.get("installed_version"):
+        return {}
+    return marker
 
 
 def mark_update_notified(version: str) -> None:

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -300,7 +300,38 @@ def _update_segment() -> str:
     latest = str(marker.get("latest_version") or "")
     if not (installed and latest):
         return ""
+    # Marker staleness guard, mirroring _plugin_common.read_update_status: the
+    # marker is a snapshot from the last background check, so after an update it
+    # keeps claiming an update is available until the next one runs. Since this
+    # renders every refresh, comparing against the running version clears the
+    # segment within one refresh instead of within an hour.
+    running = _running_plugin_version()
+    if running and running != installed:
+        return ""
     return f"   \033[1;33m⬆ Cognee update available {installed}→{latest}\033[0m"
+
+
+def _running_plugin_version() -> str:
+    """Version of the plugin copy this renderer belongs to, or '' if unreadable.
+
+    Deliberately does not import ``_plugin_common`` (see module docstring). The
+    status line is not a hook, so ``CLAUDE_PLUGIN_ROOT`` is usually unset; the
+    install path is version-pinned (``.../cognee-memory/<version>/scripts/``), so
+    this file's own location identifies the running version.
+    """
+    candidates = []
+    root = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
+    if root:
+        candidates.append(Path(root) / ".claude-plugin" / "plugin.json")
+    candidates.append(Path(__file__).resolve().parent.parent / ".claude-plugin" / "plugin.json")
+    for path in candidates:
+        try:
+            version = str(json.loads(path.read_text(encoding="utf-8")).get("version") or "").strip()
+            if version:
+                return version
+        except Exception:
+            continue
+    return ""
 
 
 def _pipeline_health_glyph() -> str:

--- a/integrations/claude-code/tests/test_update_nudge_staleness.py
+++ b/integrations/claude-code/tests/test_update_nudge_staleness.py
@@ -1,0 +1,154 @@
+"""The 'update available' nudge must disappear as soon as the update is applied.
+
+The update marker is a snapshot written by the background check in the idle
+watcher (≤ hourly). Nothing rewrites it when the plugin is actually updated, so
+between the update and the next check the marker still says
+``update_available: true`` with a now-stale ``installed_version``. Both surfaces
+that read it — the status-line segment and the SessionStart nudge — therefore
+compare the marker's ``installed_version`` against the version *running*, and
+suppress the nudge on a mismatch.
+
+The comparison is deliberately against the RUNNING version rather than the newest
+copy on disk: a background auto-update that the session has not reloaded yet must
+keep nudging, because the session really is still on the old version.
+
+Run: `python integrations/claude-code/tests/test_update_nudge_staleness.py` (or via pytest).
+"""
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _load(module_name: str, filename: str):
+    """Import a script by path (some filenames are not importable identifiers)."""
+    sys.path.insert(0, str(_SCRIPTS))
+    spec = importlib.util.spec_from_file_location(module_name, _SCRIPTS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(path: pathlib.Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _marker(installed: str, latest: str) -> dict:
+    return {
+        "update_available": True,
+        "installed_version": installed,
+        "latest_version": latest,
+        "notified_version": "",
+        "last_checked_at": 0,
+    }
+
+
+# --- status-line segment ------------------------------------------------------
+
+
+def _segment_with(marker: dict) -> str:
+    """Render just the update segment against a temp marker file."""
+    sl = _load("sl_staleness", "cognee_statusline_render.py")
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    saved = os.environ.pop("COGNEE_UPDATE_CHECK", None)
+    try:
+        sl._UPDATE_CHECK_PATH = tmp / "update-check.json"
+        _write(sl._UPDATE_CHECK_PATH, marker)
+        return sl._update_segment()
+    finally:
+        if saved is not None:
+            os.environ["COGNEE_UPDATE_CHECK"] = saved
+
+
+def test_segment_shows_when_marker_matches_running_version():
+    """Baseline: a marker written by the running version still nudges."""
+    sl = _load("sl_staleness", "cognee_statusline_render.py")
+    running = sl._running_plugin_version()
+    assert running, "expected a readable running version from the repo layout"
+
+    out = _segment_with(_marker(running, "99.0.0"))
+    assert "update available" in out, repr(out)
+    assert f"{running}→99.0.0" in out, repr(out)
+
+
+def test_segment_hidden_once_running_version_moved_past_marker():
+    """The update landed: marker's installed_version is no longer what runs."""
+    out = _segment_with(_marker("0.0.1", "99.0.0"))
+    assert out == "", repr(out)
+
+
+def test_running_version_matches_plugin_manifest():
+    """The renderer resolves its own version from its own location, not the env."""
+    sl = _load("sl_staleness", "cognee_statusline_render.py")
+    manifest = json.loads(
+        (_SCRIPTS.parent / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    assert sl._running_plugin_version() == manifest["version"]
+
+
+# --- SessionStart nudge (shared read used by _apply_update_nudge) -------------
+
+
+def _status_with(marker: dict) -> dict:
+    common = _load("common_staleness", "_plugin_common.py")
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    saved = os.environ.pop("COGNEE_UPDATE_CHECK", None)
+    try:
+        common._UPDATE_CHECK_FILE = tmp / "update-check.json"
+        _write(common._UPDATE_CHECK_FILE, marker)
+        return common.read_update_status()
+    finally:
+        if saved is not None:
+            os.environ["COGNEE_UPDATE_CHECK"] = saved
+
+
+def test_read_update_status_returns_marker_when_current():
+    common = _load("common_staleness", "_plugin_common.py")
+    running = common._installed_plugin_version()
+    assert running, "expected a readable installed version from the repo layout"
+
+    status = _status_with(_marker(running, "99.0.0"))
+    assert status.get("update_available") is True
+    assert status.get("latest_version") == "99.0.0"
+
+
+def test_read_update_status_suppressed_after_update():
+    assert _status_with(_marker("0.0.1", "99.0.0")) == {}
+
+
+def test_unreadable_running_version_falls_back_to_marker():
+    """A missing plugin.json must not silently disable the nudge entirely."""
+    common = _load("common_staleness", "_plugin_common.py")
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    saved = os.environ.pop("COGNEE_UPDATE_CHECK", None)
+    original = common._installed_plugin_version
+    try:
+        common._UPDATE_CHECK_FILE = tmp / "update-check.json"
+        _write(common._UPDATE_CHECK_FILE, _marker("1.0.0", "99.0.0"))
+        common._installed_plugin_version = lambda: ""
+        status = common.read_update_status()
+        assert status.get("installed_version") == "1.0.0", repr(status)
+    finally:
+        common._installed_plugin_version = original
+        if saved is not None:
+            os.environ["COGNEE_UPDATE_CHECK"] = saved
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print(f"PASS {_name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {_name}: {exc}")
+    print("\nALL PASSED" if not failures else f"\n{failures} FAILED")
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -12,6 +12,16 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.2.1]
 
+### Fixed
+- **The "update available" nudge now clears as soon as the update is applied.** The
+  marker is a snapshot from the background check, and nothing rewrote it when the
+  plugin actually updated — so the status kept advertising an update that was already
+  installed until the next check. Both surfaces now compare the marker's
+  `installed_version` against the version *running* and suppress the nudge on a
+  mismatch. The comparison is against the running version, not the newest copy on
+  disk, so a background auto-update that a session has not reloaded yet correctly
+  keeps nudging.
+
 ### Changed
 - **Pinned cognee version is now `1.4.0`** (was `1.2.2.dev3`). The plugin installs
   this into its own managed venv on session start, so existing installs pick it up

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -1639,18 +1639,33 @@ def maybe_check_for_update() -> None:
 
 
 def read_update_status() -> dict:
-    """Zero-network read of the update marker; {} when disabled/absent/current."""
+    """Zero-network read of the update marker; {} when disabled/absent/current.
+
+    The marker is a snapshot from the last background check, so it goes stale the
+    moment the plugin is updated — it would keep claiming an update is available
+    until the next check (≤ an hour later). Guard against that here, at read time:
+    the snapshot is only trustworthy while its ``installed_version`` is still the
+    version actually running. A mismatch means the update already landed, so the
+    nudge is suppressed immediately rather than after the next network check.
+    Note this compares against the RUNNING version, not the newest on disk — an
+    auto-update that a session has not reloaded yet correctly keeps nudging.
+    """
     if not _update_check_enabled():
         return {}
     marker = _load_json_file(_UPDATE_CHECK_FILE)
-    if (
+    if not (
         isinstance(marker, dict)
         and marker.get("update_available")
         and marker.get("installed_version")
         and marker.get("latest_version")
     ):
-        return marker
-    return {}
+        return {}
+    # An undeterminable running version falls back to trusting the marker, so a
+    # missing/unreadable plugin.json degrades to the previous behaviour.
+    running = _installed_plugin_version()
+    if running and running != marker.get("installed_version"):
+        return {}
+    return marker
 
 
 def mark_update_notified(version: str) -> None:

--- a/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
@@ -232,7 +232,35 @@ def _update_segment() -> str:
     latest = str(marker.get("latest_version") or "")
     if not (installed and latest):
         return ""
+    # Marker staleness guard, mirroring _plugin_common.read_update_status: the
+    # marker is a snapshot from the last background check, so after an update it
+    # keeps claiming an update is available until the next one runs. Comparing
+    # against the running version clears the segment on the next render instead.
+    running = _running_plugin_version()
+    if running and running != installed:
+        return ""
     return f"  ⬆ Cognee update available {installed}→{latest}"
+
+
+def _running_plugin_version() -> str:
+    """Version of the plugin copy this renderer belongs to, or '' if unreadable.
+
+    Deliberately does not import ``_plugin_common`` (see module docstring); this
+    file's own location identifies the running copy.
+    """
+    candidates = []
+    root = os.environ.get("PLUGIN_ROOT", "").strip()
+    if root:
+        candidates.append(Path(root) / ".codex-plugin" / "plugin.json")
+    candidates.append(Path(__file__).resolve().parent.parent / ".codex-plugin" / "plugin.json")
+    for path in candidates:
+        try:
+            version = str(json.loads(path.read_text(encoding="utf-8")).get("version") or "").strip()
+            if version:
+                return version
+        except Exception:
+            continue
+    return ""
 
 
 def _llm_prefix(session_id: str = "") -> str:

--- a/integrations/codex/tests/test_statusline_plain_text.py
+++ b/integrations/codex/tests/test_statusline_plain_text.py
@@ -94,9 +94,15 @@ def test_no_escapes_even_with_every_signal_firing():
     try:
         os.environ.pop("COGNEE_UPDATE_CHECK", None)
         sl._UPDATE_CHECK_PATH = tmp / "update-check.json"
+        # installed_version must be the RUNNING version, else the staleness guard
+        # in _update_segment suppresses the nudge (see _running_plugin_version).
         _write(
             sl._UPDATE_CHECK_PATH,
-            {"update_available": True, "installed_version": "1.0.0", "latest_version": "1.1.0"},
+            {
+                "update_available": True,
+                "installed_version": sl._running_plugin_version(),
+                "latest_version": "99.0.0",
+            },
         )
         with _Mode(_LOCAL_URL):
             _write(sl._LLM_STATE_DIR / "s1.json", {"llm_state": "not_set", "checked_at": 9e9})

--- a/integrations/codex/tests/test_update_nudge_staleness.py
+++ b/integrations/codex/tests/test_update_nudge_staleness.py
@@ -1,0 +1,154 @@
+"""The 'update available' nudge must disappear as soon as the update is applied.
+
+The update marker is a snapshot written by the background check in the idle
+watcher (≤ hourly). Nothing rewrites it when the plugin is actually updated, so
+between the update and the next check the marker still says
+``update_available: true`` with a now-stale ``installed_version``. Both surfaces
+that read it — the status segment and the SessionStart nudge — therefore
+compare the marker's ``installed_version`` against the version *running*, and
+suppress the nudge on a mismatch.
+
+The comparison is deliberately against the RUNNING version rather than the newest
+copy on disk: a background auto-update that the session has not reloaded yet must
+keep nudging, because the session really is still on the old version.
+
+Run: `python integrations/codex/tests/test_update_nudge_staleness.py` (or via pytest).
+"""
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "plugins" / "cognee" / "scripts"
+
+
+def _load(module_name: str, filename: str):
+    """Import a script by path (some filenames are not importable identifiers)."""
+    sys.path.insert(0, str(_SCRIPTS))
+    spec = importlib.util.spec_from_file_location(module_name, _SCRIPTS / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(path: pathlib.Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _marker(installed: str, latest: str) -> dict:
+    return {
+        "update_available": True,
+        "installed_version": installed,
+        "latest_version": latest,
+        "notified_version": "",
+        "last_checked_at": 0,
+    }
+
+
+# --- status segment ------------------------------------------------------
+
+
+def _segment_with(marker: dict) -> str:
+    """Render just the update segment against a temp marker file."""
+    sl = _load("sl_staleness", "cognee_statusline_render.py")
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    saved = os.environ.pop("COGNEE_UPDATE_CHECK", None)
+    try:
+        sl._UPDATE_CHECK_PATH = tmp / "update-check.json"
+        _write(sl._UPDATE_CHECK_PATH, marker)
+        return sl._update_segment()
+    finally:
+        if saved is not None:
+            os.environ["COGNEE_UPDATE_CHECK"] = saved
+
+
+def test_segment_shows_when_marker_matches_running_version():
+    """Baseline: a marker written by the running version still nudges."""
+    sl = _load("sl_staleness", "cognee_statusline_render.py")
+    running = sl._running_plugin_version()
+    assert running, "expected a readable running version from the repo layout"
+
+    out = _segment_with(_marker(running, "99.0.0"))
+    assert "update available" in out, repr(out)
+    assert f"{running}→99.0.0" in out, repr(out)
+
+
+def test_segment_hidden_once_running_version_moved_past_marker():
+    """The update landed: marker's installed_version is no longer what runs."""
+    out = _segment_with(_marker("0.0.1", "99.0.0"))
+    assert out == "", repr(out)
+
+
+def test_running_version_matches_plugin_manifest():
+    """The renderer resolves its own version from its own location, not the env."""
+    sl = _load("sl_staleness", "cognee_statusline_render.py")
+    manifest = json.loads(
+        (_SCRIPTS.parent / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    assert sl._running_plugin_version() == manifest["version"]
+
+
+# --- SessionStart nudge (shared read used by _apply_update_nudge) -------------
+
+
+def _status_with(marker: dict) -> dict:
+    common = _load("common_staleness", "_plugin_common.py")
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    saved = os.environ.pop("COGNEE_UPDATE_CHECK", None)
+    try:
+        common._UPDATE_CHECK_FILE = tmp / "update-check.json"
+        _write(common._UPDATE_CHECK_FILE, marker)
+        return common.read_update_status()
+    finally:
+        if saved is not None:
+            os.environ["COGNEE_UPDATE_CHECK"] = saved
+
+
+def test_read_update_status_returns_marker_when_current():
+    common = _load("common_staleness", "_plugin_common.py")
+    running = common._installed_plugin_version()
+    assert running, "expected a readable installed version from the repo layout"
+
+    status = _status_with(_marker(running, "99.0.0"))
+    assert status.get("update_available") is True
+    assert status.get("latest_version") == "99.0.0"
+
+
+def test_read_update_status_suppressed_after_update():
+    assert _status_with(_marker("0.0.1", "99.0.0")) == {}
+
+
+def test_unreadable_running_version_falls_back_to_marker():
+    """A missing plugin.json must not silently disable the nudge entirely."""
+    common = _load("common_staleness", "_plugin_common.py")
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    saved = os.environ.pop("COGNEE_UPDATE_CHECK", None)
+    original = common._installed_plugin_version
+    try:
+        common._UPDATE_CHECK_FILE = tmp / "update-check.json"
+        _write(common._UPDATE_CHECK_FILE, _marker("1.0.0", "99.0.0"))
+        common._installed_plugin_version = lambda: ""
+        status = common.read_update_status()
+        assert status.get("installed_version") == "1.0.0", repr(status)
+    finally:
+        common._installed_plugin_version = original
+        if saved is not None:
+            os.environ["COGNEE_UPDATE_CHECK"] = saved
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print(f"PASS {_name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {_name}: {exc}")
+    print("\nALL PASSED" if not failures else f"\n{failures} FAILED")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
This PR removes the update message after the plugin actually updates in Claude and Codex.