### PR TITLE
fix: no duplicate improves. recall uses dataset everywhere

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "author": {
         "name": "Cognee"
       },

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": {
     "name": "Cognee"
   },

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,6 +10,33 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.2]
+
+### Fixed
+- **Per-prompt recall now names its dataset.** `/api/v1/recall` was the only
+  data-plane call that omitted one, so the server resolved *every* dataset the user
+  can read and searched all of them on every prompt — on a machine with several
+  datasets that is the graph scope paying for unrelated stores, one of which can be
+  orders of magnitude larger than the plugin's own. It now sends
+  `datasets: [<dataset>]`, matching the explicit-search path
+  (`cognee-search.sh`), which has always scoped this way. The dataset is the usual
+  one — `COGNEE_PLUGIN_DATASET` if set, otherwise `agent_sessions` — and the key is
+  omitted entirely when no dataset is known, so a standalone invocation behaves as
+  before.
+- **One improve per session, instead of up to three at once.** The idle watcher,
+  the store hook and the SessionEnd sync all bridge sessions, and the cross-hook
+  `sync_lock` is bypassed in API mode — so in HTTP/cloud mode nothing stopped two of
+  them submitting the *same* session concurrently. The server's own per-session lock
+  answered the loser with a busy response, which drove a 15-second retry loop for up
+  to ten minutes; in one real log that accounted for two thirds of all sessions and
+  7,144 retry events. Improves are now claimed per session locally before submitting
+  (`improve_session_lock`), so the loser skips immediately instead of waiting on work
+  the winner is already doing. Freshness is unaffected: a skip reports not-synced, so
+  the caller re-drives the whole drain+improve, and the server-side busy retry still
+  covers a later attempt landing on a still-running pipeline. The claim covers both
+  the HTTP and local-SDK paths, is released on exceptions, reclaims a dead holder's
+  lock, and fails open — lock bookkeeping must never be why a session goes unsynced.
+
 ## [1.1.1]
 
 ### Fixed

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -34,6 +34,10 @@ _SAVE_COUNTER = _PLUGIN_DIR / "save_counter.json"
 _SERVER_READY_MARKER = _SHARED_PLUGIN_ROOT / "server-ready.json"
 _SERVER_READY_TTL_SECONDS = 30
 _SYNC_LOCK = _PLUGIN_DIR / "sync.lock"
+# One lock file per session (see improve_session_lock): the idle watcher, the
+# store hook and the SessionEnd sync all bridge sessions, and only one of them
+# may have an improve in flight for a given session at a time.
+_IMPROVE_LOCK_DIR = _PLUGIN_DIR / "improve-locks"
 # Per-agent-session buffer dirs. Each agent session (one Claude/Codex terminal)
 # owns its own file under these dirs, so two concurrent agents never
 # read-modify-write the same file — no locks needed, no lost-update races.
@@ -1126,6 +1130,78 @@ def touch_activity() -> None:
 
 
 @contextmanager
+def improve_session_lock(session_id: str, owner: str):
+    """Admit exactly one in-flight improve per session, machine-wide.
+
+    Three paths bridge the same session — the idle watcher, ``store-to-session``,
+    and the SessionEnd sync — and the outer ``sync_lock`` is bypassed in API mode
+    (``nullcontext(True) if api_mode``), so in HTTP/cloud mode nothing stopped two
+    of them submitting the same session concurrently. The server's own per-session
+    lock then answered the loser with ``{}`` (busy), which drove a 15s retry loop
+    for up to ten minutes; concurrent writers also collide on the single-writer
+    graph/vector store ("Could not set lock on file"), leaving pipeline runs stuck
+    and the graph unwritten.
+
+    So claim locally BEFORE submitting: the loser skips entirely rather than
+    waiting, because the winner is already bridging the very same session — the
+    work is not lost, it is in flight. Yields True when claimed, False when
+    another process owns it.
+
+    Mirrors ``sync_lock``'s stale handling (dead pid or older than
+    ``SYNC_LOCK_STALE_SECONDS``) so a crashed worker cannot wedge a session, and
+    fails OPEN on unexpected errors — a lock we cannot manage must never be the
+    reason a session goes unsynced.
+    """
+    if not session_id:
+        yield True
+        return
+
+    digest = hashlib.sha1(str(session_id).encode("utf-8")).hexdigest()
+    lock_path = _IMPROVE_LOCK_DIR / f"{digest}.lock"
+    acquired = False
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        now = datetime.now(timezone.utc).timestamp()
+        if lock_path.exists():
+            try:
+                current = json.loads(lock_path.read_text(encoding="utf-8"))
+                created_at = float(current.get("created_at", 0))
+                pid = int(current.get("pid", 0))
+            except Exception:
+                created_at, pid = 0.0, 0
+            if not (pid > 0 and _proc.pid_alive(pid)) or now - created_at > SYNC_LOCK_STALE_SECONDS:
+                try:
+                    lock_path.unlink()
+                    hook_log(
+                        "improve_lock_stale_cleared",
+                        {"session": session_id, "owner": owner, "stale_pid": pid},
+                    )
+                except FileNotFoundError:
+                    pass  # another process cleared the same stale lock
+                except Exception as exc:
+                    hook_log("improve_lock_unlink_failed", {"error": str(exc)[:200]})
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump({"owner": owner, "pid": os.getpid(), "created_at": now}, fh)
+            acquired = True
+            yield True
+        except FileExistsError:
+            hook_log("improve_skipped_concurrent", {"session": session_id, "owner": owner})
+            yield False
+    except Exception as exc:
+        # Fail open: never let lock bookkeeping cost a session its sync.
+        hook_log("improve_lock_failed_open", {"session": session_id, "error": str(exc)[:200]})
+        yield True
+    finally:
+        if acquired:
+            try:
+                lock_path.unlink()
+            except Exception as exc:
+                hook_log("improve_lock_release_failed", {"error": str(exc)[:200]})
+
+
+@contextmanager
 def sync_lock(owner: str):
     """Best-effort cross-hook lock for graph sync/improve work."""
     acquired = False
@@ -1994,6 +2070,7 @@ def recall_via_http(
     only_context: bool = True,
     search_type: str | None = None,
     context_profile: str | None = None,
+    dataset: str = "",
     timeout: float = 10.0,
 ) -> list:
     payload = {
@@ -2003,6 +2080,16 @@ def recall_via_http(
         "scope": scope,
         "only_context": only_context,
     }
+    # Always scope to the plugin's dataset. Without it the server resolves EVERY
+    # readable dataset and then reconciles against the session's binding, so the
+    # graph scope depends on that binding existing: an unbound session with more
+    # than one readable dataset is rejected as ambiguous rather than searched.
+    # Naming the dataset makes the scope explicit and matches the explicit-search
+    # path (_recall_http.do_recall), which has always sent it. The value must be
+    # the dataset the session's entries were written under — a different one is a
+    # binding mismatch server-side, which is a real error worth surfacing.
+    if dataset:
+        payload["datasets"] = [dataset]
     if search_type:
         payload["search_type"] = search_type
     if context_profile:
@@ -2569,7 +2656,23 @@ def run_session_improve(dataset: str, session_id: str) -> bool:
 
     Falls back to the legacy full-document bridge when the server does not
     support session-aware improve. Returns True when a sync ran successfully.
+
+    Serialized per session by ``improve_session_lock``. The guard lives here
+    rather than at the three call sites (idle watcher, store hook, SessionEnd
+    sync) so every path is covered by construction and a future fourth caller
+    cannot reintroduce the double-submit.
     """
+    with improve_session_lock(session_id, "run_session_improve") as claimed:
+        if not claimed:
+            # Another process is already bridging this exact session. Report
+            # not-synced so the caller's own retry/reporting path is unchanged;
+            # the work itself is in flight, not dropped.
+            return False
+        return _run_session_improve_locked(dataset, session_id)
+
+
+def _run_session_improve_locked(dataset: str, session_id: str) -> bool:
+    """Body of run_session_improve; assumes the per-session claim is held."""
     base_url = _local_api_url()
     if not _backend_reachable(base_url):
         return False

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -442,26 +442,36 @@ async def improve_session_local(dataset: str, session_id: str, user) -> dict:
     and (in foreground mode) the graph→session sync — so the explicit
     persist+sync pair below is only kept as a fallback for older cognee
     versions without session-aware improve.
+
+    Serialized per session by ``improve_session_lock``, matching the HTTP path in
+    ``run_session_improve``. ``store-to-session``'s background fire takes no outer
+    ``sync_lock``, so without this the local path could double-submit one session
+    and have two writers contend for the single-writer graph store.
     """
     if not session_id or not user:
         return {"ok": False, "error": "missing session/user"}
 
     import cognee
+    from _plugin_common import improve_session_lock
 
-    try:
-        result = await cognee.improve(
-            dataset,
-            session_ids=[session_id],
-            user=user,
-            run_in_background=False,
-        )
-        return {"ok": True, "result": result}
-    except TypeError as exc:
-        # Older cognee without session-aware improve: legacy persist + sync.
-        _config_log("improve_local_unsupported", {"error": str(exc)[:200]})
-        wrote = await persist_session_cache_to_graph(dataset, session_id, user)
-        graph_result = await sync_graph_context_to_session(dataset, session_id, user)
-        return {"ok": wrote, "legacy": True, "graph_synced": graph_result.get("synced", 0)}
+    with improve_session_lock(session_id, "improve_session_local") as claimed:
+        if not claimed:
+            # Winner is already bridging this session; not dropped, just in flight.
+            return {"ok": False, "skipped": "concurrent"}
+        try:
+            result = await cognee.improve(
+                dataset,
+                session_ids=[session_id],
+                user=user,
+                run_in_background=False,
+            )
+            return {"ok": True, "result": result}
+        except TypeError as exc:
+            # Older cognee without session-aware improve: legacy persist + sync.
+            _config_log("improve_local_unsupported", {"error": str(exc)[:200]})
+            wrote = await persist_session_cache_to_graph(dataset, session_id, user)
+            graph_result = await sync_graph_context_to_session(dataset, session_id, user)
+            return {"ok": wrote, "legacy": True, "graph_synced": graph_result.get("synced", 0)}
 
 
 def _read_field(entry, field: str) -> str:

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -304,6 +304,7 @@ async def _run(prompt: str) -> dict | None:
                     only_context=True,
                     search_type=qtype,
                     context_profile=context_profile,
+                    dataset=get_dataset(config),
                     timeout=recall_timeout,
                 )
             else:

--- a/integrations/claude-code/tests/test_improve_session_lock.py
+++ b/integrations/claude-code/tests/test_improve_session_lock.py
@@ -1,0 +1,194 @@
+"""One improve per session, machine-wide — and recall always names its dataset.
+
+Two regressions this locks down, both root-caused from a real hook.log:
+
+1. **Duplicate improves.** The idle watcher, ``store-to-session`` and the
+   SessionEnd sync all bridge sessions, and the outer ``sync_lock`` is bypassed in
+   API mode (``nullcontext(True) if api_mode``). 67% of sessions were submitted by
+   two processes at once; the server's own per-session lock answered the loser with
+   ``{}`` (busy), driving a 15s retry loop for up to ten minutes, while concurrent
+   writers collided on the single-writer graph store ("Could not set lock on file")
+   and left pipeline runs stuck with the graph unwritten.
+
+2. **Recall without a dataset.** ``/api/v1/recall`` was the only data-plane call
+   omitting one, leaving the graph scope dependent on the session's dataset binding
+   — an unbound session with several readable datasets is rejected as ambiguous
+   rather than searched.
+
+Run: `python integrations/claude-code/tests/test_improve_session_lock.py` (or via pytest).
+"""
+
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _fresh_common(tmp: pathlib.Path):
+    """Import _plugin_common with its lock dir pointed at a temp path."""
+    sys.path.insert(0, str(_SCRIPTS))
+    spec = importlib.util.spec_from_file_location(
+        f"common_lock_{tmp.name}", _SCRIPTS / "_plugin_common.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod._IMPROVE_LOCK_DIR = tmp / "improve-locks"
+    mod.hook_log = lambda *a, **kw: None
+    return mod
+
+
+# --- the per-session improve claim ------------------------------------------
+
+
+def test_second_holder_is_refused_for_the_same_session():
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    with c.improve_session_lock("sess-A", "first") as a:
+        assert a is True, "first claimer must win"
+        with c.improve_session_lock("sess-A", "second") as b:
+            assert b is False, "concurrent claim on the SAME session must be refused"
+
+
+def test_different_sessions_do_not_block_each_other():
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    with c.improve_session_lock("sess-A", "first") as a:
+        with c.improve_session_lock("sess-B", "second") as b:
+            assert a is True and b is True, "distinct sessions must run concurrently"
+
+
+def test_lock_is_released_after_the_block():
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    with c.improve_session_lock("sess-A", "first") as a:
+        assert a is True
+    with c.improve_session_lock("sess-A", "second") as b:
+        assert b is True, "lock must not leak once the holder finishes"
+
+
+def test_lock_released_even_when_body_raises():
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    try:
+        with c.improve_session_lock("sess-A", "boom"):
+            raise RuntimeError("improve blew up")
+    except RuntimeError:
+        pass
+    with c.improve_session_lock("sess-A", "after") as b:
+        assert b is True, "a crashing improve must not wedge the session"
+
+
+def test_dead_holder_lock_is_reclaimed():
+    """A crashed worker's lock must not strand the session forever."""
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    import hashlib
+
+    d = hashlib.sha1(b"sess-A").hexdigest()
+    p = tmp / "improve-locks" / f"{d}.lock"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    # created_at in the far future so age alone cannot explain the reclaim — the
+    # dead-pid branch must be what clears it. pid_alive is stubbed rather than
+    # guessing an unused pid, so the test can't flake on a recycled pid.
+    p.write_text(json.dumps({"owner": "dead", "pid": 4242, "created_at": 9e9}))
+    c._proc.pid_alive = lambda pid: False
+    with c.improve_session_lock("sess-A", "reclaimer") as claimed:
+        assert claimed is True, "stale lock from a dead pid must be reclaimed"
+
+
+def test_live_holder_lock_is_not_stolen():
+    """The reclaim path must not evict a lock whose owner is still running."""
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    import hashlib
+
+    d = hashlib.sha1(b"sess-A").hexdigest()
+    p = tmp / "improve-locks" / f"{d}.lock"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    import datetime as _dt
+
+    now = _dt.datetime.now(_dt.timezone.utc).timestamp()
+    p.write_text(json.dumps({"owner": "live", "pid": 4242, "created_at": now}))
+    c._proc.pid_alive = lambda pid: True
+    with c.improve_session_lock("sess-A", "intruder") as claimed:
+        assert claimed is False, "a live holder's lock must be respected"
+
+
+def test_missing_session_id_never_blocks():
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    with c.improve_session_lock("", "no-id") as a:
+        with c.improve_session_lock("", "also-no-id") as b:
+            assert a is True and b is True, "no session id => no claim, must fail open"
+
+
+def test_run_session_improve_skips_when_claim_is_held():
+    """The guard lives in run_session_improve, so every caller inherits it."""
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    called = []
+    c._run_session_improve_locked = lambda ds, sid: called.append((ds, sid)) or True
+
+    assert c.run_session_improve("ds", "sess-A") is True
+    assert called == [("ds", "sess-A")], "uncontended improve must run"
+
+    with c.improve_session_lock("sess-A", "holder"):
+        assert c.run_session_improve("ds", "sess-A") is False, "must report not-synced"
+    assert len(called) == 1, "contended improve must NOT reach the submit"
+
+
+# --- recall always names its dataset ----------------------------------------
+
+
+def _captured_recall_payload(tmp: pathlib.Path, **kwargs) -> dict:
+    c = _fresh_common(tmp)
+    seen = {}
+
+    def fake_request(path, payload=None, *, method="POST", timeout=30.0):
+        seen["path"], seen["payload"] = path, payload
+        return []
+
+    c._json_http_request = fake_request
+    c.recall_via_http("q", session_id="s", top_k=5, scope=["graph"], **kwargs)
+    return seen
+
+
+def test_recall_sends_the_dataset():
+    seen = _captured_recall_payload(pathlib.Path(tempfile.mkdtemp()), dataset="agent_sessions")
+    assert seen["path"] == "/api/v1/recall"
+    assert seen["payload"].get("datasets") == ["agent_sessions"], seen["payload"]
+
+
+def test_recall_omits_datasets_key_when_no_dataset_known():
+    """No dataset => no key, rather than a null/empty list the server must parse."""
+    seen = _captured_recall_payload(pathlib.Path(tempfile.mkdtemp()))
+    assert "datasets" not in seen["payload"], seen["payload"]
+
+
+def test_recall_still_sends_search_type_and_scope():
+    seen = _captured_recall_payload(
+        pathlib.Path(tempfile.mkdtemp()), dataset="ds", search_type="HYBRID_COMPLETION"
+    )
+    p = seen["payload"]
+    assert p["datasets"] == ["ds"] and p["search_type"] == "HYBRID_COMPLETION"
+    assert p["scope"] == ["graph"] and p["only_context"] is True
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print(f"PASS {_name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {_name}: {exc}")
+            except Exception as exc:  # noqa: BLE001 - report, don't mask
+                failures += 1
+                print(f"ERROR {_name}: {type(exc).__name__}: {exc}")
+    print("\nALL PASSED" if not failures else f"\n{failures} FAILED")
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,6 +10,32 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.2]
+
+### Fixed
+- **Per-prompt recall now names its dataset.** `/api/v1/recall` was the only
+  data-plane call that omitted one, so the server resolved *every* dataset the user
+  can read and searched all of them on every prompt — on a machine with several
+  datasets that is the graph scope paying for unrelated stores, one of which can be
+  orders of magnitude larger than the plugin's own. It now sends
+  `datasets: [<dataset>]`, matching the explicit-search path, which has always scoped
+  this way. Applies to the per-prompt lookup and the pre-compact recall. The dataset
+  is the usual one — `COGNEE_PLUGIN_DATASET` if set, otherwise `agent_sessions` — and
+  the key is omitted entirely when no dataset is known.
+- **One improve per session, instead of up to three at once.** The idle watcher,
+  the store hook and the SessionEnd sync all bridge sessions, and the cross-hook
+  `sync_lock` is bypassed in API mode — so in HTTP/cloud mode nothing stopped two of
+  them submitting the *same* session concurrently. The server's own per-session lock
+  answered the loser with a busy response, which drove a 15-second retry loop for up
+  to ten minutes; in one real log that accounted for two thirds of all sessions and
+  7,144 retry events. Improves are now claimed per session locally before submitting
+  (`improve_session_lock`), so the loser skips immediately instead of waiting on work
+  the winner is already doing. Freshness is unaffected: a skip reports not-synced, so
+  the caller re-drives the whole drain+improve, and the server-side busy retry still
+  covers a later attempt landing on a still-running pipeline. The claim covers both
+  the HTTP and local-SDK paths, is released on exceptions, reclaims a dead holder's
+  lock, and fails open — lock bookkeeping must never be why a session goes unsynced.
+
 ## [1.2.1]
 
 ### Fixed

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -34,6 +34,10 @@ _SAVE_COUNTER = _PLUGIN_DIR / "save_counter.json"
 _SERVER_READY_MARKER = _SHARED_PLUGIN_ROOT / "server-ready.json"
 _SERVER_READY_TTL_SECONDS = 30
 _SYNC_LOCK = _PLUGIN_DIR / "sync.lock"
+# One lock file per session (see improve_session_lock): the idle watcher, the
+# store hook and the SessionEnd sync all bridge sessions, and only one of them
+# may have an improve in flight for a given session at a time.
+_IMPROVE_LOCK_DIR = _PLUGIN_DIR / "improve-locks"
 # Per-agent-session buffer dirs. Each agent session (one Claude/Codex terminal)
 # owns its own file under these dirs, so two concurrent agents never
 # read-modify-write the same file — no locks needed, no lost-update races.
@@ -1060,6 +1064,78 @@ def touch_activity() -> None:
 
 
 @contextmanager
+def improve_session_lock(session_id: str, owner: str):
+    """Admit exactly one in-flight improve per session, machine-wide.
+
+    Three paths bridge the same session — the idle watcher, ``store-to-session``,
+    and the SessionEnd sync — and the outer ``sync_lock`` is bypassed in API mode
+    (``nullcontext(True) if api_mode``), so in HTTP/cloud mode nothing stopped two
+    of them submitting the same session concurrently. The server's own per-session
+    lock then answered the loser with ``{}`` (busy), which drove a 15s retry loop
+    for up to ten minutes; concurrent writers also collide on the single-writer
+    graph/vector store ("Could not set lock on file"), leaving pipeline runs stuck
+    and the graph unwritten.
+
+    So claim locally BEFORE submitting: the loser skips entirely rather than
+    waiting, because the winner is already bridging the very same session — the
+    work is not lost, it is in flight. Yields True when claimed, False when
+    another process owns it.
+
+    Mirrors ``sync_lock``'s stale handling (dead pid or older than
+    ``SYNC_LOCK_STALE_SECONDS``) so a crashed worker cannot wedge a session, and
+    fails OPEN on unexpected errors — a lock we cannot manage must never be the
+    reason a session goes unsynced.
+    """
+    if not session_id:
+        yield True
+        return
+
+    digest = hashlib.sha1(str(session_id).encode("utf-8")).hexdigest()
+    lock_path = _IMPROVE_LOCK_DIR / f"{digest}.lock"
+    acquired = False
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        now = datetime.now(timezone.utc).timestamp()
+        if lock_path.exists():
+            try:
+                current = json.loads(lock_path.read_text(encoding="utf-8"))
+                created_at = float(current.get("created_at", 0))
+                pid = int(current.get("pid", 0))
+            except Exception:
+                created_at, pid = 0.0, 0
+            if not (pid > 0 and _proc.pid_alive(pid)) or now - created_at > SYNC_LOCK_STALE_SECONDS:
+                try:
+                    lock_path.unlink()
+                    hook_log(
+                        "improve_lock_stale_cleared",
+                        {"session": session_id, "owner": owner, "stale_pid": pid},
+                    )
+                except FileNotFoundError:
+                    pass  # another process cleared the same stale lock
+                except Exception as exc:
+                    hook_log("improve_lock_unlink_failed", {"error": str(exc)[:200]})
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump({"owner": owner, "pid": os.getpid(), "created_at": now}, fh)
+            acquired = True
+            yield True
+        except FileExistsError:
+            hook_log("improve_skipped_concurrent", {"session": session_id, "owner": owner})
+            yield False
+    except Exception as exc:
+        # Fail open: never let lock bookkeeping cost a session its sync.
+        hook_log("improve_lock_failed_open", {"session": session_id, "error": str(exc)[:200]})
+        yield True
+    finally:
+        if acquired:
+            try:
+                lock_path.unlink()
+            except Exception as exc:
+                hook_log("improve_lock_release_failed", {"error": str(exc)[:200]})
+
+
+@contextmanager
 def sync_lock(owner: str):
     """Best-effort cross-hook lock for graph sync/improve work."""
     acquired = False
@@ -1811,6 +1887,7 @@ def recall_via_http(
     only_context: bool = True,
     search_type: str | None = None,
     context_profile: str | None = None,
+    dataset: str = "",
     timeout: float = 10.0,
 ) -> list:
     payload = {
@@ -1820,6 +1897,14 @@ def recall_via_http(
         "scope": scope,
         "only_context": only_context,
     }
+    # Always scope to the plugin's dataset. Without it the server resolves EVERY
+    # readable dataset and then reconciles against the session's binding, so the
+    # graph scope depends on that binding existing: an unbound session with more
+    # than one readable dataset is rejected as ambiguous rather than searched.
+    # The value must be the dataset the session's entries were written under — a
+    # different one is a binding mismatch server-side, a real error worth surfacing.
+    if dataset:
+        payload["datasets"] = [dataset]
     if search_type:
         payload["search_type"] = search_type
     if context_profile:
@@ -2250,7 +2335,23 @@ def run_session_improve(dataset: str, session_id: str) -> bool:
 
     Falls back to the legacy full-document bridge when the server does not
     support session-aware improve. Returns True when a sync ran successfully.
+
+    Serialized per session by ``improve_session_lock``. The guard lives here
+    rather than at the three call sites (idle watcher, store hook, SessionEnd
+    sync) so every path is covered by construction and a future fourth caller
+    cannot reintroduce the double-submit.
     """
+    with improve_session_lock(session_id, "run_session_improve") as claimed:
+        if not claimed:
+            # Another process is already bridging this exact session. Report
+            # not-synced so the caller's own retry/reporting path is unchanged;
+            # the work itself is in flight, not dropped.
+            return False
+        return _run_session_improve_locked(dataset, session_id)
+
+
+def _run_session_improve_locked(dataset: str, session_id: str) -> bool:
+    """Body of run_session_improve; assumes the per-session claim is held."""
     base_url = _local_api_url()
     if not _backend_reachable(base_url):
         return False

--- a/integrations/codex/plugins/cognee/scripts/config.py
+++ b/integrations/codex/plugins/cognee/scripts/config.py
@@ -422,26 +422,36 @@ async def improve_session_local(dataset: str, session_id: str, user) -> dict:
     and (in foreground mode) the graph→session sync — so the explicit
     persist+sync pair below is only kept as a fallback for older cognee
     versions without session-aware improve.
+
+    Serialized per session by ``improve_session_lock``, matching the HTTP path in
+    ``run_session_improve``. ``store-to-session``'s background fire takes no outer
+    ``sync_lock``, so without this the local path could double-submit one session
+    and have two writers contend for the single-writer graph store.
     """
     if not session_id or not user:
         return {"ok": False, "error": "missing session/user"}
 
     import cognee
+    from _plugin_common import improve_session_lock
 
-    try:
-        result = await cognee.improve(
-            dataset,
-            session_ids=[session_id],
-            user=user,
-            run_in_background=False,
-        )
-        return {"ok": True, "result": result}
-    except TypeError as exc:
-        # Older cognee without session-aware improve: legacy persist + sync.
-        _config_log("improve_local_unsupported", {"error": str(exc)[:200]})
-        wrote = await persist_session_cache_to_graph(dataset, session_id, user)
-        graph_result = await sync_graph_context_to_session(dataset, session_id, user)
-        return {"ok": wrote, "legacy": True, "graph_synced": graph_result.get("synced", 0)}
+    with improve_session_lock(session_id, "improve_session_local") as claimed:
+        if not claimed:
+            # Winner is already bridging this session; not dropped, just in flight.
+            return {"ok": False, "skipped": "concurrent"}
+        try:
+            result = await cognee.improve(
+                dataset,
+                session_ids=[session_id],
+                user=user,
+                run_in_background=False,
+            )
+            return {"ok": True, "result": result}
+        except TypeError as exc:
+            # Older cognee without session-aware improve: legacy persist + sync.
+            _config_log("improve_local_unsupported", {"error": str(exc)[:200]})
+            wrote = await persist_session_cache_to_graph(dataset, session_id, user)
+            graph_result = await sync_graph_context_to_session(dataset, session_id, user)
+            return {"ok": wrote, "legacy": True, "graph_synced": graph_result.get("synced", 0)}
 
 
 def _read_field(entry, field: str) -> str:

--- a/integrations/codex/plugins/cognee/scripts/pre-compact.py
+++ b/integrations/codex/plugins/cognee/scripts/pre-compact.py
@@ -122,6 +122,7 @@ async def _recall(
                 scope=scope,
                 only_context=True,
                 search_type=qtype,
+                dataset=get_dataset(config),
             )
         else:
             import cognee

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -292,6 +292,7 @@ async def _run(prompt: str) -> dict | None:
                     only_context=True,
                     search_type=qtype,
                     context_profile=context_profile,
+                    dataset=get_dataset(config),
                     timeout=recall_timeout,
                 )
             else:

--- a/integrations/codex/tests/test_improve_session_lock.py
+++ b/integrations/codex/tests/test_improve_session_lock.py
@@ -1,0 +1,194 @@
+"""One improve per session, machine-wide — and recall always names its dataset.
+
+Two regressions this locks down, both root-caused from a real hook.log:
+
+1. **Duplicate improves.** The idle watcher, ``store-to-session`` and the
+   SessionEnd sync all bridge sessions, and the outer ``sync_lock`` is bypassed in
+   API mode (``nullcontext(True) if api_mode``). 67% of sessions were submitted by
+   two processes at once; the server's own per-session lock answered the loser with
+   ``{}`` (busy), driving a 15s retry loop for up to ten minutes, while concurrent
+   writers collided on the single-writer graph store ("Could not set lock on file")
+   and left pipeline runs stuck with the graph unwritten.
+
+2. **Recall without a dataset.** ``/api/v1/recall`` was the only data-plane call
+   omitting one, leaving the graph scope dependent on the session's dataset binding
+   — an unbound session with several readable datasets is rejected as ambiguous
+   rather than searched.
+
+Run: `python integrations/codex/tests/test_improve_session_lock.py` (or via pytest).
+"""
+
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "plugins" / "cognee" / "scripts"
+
+
+def _fresh_common(tmp: pathlib.Path):
+    """Import _plugin_common with its lock dir pointed at a temp path."""
+    sys.path.insert(0, str(_SCRIPTS))
+    spec = importlib.util.spec_from_file_location(
+        f"common_lock_{tmp.name}", _SCRIPTS / "_plugin_common.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod._IMPROVE_LOCK_DIR = tmp / "improve-locks"
+    mod.hook_log = lambda *a, **kw: None
+    return mod
+
+
+# --- the per-session improve claim ------------------------------------------
+
+
+def test_second_holder_is_refused_for_the_same_session():
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    with c.improve_session_lock("sess-A", "first") as a:
+        assert a is True, "first claimer must win"
+        with c.improve_session_lock("sess-A", "second") as b:
+            assert b is False, "concurrent claim on the SAME session must be refused"
+
+
+def test_different_sessions_do_not_block_each_other():
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    with c.improve_session_lock("sess-A", "first") as a:
+        with c.improve_session_lock("sess-B", "second") as b:
+            assert a is True and b is True, "distinct sessions must run concurrently"
+
+
+def test_lock_is_released_after_the_block():
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    with c.improve_session_lock("sess-A", "first") as a:
+        assert a is True
+    with c.improve_session_lock("sess-A", "second") as b:
+        assert b is True, "lock must not leak once the holder finishes"
+
+
+def test_lock_released_even_when_body_raises():
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    try:
+        with c.improve_session_lock("sess-A", "boom"):
+            raise RuntimeError("improve blew up")
+    except RuntimeError:
+        pass
+    with c.improve_session_lock("sess-A", "after") as b:
+        assert b is True, "a crashing improve must not wedge the session"
+
+
+def test_dead_holder_lock_is_reclaimed():
+    """A crashed worker's lock must not strand the session forever."""
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    import hashlib
+
+    d = hashlib.sha1(b"sess-A").hexdigest()
+    p = tmp / "improve-locks" / f"{d}.lock"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    # created_at in the far future so age alone cannot explain the reclaim — the
+    # dead-pid branch must be what clears it. pid_alive is stubbed rather than
+    # guessing an unused pid, so the test can't flake on a recycled pid.
+    p.write_text(json.dumps({"owner": "dead", "pid": 4242, "created_at": 9e9}))
+    c._proc.pid_alive = lambda pid: False
+    with c.improve_session_lock("sess-A", "reclaimer") as claimed:
+        assert claimed is True, "stale lock from a dead pid must be reclaimed"
+
+
+def test_live_holder_lock_is_not_stolen():
+    """The reclaim path must not evict a lock whose owner is still running."""
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    import hashlib
+
+    d = hashlib.sha1(b"sess-A").hexdigest()
+    p = tmp / "improve-locks" / f"{d}.lock"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    import datetime as _dt
+
+    now = _dt.datetime.now(_dt.timezone.utc).timestamp()
+    p.write_text(json.dumps({"owner": "live", "pid": 4242, "created_at": now}))
+    c._proc.pid_alive = lambda pid: True
+    with c.improve_session_lock("sess-A", "intruder") as claimed:
+        assert claimed is False, "a live holder's lock must be respected"
+
+
+def test_missing_session_id_never_blocks():
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    with c.improve_session_lock("", "no-id") as a:
+        with c.improve_session_lock("", "also-no-id") as b:
+            assert a is True and b is True, "no session id => no claim, must fail open"
+
+
+def test_run_session_improve_skips_when_claim_is_held():
+    """The guard lives in run_session_improve, so every caller inherits it."""
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    c = _fresh_common(tmp)
+    called = []
+    c._run_session_improve_locked = lambda ds, sid: called.append((ds, sid)) or True
+
+    assert c.run_session_improve("ds", "sess-A") is True
+    assert called == [("ds", "sess-A")], "uncontended improve must run"
+
+    with c.improve_session_lock("sess-A", "holder"):
+        assert c.run_session_improve("ds", "sess-A") is False, "must report not-synced"
+    assert len(called) == 1, "contended improve must NOT reach the submit"
+
+
+# --- recall always names its dataset ----------------------------------------
+
+
+def _captured_recall_payload(tmp: pathlib.Path, **kwargs) -> dict:
+    c = _fresh_common(tmp)
+    seen = {}
+
+    def fake_request(path, payload=None, *, method="POST", timeout=30.0):
+        seen["path"], seen["payload"] = path, payload
+        return []
+
+    c._json_http_request = fake_request
+    c.recall_via_http("q", session_id="s", top_k=5, scope=["graph"], **kwargs)
+    return seen
+
+
+def test_recall_sends_the_dataset():
+    seen = _captured_recall_payload(pathlib.Path(tempfile.mkdtemp()), dataset="agent_sessions")
+    assert seen["path"] == "/api/v1/recall"
+    assert seen["payload"].get("datasets") == ["agent_sessions"], seen["payload"]
+
+
+def test_recall_omits_datasets_key_when_no_dataset_known():
+    """No dataset => no key, rather than a null/empty list the server must parse."""
+    seen = _captured_recall_payload(pathlib.Path(tempfile.mkdtemp()))
+    assert "datasets" not in seen["payload"], seen["payload"]
+
+
+def test_recall_still_sends_search_type_and_scope():
+    seen = _captured_recall_payload(
+        pathlib.Path(tempfile.mkdtemp()), dataset="ds", search_type="HYBRID_COMPLETION"
+    )
+    p = seen["payload"]
+    assert p["datasets"] == ["ds"] and p["search_type"] == "HYBRID_COMPLETION"
+    assert p["scope"] == ["graph"] and p["only_context"] is True
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print(f"PASS {_name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {_name}: {exc}")
+            except Exception as exc:  # noqa: BLE001 - report, don't mask
+                failures += 1
+                print(f"ERROR {_name}: {type(exc).__name__}: {exc}")
+    print("\nALL PASSED" if not failures else f"\n{failures} FAILED")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
This PR fixes improve call duplication, plus recall now correctly specifies a dataset at every call.