### PR TITLE
feat: add env file for all env vars

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "author": {
         "name": "Cognee"
       },

--- a/README.md
+++ b/README.md
@@ -93,14 +93,22 @@ Run these slash commands directly in the Claude Code chat:
 
 In local mode (the default), the plugin bootstraps a local Cognee API on
 `http://localhost:8011`. Cognee extracts knowledge with an LLM, so set `LLM_API_KEY`
-in the shell that launches Claude Code:
+**once** in `~/.cognee/.env` (shared by the Claude Code and Codex plugins) — one
+paste, no editor needed:
 
 ```bash
-export LLM_API_KEY="sk-..."
+mkdir -p ~/.cognee
+cat >> ~/.cognee/.env <<'EOF'
+LLM_API_KEY="sk-..."
+EOF
+chmod 600 ~/.cognee/.env
 ```
 
+A plain `export` in the launching shell also works and overrides the file. Re-pasting
+the block with a new value is safe — the last value wins.
+
 To target Cognee Cloud or a remote server instead, set `COGNEE_BASE_URL` and
-`COGNEE_API_KEY`. On startup you should see a **"Cognee Memory Connected"** message.
+`COGNEE_API_KEY` there. On startup you should see a **"Cognee Memory Connected"** message.
 
 **3. Use Claude Code as usual**
 

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": {
     "name": "Cognee"
   },

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,6 +10,24 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.0]
+
+### Added
+- **One-time configuration via `~/.cognee/.env`.** API keys and URLs
+  (`COGNEE_BASE_URL`, `COGNEE_API_KEY`, `LLM_API_KEY`, and every other env var the
+  plugin reads) no longer need to be exported in each shell: values placed in
+  `~/.cognee/.env` — the durable cognee home shared with the Codex plugin — are
+  injected into the environment at process start with setdefault semantics, so a
+  real shell export still wins per terminal, and spawned processes (local server,
+  watchers) inherit them unchanged. The file accepts pasted `export KEY=value`
+  lines, is created with a commented template (mode `0600`) on first session
+  start, and its location can be overridden with `COGNEE_ENV_FILE`. `doctor.py`
+  gained an **Env File** row showing which keys the file defines (names only,
+  never values) and which are overridden by shell exports. The parser tolerates
+  Windows-written files: a UTF-8 BOM (PowerShell 5.1) is stripped, UTF-16 (a PS5
+  `>` redirect) is decoded, and CRLF line endings are handled — so copy/paste
+  setup blocks work from any shell.
+
 ## [1.1.1]
 
 ### Fixed

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -18,13 +18,17 @@ claude plugin install cognee-memory@cognee
 
 These CLI subcommands use the exact same plugin manager as the in-chat `/plugin` commands — same marketplace clone, same install cache, same global state — they just run before you enter the terminal. Default install scope is `user` (global); pass `--scope project` or `--scope local` to confine it.
 
-Then set environment variables for your runtime mode (in the shell you'll launch `claude` from).
+Then configure your runtime mode — **once** — in `~/.cognee/.env`. The file is created with a commented template on the first session start; values in it act exactly like shell exports (a real `export` in your shell still overrides the file, per terminal). It is shared with the Codex plugin, so both read the same configuration. Lines may optionally start with `export `, so existing export lines can be pasted verbatim.
 
-**Cognee Cloud or a remote server** — set both:
+**Cognee Cloud or a remote server** — set both (one paste, no editor needed):
 
 ```bash
-export COGNEE_BASE_URL="https://your-instance.cognee.ai"
-export COGNEE_API_KEY="ck_..."
+mkdir -p ~/.cognee
+cat >> ~/.cognee/.env <<'EOF'
+COGNEE_BASE_URL="https://your-instance.cognee.ai"
+COGNEE_API_KEY="ck_..."
+EOF
+chmod 600 ~/.cognee/.env
 ```
 
 > Cloud mode is a pure thin client: it talks to your remote server over HTTP only and does **not** install a local Cognee runtime. The bundled virtualenv (`~/.cognee-plugin/venv`) is built only in local mode, where an in-process server actually runs.
@@ -32,8 +36,24 @@ export COGNEE_API_KEY="ck_..."
 **Local mode** (default when `COGNEE_BASE_URL` is not set) — the plugin bootstraps a local Cognee API at `http://localhost:8011`. Only `LLM_API_KEY` is required; `COGNEE_API_KEY` is auto-minted if absent:
 
 ```bash
-export LLM_API_KEY="sk-..."
+mkdir -p ~/.cognee
+cat >> ~/.cognee/.env <<'EOF'
+LLM_API_KEY="sk-..."
+EOF
+chmod 600 ~/.cognee/.env
 ```
+
+**Windows (PowerShell)** — same idea, same file:
+
+```powershell
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.cognee" | Out-Null
+@'
+COGNEE_BASE_URL="https://your-instance.cognee.ai"
+COGNEE_API_KEY="ck_..."
+'@ | Add-Content "$env:USERPROFILE\.cognee\.env"
+```
+
+Re-running any of these blocks is safe: when a key appears more than once, the **last value wins**, so pasting again with a new value updates the configuration. Editing the file directly (`nano ~/.cognee/.env`) works too — e.g. to remove a variable such as `COGNEE_BASE_URL` when switching from cloud back to local mode. Changes apply on the next session launch. Plain shell `export`s in the launching terminal still take precedence over `~/.cognee/.env` — useful to override the shared config for one terminal.
 
 You can also set config in `~/.cognee-plugin/claude-code/config.json`:
 
@@ -46,7 +66,7 @@ You can also set config in `~/.cognee-plugin/claude-code/config.json`:
 
 Then launch `claude`. All setup happens in the `SessionStart` hook, which fires once per fresh launch — so with the shell install above, the first launch connects memory with no extra steps.
 
-If you instead installed **from inside the chat** with the `/plugin` slash commands, you must **restart Claude Code** (start a new session) before memory connects: `/reload-plugins` makes the skills and agents available in the current session but does not run `SessionStart`. On a first-run marketplace install the marketplace is also fetched asynchronously, so `SessionStart` may not fire that session even with a reload. Either way, make sure your env vars are set in the shell you launch from.
+If you instead installed **from inside the chat** with the `/plugin` slash commands, you must **restart Claude Code** (start a new session) before memory connects: `/reload-plugins` makes the skills and agents available in the current session but does not run `SessionStart`. On a first-run marketplace install the marketplace is also fetched asynchronously, so `SessionStart` may not fire that session even with a reload. Either way, make sure your configuration is in `~/.cognee/.env` (or exported in the shell you launch from).
 
 On startup you should see a "Cognee Memory Connected" system message.
 
@@ -407,9 +427,12 @@ skips local-path (dev) installs. Turn it off with `COGNEE_UPDATE_CHECK=false`.
 ## Configuration reference
 
 Config precedence:
-1. env vars
-2. `~/.cognee-plugin/claude-code/config.json`
-3. defaults
+1. env vars (shell exports)
+2. `~/.cognee/.env` (one-time setup file, shared with the Codex plugin; loaded into the environment at process start, so every env var below can live here)
+3. `~/.cognee-plugin/claude-code/config.json`
+4. defaults
+
+`~/.cognee/.env` is created with a commented template on first session start (permissions `0600`; the path can be overridden with `COGNEE_ENV_FILE`). Run `doctor.py` to see which keys the file defines and which are overridden by shell exports.
 
 | Key | Env var(s) | Default | Notes |
 |---|---|---|---|

--- a/integrations/claude-code/scripts/_cognee_client.py
+++ b/integrations/claude-code/scripts/_cognee_client.py
@@ -21,7 +21,11 @@ import pathlib
 import sys
 import time
 
+from _env_file import load_env_file
 from _recall_http import UNREACHABLE, _error, do_recall
+
+# ~/.cognee/.env must land in os.environ before the module-level reads below.
+load_env_file()
 
 # Tunables (mirror Hermes's provider defaults).
 _THRESHOLD = int(os.environ.get("COGNEE_BREAKER_THRESHOLD", "5"))

--- a/integrations/claude-code/scripts/_env_file.py
+++ b/integrations/claude-code/scripts/_env_file.py
@@ -1,0 +1,196 @@
+"""One-time plugin configuration via ~/.cognee/.env.
+
+Users historically had to `export COGNEE_BASE_URL=...`, `export LLM_API_KEY=...`
+in every shell. This module makes that a one-time step: values placed in
+``~/.cognee/.env`` (the durable, venv-rebuild-safe cognee home shared by the
+Claude Code and Codex plugins) are injected into ``os.environ`` at process
+start with **setdefault** semantics, so:
+
+  real exported env vars  >  ~/.cognee/.env  >  config.json  >  defaults
+
+Every existing ``os.environ.get(...)`` call site — and every child process the
+hooks spawn (the local cognee server, idle/exit watchers) — picks the values up
+unchanged.
+
+Deliberately stdlib-only: hook scripts must run outside the plugin venv on the
+cloud path, so python-dotenv is not an option. The parser accepts a leading
+``export `` so users can paste their existing shell export lines verbatim.
+
+Loading must never break a hook: any parse or IO problem results in the file
+being (partially) ignored, never an exception.
+"""
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+_COGNEE_HOME = Path.home() / ".cognee"
+_DEFAULT_ENV_FILE = _COGNEE_HOME / ".env"
+
+# Vars that could hijack process behavior if injected from a config file.
+# Everything else (COGNEE_*, LLM_*, EMBEDDING_*, provider keys, ...) is allowed
+# so the values also flow through to the spawned local cognee server.
+_DENYLIST_EXACT = {"PATH", "HOME", "PYTHONPATH", "PYTHONHOME", "SHELL", "USER"}
+_DENYLIST_PREFIXES = ("LD_", "DYLD_")
+
+_TEMPLATE = """\
+# Cognee plugin configuration — shared by the Claude Code and Codex plugins.
+# Values here are loaded at session start and act like shell exports, except
+# you only set them once. A real `export` in your shell still wins over this
+# file. Lines starting with `#` are comments; a leading `export ` is allowed.
+
+## Cloud / remote mode — point the plugins at a Cognee instance:
+# COGNEE_BASE_URL="https://your-instance.cognee.ai"
+# COGNEE_API_KEY="ck_..."
+
+## Local mode (default when COGNEE_BASE_URL is unset) — the plugin runs a
+## local Cognee API; only an LLM key is required:
+# LLM_API_KEY="sk-..."
+# LLM_MODEL="openai/gpt-4o-mini"
+
+## Optional:
+# COGNEE_PLUGIN_DATASET="agent_sessions"
+"""
+
+
+def env_file_path() -> Path:
+    """The env file location (COGNEE_ENV_FILE overrides the default)."""
+    override = os.environ.get("COGNEE_ENV_FILE", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return _DEFAULT_ENV_FILE
+
+
+def _unquote(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
+def _blocked(key: str) -> bool:
+    return key in _DENYLIST_EXACT or key.startswith(_DENYLIST_PREFIXES)
+
+
+def parse_env_file(path: Path) -> dict:
+    """Parse a dotenv-style file into a dict. Malformed lines are skipped.
+
+    Supported: ``KEY=VALUE``, blank lines, ``#`` comments, an optional leading
+    ``export ``, and single/double quotes around the value. No interpolation,
+    no multi-line values.
+    """
+    result: dict[str, str] = {}
+    try:
+        # utf-8-sig strips a UTF-8 BOM when present (Windows PowerShell 5.1
+        # writes one) and is a no-op otherwise. A PS5 `>` redirect produces
+        # UTF-16 instead — retry with that before giving up.
+        try:
+            text = path.read_text(encoding="utf-8-sig")
+        except UnicodeDecodeError:
+            text = path.read_text(encoding="utf-16")
+    except Exception:
+        return result
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not key or not all(c.isalnum() or c == "_" for c in key):
+            continue
+        result[key] = _unquote(value)
+    return result
+
+
+_loaded = False
+
+
+def load_env_file() -> None:
+    """Inject env-file values into os.environ (setdefault). Never raises.
+
+    Idempotent per process: repeated calls (this module is imported from
+    several entry-point modules) parse the file at most once.
+    """
+    global _loaded
+    if _loaded:
+        return
+    _loaded = True
+
+    try:
+        path = env_file_path()
+        if not path.is_file():
+            return
+        _tighten_permissions(path)
+        for key, value in parse_env_file(path).items():
+            if _blocked(key):
+                continue
+            os.environ.setdefault(key, value)
+    except Exception:
+        pass
+
+
+def _tighten_permissions(path: Path) -> None:
+    """Best-effort chmod 0600: the file may hold API keys."""
+    if os.name == "nt":
+        return
+    try:
+        mode = stat.S_IMODE(path.stat().st_mode)
+        if mode & 0o077:
+            path.chmod(0o600)
+    except Exception:
+        pass
+
+
+def ensure_env_file_template() -> bool:
+    """Write a commented template to ~/.cognee/.env if no file exists yet.
+
+    Returns True when the template was created. Called from SessionStart so
+    users find a documented file to fill in instead of an empty folder. Only
+    the default location gets a template — an explicit COGNEE_ENV_FILE
+    pointing elsewhere is the user's own file to manage.
+    """
+    if os.environ.get("COGNEE_ENV_FILE", "").strip():
+        return False
+    try:
+        if _DEFAULT_ENV_FILE.exists():
+            return False
+        _COGNEE_HOME.mkdir(parents=True, exist_ok=True)
+        _DEFAULT_ENV_FILE.write_text(_TEMPLATE, encoding="utf-8")
+        if os.name != "nt":
+            _DEFAULT_ENV_FILE.chmod(0o600)
+        return True
+    except Exception:
+        return False
+
+
+def env_file_status() -> dict:
+    """Diagnostics for doctor: existence, perms, and key *names* (no values)."""
+    path = env_file_path()
+    info: dict = {"path": str(path), "exists": path.is_file()}
+    if not info["exists"]:
+        return info
+    try:
+        info["mode"] = oct(stat.S_IMODE(path.stat().st_mode))
+    except Exception:
+        pass
+    values = parse_env_file(path)
+    info["keys"] = sorted(values)
+    info["blocked"] = sorted(k for k in values if _blocked(k))
+    # A shell export (or another source) that set a different value wins over
+    # the file; surface those so mode-selection surprises are debuggable.
+    info["overridden"] = sorted(
+        k for k in values if not _blocked(k) and os.environ.get(k, values[k]) != values[k]
+    )
+    return info
+
+
+if __name__ == "__main__":
+    import json
+
+    load_env_file()
+    json.dump(env_file_status(), sys.stdout, indent=2)
+    print()

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -23,6 +23,11 @@ from pathlib import Path
 from typing import Optional
 
 import _proc
+from _env_file import load_env_file
+
+# One-time config: ~/.cognee/.env acts like shell exports (setdefault — a real
+# export still wins). Loaded before any env read below or in importers.
+load_env_file()
 
 _PLUGIN_DIR = Path.home() / ".cognee-plugin" / "claude-code"
 _SHARED_PLUGIN_ROOT = Path.home() / ".cognee-plugin"

--- a/integrations/claude-code/scripts/cognee-remember.sh
+++ b/integrations/claude-code/scripts/cognee-remember.sh
@@ -16,13 +16,21 @@
 set -euo pipefail
 
 PLUGIN_DIR="${HOME}/.cognee-plugin/claude-code"
-runtime_json="$(python3 - <<'PY' "${PLUGIN_DIR}" 2>/dev/null || true
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+runtime_json="$(python3 - <<'PY' "${PLUGIN_DIR}" "${SELF_DIR}" 2>/dev/null || true
 import json
 import pathlib
 import sys
 
 plugin_dir = pathlib.Path(sys.argv[1])
 import os
+# One-time config from ~/.cognee/.env (shell exports still win).
+sys.path.insert(0, sys.argv[2])
+try:
+    from _env_file import load_env_file
+    load_env_file()
+except Exception:
+    pass
 service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
 api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
 
@@ -103,7 +111,6 @@ fi
 # Server-first: POST to /api/v1/remember via _remember_http.py.
 # UNREACHABLE → fall back to cognee-cli and warn.
 # Any other result (ok or error) → authoritative; do not fall back.
-SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
 RESULT="$(python3 "${SELF_DIR}/_remember_http.py" "$SERVICE_URL" "$API_KEY" "$CONTENT" "$DATASET" "$NODE_SET" || true)"
 
 if [ -n "$RESULT" ] && [ "$RESULT" != "UNREACHABLE" ]; then

--- a/integrations/claude-code/scripts/cognee-search.sh
+++ b/integrations/claude-code/scripts/cognee-search.sh
@@ -15,7 +15,8 @@
 set -euo pipefail
 
 PLUGIN_DIR="${HOME}/.cognee-plugin/claude-code"
-runtime_json="$(python3 - <<'PY' "${PLUGIN_DIR}" 2>/dev/null || true
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+runtime_json="$(python3 - <<'PY' "${PLUGIN_DIR}" "${SELF_DIR}" 2>/dev/null || true
 import json
 import pathlib
 import sys
@@ -25,6 +26,13 @@ import urllib.request
 
 plugin_dir = pathlib.Path(sys.argv[1])
 import os
+# One-time config from ~/.cognee/.env (shell exports still win).
+sys.path.insert(0, sys.argv[2])
+try:
+    from _env_file import load_env_file
+    load_env_file()
+except Exception:
+    pass
 service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
 api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
 if not api_key:
@@ -147,7 +155,6 @@ esac
 # $DATASET is resolved above (COGNEE_PLUGIN_DATASET → default)
 # and scopes the search to the plugin's dataset so unrelated datasets don't bleed in.
 # Logic lives in _recall_http.py (stdlib-only, unit-tested); stderr is surfaced.
-SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
 export COGNEE_PLUGIN_STATE_DIR="$PLUGIN_DIR"
 RECALL_JSON="$(python3 "${SELF_DIR}/_cognee_client.py" "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$SCOPE" "$TOP_K" "$DATASET" || true)"
 

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -17,6 +17,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
+from _env_file import load_env_file
+
+# ~/.cognee/.env is pure-local too, so loading it here keeps the renderer's
+# no-network/no-_plugin_common contract while honoring one-time config.
+load_env_file()
+
 _SHARED_ROOT = Path.home() / ".cognee-plugin"
 _CONFIG_PATH = _SHARED_ROOT / "claude-code" / "config.json"
 _SERVER_READY_PATH = _SHARED_ROOT / "server-ready.json"

--- a/integrations/claude-code/scripts/config.py
+++ b/integrations/claude-code/scripts/config.py
@@ -2,8 +2,10 @@
 
 Loads settings from (in priority order):
   1. Environment variables (runtime overrides)
-  2. Config file (~/.cognee-plugin/config.json)
-  3. Defaults
+  2. Env file (~/.cognee/.env — one-time setup, injected into os.environ
+     with setdefault, so it sits just below real shell exports)
+  3. Config file (~/.cognee-plugin/config.json)
+  4. Defaults
 
 Config file is created on first SessionStart if it doesn't exist.
 
@@ -20,6 +22,12 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Optional
+
+from _env_file import load_env_file
+
+# Must run before the _ENV_MAP scan in load_config() and before any importer's
+# module-level os.environ reads.
+load_env_file()
 
 _CONFIG_DIR = Path.home() / ".cognee-plugin" / "claude-code"
 _STATE_DIR = _CONFIG_DIR

--- a/integrations/claude-code/scripts/doctor.py
+++ b/integrations/claude-code/scripts/doctor.py
@@ -100,10 +100,18 @@ _KEY_SOURCE_LABELS = {
 
 def _resolve_api_key_source() -> str:
     """Return a human-friendly label for where the API key came from."""
+    from _env_file import env_file_path, parse_env_file
     from _plugin_common import _api_key_with_source
 
-    _key, source = _api_key_with_source()
-    return _KEY_SOURCE_LABELS.get(source, source)
+    key, source = _api_key_with_source()
+    label = _KEY_SOURCE_LABELS.get(source, source)
+    if source == "env_api_key" and key:
+        # The env layer is fed by both real exports and ~/.cognee/.env
+        # (setdefault); tell them apart for debuggability.
+        file_key = parse_env_file(env_file_path()).get("COGNEE_API_KEY", "")
+        if file_key and file_key == key:
+            label = "Env file"
+    return label
 
 
 def _check_health(server_url: str, timeout: float = 5.0) -> dict:
@@ -167,6 +175,26 @@ def _resolve_embedding() -> tuple[str, str]:
     return model, dims
 
 
+def _resolve_env_file() -> str:
+    """One-time config file (~/.cognee/.env): presence, key names, overrides.
+
+    Values are never shown — only which keys the file defines, and which of
+    them are shadowed by a real shell export (exports win over the file).
+    """
+    from _env_file import env_file_status
+
+    status = env_file_status()
+    path = status.get("path", "")
+    if not status.get("exists"):
+        return f"Not found ({path})"
+    keys = status.get("keys") or []
+    desc = f"{path} ({len(keys)} key{'s' if len(keys) != 1 else ''}: {', '.join(keys)})"
+    overridden = status.get("overridden") or []
+    if overridden:
+        desc += f" — overridden by shell env: {', '.join(overridden)}"
+    return desc
+
+
 def collect_report() -> dict:
     """Gather all diagnostic fields into an ordered dict."""
     mode = _resolve_mode()
@@ -180,6 +208,7 @@ def collect_report() -> dict:
 
     return {
         "mode": mode,
+        "env_file": _resolve_env_file(),
         "server_url": display_url if display_url != "-" else None,
         "api_key_source": api_key_source,
         "reachable": health["reachable"],
@@ -194,6 +223,7 @@ def collect_report() -> dict:
 
 _DISPLAY_ORDER = [
     ("Mode", "mode"),
+    ("Env File", "env_file"),
     ("Server URL", "server_url"),
     ("API Key Source", "api_key_source"),
     ("Reachable", "reachable"),

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -1454,6 +1454,14 @@ async def _start(payload: dict | None = None) -> dict:
 
 
 def main():
+    # First run: leave a commented ~/.cognee/.env template so one-time config
+    # has a documented file to land in. Values (if any) were already loaded
+    # into os.environ when _plugin_common was imported.
+    from _env_file import ensure_env_file_template, env_file_path
+
+    if ensure_env_file_template():
+        hook_log("env_file_template_created", {"path": str(env_file_path())})
+
     # Detached bootstrap mode: run the slow server boot + registration out of
     # band so the SessionStart hook itself returns fast.
     if _BOOTSTRAP_ARG in sys.argv:

--- a/integrations/claude-code/tests/test_doctor.py
+++ b/integrations/claude-code/tests/test_doctor.py
@@ -256,6 +256,7 @@ def test_json_output():
     parsed = json.loads(doctor.format_json(report))
     expected = {
         "mode",
+        "env_file",
         "server_url",
         "api_key_source",
         "reachable",

--- a/integrations/claude-code/tests/test_env_file.py
+++ b/integrations/claude-code/tests/test_env_file.py
@@ -1,0 +1,233 @@
+"""Unit tests for _env_file (one-time config via ~/.cognee/.env).
+
+Covers:
+  - dotenv parsing (comments, quotes, `export ` prefix, malformed lines)
+  - setdefault precedence: a real env var always beats the file
+  - denylist enforcement (PATH & friends never injected)
+  - missing / unreadable file is a silent no-op
+  - permission tightening to 0600 on load
+  - first-run template creation (and that it never overwrites)
+  - env_file_status diagnostics (names only, override detection)
+
+Every test runs under plain `python3 tests/test_env_file.py` (no pytest
+fixtures) as well as under `pytest`, matching the sibling test convention.
+"""
+
+import os
+import pathlib
+import stat
+import sys
+import tempfile
+
+_SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parents[1] / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import _env_file  # noqa: E402
+
+_TMP = pathlib.Path(tempfile.mkdtemp(prefix="cognee-env-file-test-"))
+
+
+def _fresh(content: str | None, name: str = ".env") -> pathlib.Path:
+    """Point COGNEE_ENV_FILE at a fresh temp file and reset the loader."""
+    path = _TMP / name
+    if path.exists():
+        path.unlink()
+    if content is not None:
+        path.write_text(content, encoding="utf-8")
+    os.environ["COGNEE_ENV_FILE"] = str(path)
+    _env_file._loaded = False
+    return path
+
+
+def test_parse_basic_and_quotes():
+    path = _fresh(
+        "\n".join(
+            [
+                "# a comment",
+                "",
+                "PLAIN=value",
+                'DQ="double quoted"',
+                "SQ='single quoted'",
+                "SPACED =  padded value  ",
+                "export EXPORTED=works",
+                "EMPTY=",
+            ]
+        )
+    )
+    parsed = _env_file.parse_env_file(path)
+    assert parsed["PLAIN"] == "value"
+    assert parsed["DQ"] == "double quoted"
+    assert parsed["SQ"] == "single quoted"
+    assert parsed["SPACED"] == "padded value"
+    assert parsed["EXPORTED"] == "works"
+    assert parsed["EMPTY"] == ""
+
+
+def test_parse_skips_malformed_lines():
+    path = _fresh(
+        "\n".join(
+            [
+                "no_equals_sign_here",
+                "BAD KEY=has space",
+                "=novalue",
+                "GOOD=1",
+                "1NUM=still fine",  # isalnum allows leading digit; shells don't, but harmless
+            ]
+        )
+    )
+    parsed = _env_file.parse_env_file(path)
+    assert "no_equals_sign_here" not in parsed
+    assert "BAD KEY" not in parsed
+    assert "" not in parsed
+    assert parsed["GOOD"] == "1"
+
+
+def test_load_sets_missing_and_respects_existing():
+    _fresh("COGNEE_TEST_FROM_FILE=file-value\nCOGNEE_TEST_EXPORTED=file-value\n")
+    os.environ.pop("COGNEE_TEST_FROM_FILE", None)
+    os.environ["COGNEE_TEST_EXPORTED"] = "shell-value"
+    try:
+        _env_file.load_env_file()
+        assert os.environ.get("COGNEE_TEST_FROM_FILE") == "file-value"
+        assert os.environ.get("COGNEE_TEST_EXPORTED") == "shell-value"
+    finally:
+        os.environ.pop("COGNEE_TEST_FROM_FILE", None)
+        os.environ.pop("COGNEE_TEST_EXPORTED", None)
+
+
+def test_load_is_idempotent_per_process():
+    _fresh("COGNEE_TEST_ONCE=first\n")
+    os.environ.pop("COGNEE_TEST_ONCE", None)
+    try:
+        _env_file.load_env_file()
+        assert os.environ.get("COGNEE_TEST_ONCE") == "first"
+        os.environ.pop("COGNEE_TEST_ONCE", None)
+        # Second call without a reset must not re-read the file.
+        _env_file.load_env_file()
+        assert "COGNEE_TEST_ONCE" not in os.environ
+    finally:
+        os.environ.pop("COGNEE_TEST_ONCE", None)
+
+
+def test_denylist_never_injected():
+    original_path = os.environ.get("PATH", "")
+    _fresh(
+        "PATH=/evil\nLD_PRELOAD=/evil.so\nDYLD_INSERT_LIBRARIES=/evil.dylib\nPYTHONPATH=/evil\nCOGNEE_TEST_OK=1\n"
+    )
+    os.environ.pop("LD_PRELOAD", None)
+    os.environ.pop("DYLD_INSERT_LIBRARIES", None)
+    os.environ.pop("COGNEE_TEST_OK", None)
+    try:
+        _env_file.load_env_file()
+        assert os.environ.get("PATH", "") == original_path
+        assert "LD_PRELOAD" not in os.environ
+        assert "DYLD_INSERT_LIBRARIES" not in os.environ
+        assert os.environ.get("COGNEE_TEST_OK") == "1"
+    finally:
+        os.environ.pop("COGNEE_TEST_OK", None)
+
+
+def test_parse_tolerates_utf8_bom_and_crlf():
+    # Windows PowerShell 5.1 writes UTF-8 with a BOM and CRLF line endings;
+    # the BOM must not glue onto the first key name.
+    path = _fresh(None)
+    path.write_bytes(b'\xef\xbb\xbfCOGNEE_TEST_BOM="first"\r\nCOGNEE_TEST_SECOND=2\r\n')
+    parsed = _env_file.parse_env_file(path)
+    assert parsed["COGNEE_TEST_BOM"] == "first"
+    assert parsed["COGNEE_TEST_SECOND"] == "2"
+
+
+def test_parse_tolerates_utf16():
+    # A PowerShell 5.1 `>` redirect (Out-File) writes UTF-16 LE with a BOM.
+    path = _fresh(None)
+    path.write_text('COGNEE_TEST_U16="wide"\n', encoding="utf-16")
+    parsed = _env_file.parse_env_file(path)
+    assert parsed["COGNEE_TEST_U16"] == "wide"
+
+
+def test_missing_file_is_noop():
+    _fresh(None)
+    _env_file.load_env_file()  # must not raise
+
+
+def test_load_tightens_permissions():
+    if os.name == "nt":
+        return
+    path = _fresh("COGNEE_TEST_PERMS=1\n")
+    path.chmod(0o644)
+    try:
+        _env_file.load_env_file()
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    finally:
+        os.environ.pop("COGNEE_TEST_PERMS", None)
+
+
+def test_env_file_path_override_and_default():
+    override = _fresh("A=1\n")
+    assert _env_file.env_file_path() == override
+    os.environ.pop("COGNEE_ENV_FILE", None)
+    assert _env_file.env_file_path() == pathlib.Path.home() / ".cognee" / ".env"
+
+
+def test_template_not_written_when_override_set():
+    _fresh(None)
+    assert _env_file.ensure_env_file_template() is False
+
+
+def test_template_never_overwrites():
+    # Redirect the default location into the temp dir for this test.
+    os.environ.pop("COGNEE_ENV_FILE", None)
+    orig_home, orig_default = _env_file._COGNEE_HOME, _env_file._DEFAULT_ENV_FILE
+    _env_file._COGNEE_HOME = _TMP / "cognee-home"
+    _env_file._DEFAULT_ENV_FILE = _env_file._COGNEE_HOME / ".env"
+    try:
+        assert _env_file.ensure_env_file_template() is True
+        text = _env_file._DEFAULT_ENV_FILE.read_text(encoding="utf-8")
+        assert "COGNEE_BASE_URL" in text
+        assert all(line.startswith("#") or not line for line in text.splitlines())
+        if os.name != "nt":
+            assert stat.S_IMODE(_env_file._DEFAULT_ENV_FILE.stat().st_mode) == 0o600
+        _env_file._DEFAULT_ENV_FILE.write_text("USER_EDIT=kept\n", encoding="utf-8")
+        assert _env_file.ensure_env_file_template() is False
+        assert _env_file._DEFAULT_ENV_FILE.read_text(encoding="utf-8") == "USER_EDIT=kept\n"
+    finally:
+        _env_file._COGNEE_HOME = orig_home
+        _env_file._DEFAULT_ENV_FILE = orig_default
+
+
+def test_status_reports_names_not_values():
+    _fresh("COGNEE_TEST_SECRET=super-secret\nPATH=/evil\nCOGNEE_TEST_SHADOWED=file-value\n")
+    os.environ["COGNEE_TEST_SHADOWED"] = "shell-value"
+    os.environ.pop("COGNEE_TEST_SECRET", None)
+    try:
+        _env_file.load_env_file()
+        status = _env_file.env_file_status()
+        assert status["exists"] is True
+        assert "COGNEE_TEST_SECRET" in status["keys"]
+        assert "super-secret" not in str(status)
+        assert status["blocked"] == ["PATH"]
+        assert status["overridden"] == ["COGNEE_TEST_SHADOWED"]
+    finally:
+        os.environ.pop("COGNEE_TEST_SECRET", None)
+        os.environ.pop("COGNEE_TEST_SHADOWED", None)
+
+
+def test_status_missing_file():
+    path = _fresh(None)
+    status = _env_file.env_file_status()
+    assert status == {"path": str(path), "exists": False}
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if not _name.startswith("test_") or not callable(_fn):
+            continue
+        try:
+            _fn()
+            print(f"PASS {_name}")
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL {_name}: {e}")
+    sys.exit(1 if failures else 0)

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -30,13 +30,17 @@ codex plugin marketplace add topoteretes/cognee-integrations --ref main
 codex plugin add cognee@cognee
 ```
 
-Then set environment variables for your runtime mode.
+Then configure your runtime mode — **once** — in `~/.cognee/.env`. The file is created with a commented template on the first session start; values in it act exactly like shell exports (a real `export` in your shell still overrides the file, per terminal). It is shared with the Claude Code plugin, so both read the same configuration. Lines may optionally start with `export `, so existing export lines can be pasted verbatim.
 
-**Cognee Cloud or a remote server** — set both:
+**Cognee Cloud or a remote server** — set both (one paste, no editor needed):
 
 ```bash
-export COGNEE_BASE_URL="https://your-instance.cognee.ai"
-export COGNEE_API_KEY="ck_..."
+mkdir -p ~/.cognee
+cat >> ~/.cognee/.env <<'EOF'
+COGNEE_BASE_URL="https://your-instance.cognee.ai"
+COGNEE_API_KEY="ck_..."
+EOF
+chmod 600 ~/.cognee/.env
 ```
 
 > Cloud mode is a pure thin client: it talks to your remote server over HTTP only and does **not** install a local Cognee runtime. The bundled virtualenv (`~/.cognee-plugin/venv`) is built only in local mode, where an in-process server actually runs.
@@ -44,8 +48,24 @@ export COGNEE_API_KEY="ck_..."
 **Local mode** (default when `COGNEE_BASE_URL` is not set) — the plugin bootstraps a local Cognee API at `http://localhost:8011`. Only `LLM_API_KEY` is required; `COGNEE_API_KEY` is auto-minted if absent:
 
 ```bash
-export LLM_API_KEY="sk-..."
+mkdir -p ~/.cognee
+cat >> ~/.cognee/.env <<'EOF'
+LLM_API_KEY="sk-..."
+EOF
+chmod 600 ~/.cognee/.env
 ```
+
+**Windows (PowerShell)** — same idea, same file:
+
+```powershell
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.cognee" | Out-Null
+@'
+COGNEE_BASE_URL="https://your-instance.cognee.ai"
+COGNEE_API_KEY="ck_..."
+'@ | Add-Content "$env:USERPROFILE\.cognee\.env"
+```
+
+Re-running any of these blocks is safe: when a key appears more than once, the **last value wins**, so pasting again with a new value updates the configuration. Editing the file directly (`nano ~/.cognee/.env`) works too — e.g. to remove a variable such as `COGNEE_BASE_URL` when switching from cloud back to local mode. Changes apply on the next session launch. Plain shell `export`s in the launching terminal still take precedence over `~/.cognee/.env` — useful to override the shared config for one terminal.
 
 You can also set config in `~/.cognee-plugin/config.json`:
 
@@ -275,9 +295,12 @@ codex plugin marketplace remove cognee
 ## Configuration reference
 
 Config precedence:
-1. env vars
-2. `~/.cognee-plugin/config.json`
-3. defaults
+1. env vars (shell exports)
+2. `~/.cognee/.env` (one-time setup file, shared with the Claude Code plugin; loaded into the environment at process start, so every env var below can live here)
+3. `~/.cognee-plugin/config.json`
+4. defaults
+
+`~/.cognee/.env` is created with a commented template on first session start (permissions `0600`; the path can be overridden with `COGNEE_ENV_FILE`). Run `doctor.py` to see which keys the file defines and which are overridden by shell exports.
 
 | Key | Env var(s) | Default | Notes |
 |---|---|---|---|

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,6 +10,24 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.0]
+
+### Added
+- **One-time configuration via `~/.cognee/.env`.** API keys and URLs
+  (`COGNEE_BASE_URL`, `COGNEE_API_KEY`, `LLM_API_KEY`, and every other env var the
+  plugin reads) no longer need to be exported in each shell: values placed in
+  `~/.cognee/.env` — the durable cognee home shared with the Claude Code plugin —
+  are injected into the environment at process start with setdefault semantics, so
+  a real shell export still wins per terminal, and spawned processes (local
+  server, watchers) inherit them unchanged. The file accepts pasted
+  `export KEY=value` lines, is created with a commented template (mode `0600`) on
+  first session start, and its location can be overridden with `COGNEE_ENV_FILE`.
+  `doctor.py` gained an **Env File** row showing which keys the file defines
+  (names only, never values) and which are overridden by shell exports. The
+  parser tolerates Windows-written files: a UTF-8 BOM (PowerShell 5.1) is
+  stripped, UTF-16 (a PS5 `>` redirect) is decoded, and CRLF line endings are
+  handled — so copy/paste setup blocks work from any shell.
+
 ## [1.2.1]
 
 ### Fixed

--- a/integrations/codex/plugins/cognee/scripts/_cognee_client.py
+++ b/integrations/codex/plugins/cognee/scripts/_cognee_client.py
@@ -21,7 +21,11 @@ import pathlib
 import sys
 import time
 
+from _env_file import load_env_file
 from _recall_http import UNREACHABLE, _error, do_recall
+
+# ~/.cognee/.env must land in os.environ before the module-level reads below.
+load_env_file()
 
 # Tunables (mirror Hermes's provider defaults).
 _THRESHOLD = int(os.environ.get("COGNEE_BREAKER_THRESHOLD", "5"))

--- a/integrations/codex/plugins/cognee/scripts/_env_file.py
+++ b/integrations/codex/plugins/cognee/scripts/_env_file.py
@@ -1,0 +1,196 @@
+"""One-time plugin configuration via ~/.cognee/.env.
+
+Users historically had to `export COGNEE_BASE_URL=...`, `export LLM_API_KEY=...`
+in every shell. This module makes that a one-time step: values placed in
+``~/.cognee/.env`` (the durable, venv-rebuild-safe cognee home shared by the
+Claude Code and Codex plugins) are injected into ``os.environ`` at process
+start with **setdefault** semantics, so:
+
+  real exported env vars  >  ~/.cognee/.env  >  config.json  >  defaults
+
+Every existing ``os.environ.get(...)`` call site — and every child process the
+hooks spawn (the local cognee server, idle/exit watchers) — picks the values up
+unchanged.
+
+Deliberately stdlib-only: hook scripts must run outside the plugin venv on the
+cloud path, so python-dotenv is not an option. The parser accepts a leading
+``export `` so users can paste their existing shell export lines verbatim.
+
+Loading must never break a hook: any parse or IO problem results in the file
+being (partially) ignored, never an exception.
+"""
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+_COGNEE_HOME = Path.home() / ".cognee"
+_DEFAULT_ENV_FILE = _COGNEE_HOME / ".env"
+
+# Vars that could hijack process behavior if injected from a config file.
+# Everything else (COGNEE_*, LLM_*, EMBEDDING_*, provider keys, ...) is allowed
+# so the values also flow through to the spawned local cognee server.
+_DENYLIST_EXACT = {"PATH", "HOME", "PYTHONPATH", "PYTHONHOME", "SHELL", "USER"}
+_DENYLIST_PREFIXES = ("LD_", "DYLD_")
+
+_TEMPLATE = """\
+# Cognee plugin configuration — shared by the Claude Code and Codex plugins.
+# Values here are loaded at session start and act like shell exports, except
+# you only set them once. A real `export` in your shell still wins over this
+# file. Lines starting with `#` are comments; a leading `export ` is allowed.
+
+## Cloud / remote mode — point the plugins at a Cognee instance:
+# COGNEE_BASE_URL="https://your-instance.cognee.ai"
+# COGNEE_API_KEY="ck_..."
+
+## Local mode (default when COGNEE_BASE_URL is unset) — the plugin runs a
+## local Cognee API; only an LLM key is required:
+# LLM_API_KEY="sk-..."
+# LLM_MODEL="openai/gpt-4o-mini"
+
+## Optional:
+# COGNEE_PLUGIN_DATASET="agent_sessions"
+"""
+
+
+def env_file_path() -> Path:
+    """The env file location (COGNEE_ENV_FILE overrides the default)."""
+    override = os.environ.get("COGNEE_ENV_FILE", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return _DEFAULT_ENV_FILE
+
+
+def _unquote(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
+def _blocked(key: str) -> bool:
+    return key in _DENYLIST_EXACT or key.startswith(_DENYLIST_PREFIXES)
+
+
+def parse_env_file(path: Path) -> dict:
+    """Parse a dotenv-style file into a dict. Malformed lines are skipped.
+
+    Supported: ``KEY=VALUE``, blank lines, ``#`` comments, an optional leading
+    ``export ``, and single/double quotes around the value. No interpolation,
+    no multi-line values.
+    """
+    result: dict[str, str] = {}
+    try:
+        # utf-8-sig strips a UTF-8 BOM when present (Windows PowerShell 5.1
+        # writes one) and is a no-op otherwise. A PS5 `>` redirect produces
+        # UTF-16 instead — retry with that before giving up.
+        try:
+            text = path.read_text(encoding="utf-8-sig")
+        except UnicodeDecodeError:
+            text = path.read_text(encoding="utf-16")
+    except Exception:
+        return result
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not key or not all(c.isalnum() or c == "_" for c in key):
+            continue
+        result[key] = _unquote(value)
+    return result
+
+
+_loaded = False
+
+
+def load_env_file() -> None:
+    """Inject env-file values into os.environ (setdefault). Never raises.
+
+    Idempotent per process: repeated calls (this module is imported from
+    several entry-point modules) parse the file at most once.
+    """
+    global _loaded
+    if _loaded:
+        return
+    _loaded = True
+
+    try:
+        path = env_file_path()
+        if not path.is_file():
+            return
+        _tighten_permissions(path)
+        for key, value in parse_env_file(path).items():
+            if _blocked(key):
+                continue
+            os.environ.setdefault(key, value)
+    except Exception:
+        pass
+
+
+def _tighten_permissions(path: Path) -> None:
+    """Best-effort chmod 0600: the file may hold API keys."""
+    if os.name == "nt":
+        return
+    try:
+        mode = stat.S_IMODE(path.stat().st_mode)
+        if mode & 0o077:
+            path.chmod(0o600)
+    except Exception:
+        pass
+
+
+def ensure_env_file_template() -> bool:
+    """Write a commented template to ~/.cognee/.env if no file exists yet.
+
+    Returns True when the template was created. Called from SessionStart so
+    users find a documented file to fill in instead of an empty folder. Only
+    the default location gets a template — an explicit COGNEE_ENV_FILE
+    pointing elsewhere is the user's own file to manage.
+    """
+    if os.environ.get("COGNEE_ENV_FILE", "").strip():
+        return False
+    try:
+        if _DEFAULT_ENV_FILE.exists():
+            return False
+        _COGNEE_HOME.mkdir(parents=True, exist_ok=True)
+        _DEFAULT_ENV_FILE.write_text(_TEMPLATE, encoding="utf-8")
+        if os.name != "nt":
+            _DEFAULT_ENV_FILE.chmod(0o600)
+        return True
+    except Exception:
+        return False
+
+
+def env_file_status() -> dict:
+    """Diagnostics for doctor: existence, perms, and key *names* (no values)."""
+    path = env_file_path()
+    info: dict = {"path": str(path), "exists": path.is_file()}
+    if not info["exists"]:
+        return info
+    try:
+        info["mode"] = oct(stat.S_IMODE(path.stat().st_mode))
+    except Exception:
+        pass
+    values = parse_env_file(path)
+    info["keys"] = sorted(values)
+    info["blocked"] = sorted(k for k in values if _blocked(k))
+    # A shell export (or another source) that set a different value wins over
+    # the file; surface those so mode-selection surprises are debuggable.
+    info["overridden"] = sorted(
+        k for k in values if not _blocked(k) and os.environ.get(k, values[k]) != values[k]
+    )
+    return info
+
+
+if __name__ == "__main__":
+    import json
+
+    load_env_file()
+    json.dump(env_file_status(), sys.stdout, indent=2)
+    print()

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -23,6 +23,11 @@ from pathlib import Path
 from typing import Optional
 
 import _proc
+from _env_file import load_env_file
+
+# One-time config: ~/.cognee/.env acts like shell exports (setdefault — a real
+# export still wins). Loaded before any env read below or in importers.
+load_env_file()
 
 _PLUGIN_DIR = Path.home() / ".cognee-plugin" / "codex"
 _SHARED_PLUGIN_ROOT = Path.home() / ".cognee-plugin"

--- a/integrations/codex/plugins/cognee/scripts/cognee-remember.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-remember.sh
@@ -16,13 +16,21 @@
 set -euo pipefail
 
 PLUGIN_DIR="${HOME}/.cognee-plugin/codex"
-runtime_json="$(python3 - <<'PY' "${PLUGIN_DIR}" 2>/dev/null || true
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+runtime_json="$(python3 - <<'PY' "${PLUGIN_DIR}" "${SELF_DIR}" 2>/dev/null || true
 import json
 import pathlib
 import sys
 
 plugin_dir = pathlib.Path(sys.argv[1])
 import os
+# One-time config from ~/.cognee/.env (shell exports still win).
+sys.path.insert(0, sys.argv[2])
+try:
+    from _env_file import load_env_file
+    load_env_file()
+except Exception:
+    pass
 service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
 api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
 
@@ -103,7 +111,6 @@ fi
 # Server-first: POST to /api/v1/remember via _remember_http.py.
 # UNREACHABLE → fall back to cognee-cli and warn.
 # Any other result (ok or error) → authoritative; do not fall back.
-SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
 RESULT="$(python3 "${SELF_DIR}/_remember_http.py" "$SERVICE_URL" "$API_KEY" "$CONTENT" "$DATASET" "$NODE_SET" || true)"
 
 if [ -n "$RESULT" ] && [ "$RESULT" != "UNREACHABLE" ]; then

--- a/integrations/codex/plugins/cognee/scripts/cognee-search.sh
+++ b/integrations/codex/plugins/cognee/scripts/cognee-search.sh
@@ -15,7 +15,8 @@
 set -euo pipefail
 
 PLUGIN_DIR="${HOME}/.cognee-plugin/codex"
-runtime_json="$(python3 - <<'PY' "${PLUGIN_DIR}" 2>/dev/null || true
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+runtime_json="$(python3 - <<'PY' "${PLUGIN_DIR}" "${SELF_DIR}" 2>/dev/null || true
 import json
 import pathlib
 import sys
@@ -25,6 +26,13 @@ import urllib.request
 
 plugin_dir = pathlib.Path(sys.argv[1])
 import os
+# One-time config from ~/.cognee/.env (shell exports still win).
+sys.path.insert(0, sys.argv[2])
+try:
+    from _env_file import load_env_file
+    load_env_file()
+except Exception:
+    pass
 service_url = (os.environ.get("COGNEE_BASE_URL") or os.environ.get("COGNEE_LOCAL_API_URL") or "http://localhost:8011").strip()
 api_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
 if not api_key:
@@ -147,7 +155,6 @@ esac
 # $DATASET is resolved above (COGNEE_PLUGIN_DATASET → default)
 # and scopes the search to the plugin's dataset so unrelated datasets don't bleed in.
 # Logic lives in _recall_http.py (stdlib-only, unit-tested); stderr is surfaced.
-SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
 export COGNEE_PLUGIN_STATE_DIR="$PLUGIN_DIR"
 RECALL_JSON="$(python3 "${SELF_DIR}/_cognee_client.py" "$SERVICE_URL" "$API_KEY" "$QUERY" "$SESSION_ID" "$SCOPE" "$TOP_K" "$DATASET" || true)"
 

--- a/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
@@ -16,6 +16,12 @@ import time
 from pathlib import Path
 from urllib.parse import urlparse
 
+from _env_file import load_env_file
+
+# ~/.cognee/.env is pure-local too, so loading it here keeps the renderer's
+# no-network/no-_plugin_common contract while honoring one-time config.
+load_env_file()
+
 _SHARED_ROOT = Path.home() / ".cognee-plugin"
 _CONFIG_PATH = _SHARED_ROOT / "config.json"
 _SERVER_READY_PATH = _SHARED_ROOT / "server-ready.json"

--- a/integrations/codex/plugins/cognee/scripts/config.py
+++ b/integrations/codex/plugins/cognee/scripts/config.py
@@ -2,8 +2,10 @@
 
 Loads settings from (in priority order):
   1. Environment variables (runtime overrides)
-  2. Config file (~/.cognee-plugin/config.json)
-  3. Defaults
+  2. Env file (~/.cognee/.env — one-time setup, injected into os.environ
+     with setdefault, so it sits just below real shell exports)
+  3. Config file (~/.cognee-plugin/config.json)
+  4. Defaults
 
 Config file is created on first SessionStart if it doesn't exist.
 
@@ -20,6 +22,12 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import Optional
+
+from _env_file import load_env_file
+
+# Must run before the _ENV_MAP scan in load_config() and before any importer's
+# module-level os.environ reads.
+load_env_file()
 
 _CONFIG_DIR = Path.home() / ".cognee-plugin"
 _STATE_DIR = _CONFIG_DIR / "codex"

--- a/integrations/codex/plugins/cognee/scripts/doctor.py
+++ b/integrations/codex/plugins/cognee/scripts/doctor.py
@@ -108,6 +108,13 @@ def _resolve_api_key_source() -> str:
     """
     env_key = (os.environ.get("COGNEE_API_KEY") or "").strip()
     if env_key:
+        # The env layer is fed by both real exports and ~/.cognee/.env
+        # (setdefault); tell them apart for debuggability.
+        from _env_file import env_file_path, parse_env_file
+
+        file_key = parse_env_file(env_file_path()).get("COGNEE_API_KEY", "")
+        if file_key and file_key == env_key:
+            return "Env file"
         return "ENV"
 
     # Check the single cached key file.
@@ -183,6 +190,26 @@ def _resolve_embedding() -> tuple[str, str]:
     return model, dims
 
 
+def _resolve_env_file() -> str:
+    """One-time config file (~/.cognee/.env): presence, key names, overrides.
+
+    Values are never shown — only which keys the file defines, and which of
+    them are shadowed by a real shell export (exports win over the file).
+    """
+    from _env_file import env_file_status
+
+    status = env_file_status()
+    path = status.get("path", "")
+    if not status.get("exists"):
+        return f"Not found ({path})"
+    keys = status.get("keys") or []
+    desc = f"{path} ({len(keys)} key{'s' if len(keys) != 1 else ''}: {', '.join(keys)})"
+    overridden = status.get("overridden") or []
+    if overridden:
+        desc += f" — overridden by shell env: {', '.join(overridden)}"
+    return desc
+
+
 def collect_report() -> dict:
     """Gather all diagnostic fields into an ordered dict."""
     mode = _resolve_mode()
@@ -196,6 +223,7 @@ def collect_report() -> dict:
 
     return {
         "mode": mode,
+        "env_file": _resolve_env_file(),
         "server_url": display_url if display_url != "-" else None,
         "api_key_source": api_key_source,
         "reachable": health["reachable"],
@@ -210,6 +238,7 @@ def collect_report() -> dict:
 
 _DISPLAY_ORDER = [
     ("Mode", "mode"),
+    ("Env File", "env_file"),
     ("Server URL", "server_url"),
     ("API Key Source", "api_key_source"),
     ("Reachable", "reachable"),

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -1297,6 +1297,14 @@ def _update_nudge_suffix() -> str:
 
 
 def main():
+    # First run: leave a commented ~/.cognee/.env template so one-time config
+    # has a documented file to land in. Values (if any) were already loaded
+    # into os.environ when _plugin_common was imported.
+    from _env_file import ensure_env_file_template, env_file_path
+
+    if ensure_env_file_template():
+        hook_log("env_file_template_created", {"path": str(env_file_path())})
+
     # Detached bootstrap mode: run the slow server boot + registration out of
     # band so the SessionStart hook itself returns fast.
     if _BOOTSTRAP_ARG in sys.argv:

--- a/integrations/codex/plugins/cognee/skills/setup/SKILL.md
+++ b/integrations/codex/plugins/cognee/skills/setup/SKILL.md
@@ -51,6 +51,12 @@ uv run cognee-cli serve --url http://localhost:8000
 For a hosted instance with an API key, do not paste the key into the transcript.
 Use an environment variable or an already configured credential.
 
+For the plugin itself, durable configuration (`COGNEE_BASE_URL`,
+`COGNEE_API_KEY`, `LLM_API_KEY`, ...) belongs in `~/.cognee/.env` — a one-time
+setup file shared with the Claude Code plugin, loaded at session start. Shell
+exports still override it per terminal. Guide the user to edit that file
+rather than exporting in every shell; never echo its secret values.
+
 To disconnect:
 
 ```bash

--- a/integrations/codex/plugins/cognee/tests/test_doctor.py
+++ b/integrations/codex/plugins/cognee/tests/test_doctor.py
@@ -256,6 +256,7 @@ def test_json_output():
     parsed = json.loads(doctor.format_json(report))
     expected = {
         "mode",
+        "env_file",
         "server_url",
         "api_key_source",
         "reachable",

--- a/integrations/codex/plugins/cognee/tests/test_env_file.py
+++ b/integrations/codex/plugins/cognee/tests/test_env_file.py
@@ -1,0 +1,233 @@
+"""Unit tests for _env_file (one-time config via ~/.cognee/.env).
+
+Covers:
+  - dotenv parsing (comments, quotes, `export ` prefix, malformed lines)
+  - setdefault precedence: a real env var always beats the file
+  - denylist enforcement (PATH & friends never injected)
+  - missing / unreadable file is a silent no-op
+  - permission tightening to 0600 on load
+  - first-run template creation (and that it never overwrites)
+  - env_file_status diagnostics (names only, override detection)
+
+Every test runs under plain `python3 tests/test_env_file.py` (no pytest
+fixtures) as well as under `pytest`, matching the sibling test convention.
+"""
+
+import os
+import pathlib
+import stat
+import sys
+import tempfile
+
+_SCRIPTS_DIR = str(pathlib.Path(__file__).resolve().parents[1] / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import _env_file  # noqa: E402
+
+_TMP = pathlib.Path(tempfile.mkdtemp(prefix="cognee-env-file-test-"))
+
+
+def _fresh(content: str | None, name: str = ".env") -> pathlib.Path:
+    """Point COGNEE_ENV_FILE at a fresh temp file and reset the loader."""
+    path = _TMP / name
+    if path.exists():
+        path.unlink()
+    if content is not None:
+        path.write_text(content, encoding="utf-8")
+    os.environ["COGNEE_ENV_FILE"] = str(path)
+    _env_file._loaded = False
+    return path
+
+
+def test_parse_basic_and_quotes():
+    path = _fresh(
+        "\n".join(
+            [
+                "# a comment",
+                "",
+                "PLAIN=value",
+                'DQ="double quoted"',
+                "SQ='single quoted'",
+                "SPACED =  padded value  ",
+                "export EXPORTED=works",
+                "EMPTY=",
+            ]
+        )
+    )
+    parsed = _env_file.parse_env_file(path)
+    assert parsed["PLAIN"] == "value"
+    assert parsed["DQ"] == "double quoted"
+    assert parsed["SQ"] == "single quoted"
+    assert parsed["SPACED"] == "padded value"
+    assert parsed["EXPORTED"] == "works"
+    assert parsed["EMPTY"] == ""
+
+
+def test_parse_skips_malformed_lines():
+    path = _fresh(
+        "\n".join(
+            [
+                "no_equals_sign_here",
+                "BAD KEY=has space",
+                "=novalue",
+                "GOOD=1",
+                "1NUM=still fine",  # isalnum allows leading digit; shells don't, but harmless
+            ]
+        )
+    )
+    parsed = _env_file.parse_env_file(path)
+    assert "no_equals_sign_here" not in parsed
+    assert "BAD KEY" not in parsed
+    assert "" not in parsed
+    assert parsed["GOOD"] == "1"
+
+
+def test_load_sets_missing_and_respects_existing():
+    _fresh("COGNEE_TEST_FROM_FILE=file-value\nCOGNEE_TEST_EXPORTED=file-value\n")
+    os.environ.pop("COGNEE_TEST_FROM_FILE", None)
+    os.environ["COGNEE_TEST_EXPORTED"] = "shell-value"
+    try:
+        _env_file.load_env_file()
+        assert os.environ.get("COGNEE_TEST_FROM_FILE") == "file-value"
+        assert os.environ.get("COGNEE_TEST_EXPORTED") == "shell-value"
+    finally:
+        os.environ.pop("COGNEE_TEST_FROM_FILE", None)
+        os.environ.pop("COGNEE_TEST_EXPORTED", None)
+
+
+def test_load_is_idempotent_per_process():
+    _fresh("COGNEE_TEST_ONCE=first\n")
+    os.environ.pop("COGNEE_TEST_ONCE", None)
+    try:
+        _env_file.load_env_file()
+        assert os.environ.get("COGNEE_TEST_ONCE") == "first"
+        os.environ.pop("COGNEE_TEST_ONCE", None)
+        # Second call without a reset must not re-read the file.
+        _env_file.load_env_file()
+        assert "COGNEE_TEST_ONCE" not in os.environ
+    finally:
+        os.environ.pop("COGNEE_TEST_ONCE", None)
+
+
+def test_denylist_never_injected():
+    original_path = os.environ.get("PATH", "")
+    _fresh(
+        "PATH=/evil\nLD_PRELOAD=/evil.so\nDYLD_INSERT_LIBRARIES=/evil.dylib\nPYTHONPATH=/evil\nCOGNEE_TEST_OK=1\n"
+    )
+    os.environ.pop("LD_PRELOAD", None)
+    os.environ.pop("DYLD_INSERT_LIBRARIES", None)
+    os.environ.pop("COGNEE_TEST_OK", None)
+    try:
+        _env_file.load_env_file()
+        assert os.environ.get("PATH", "") == original_path
+        assert "LD_PRELOAD" not in os.environ
+        assert "DYLD_INSERT_LIBRARIES" not in os.environ
+        assert os.environ.get("COGNEE_TEST_OK") == "1"
+    finally:
+        os.environ.pop("COGNEE_TEST_OK", None)
+
+
+def test_parse_tolerates_utf8_bom_and_crlf():
+    # Windows PowerShell 5.1 writes UTF-8 with a BOM and CRLF line endings;
+    # the BOM must not glue onto the first key name.
+    path = _fresh(None)
+    path.write_bytes(b'\xef\xbb\xbfCOGNEE_TEST_BOM="first"\r\nCOGNEE_TEST_SECOND=2\r\n')
+    parsed = _env_file.parse_env_file(path)
+    assert parsed["COGNEE_TEST_BOM"] == "first"
+    assert parsed["COGNEE_TEST_SECOND"] == "2"
+
+
+def test_parse_tolerates_utf16():
+    # A PowerShell 5.1 `>` redirect (Out-File) writes UTF-16 LE with a BOM.
+    path = _fresh(None)
+    path.write_text('COGNEE_TEST_U16="wide"\n', encoding="utf-16")
+    parsed = _env_file.parse_env_file(path)
+    assert parsed["COGNEE_TEST_U16"] == "wide"
+
+
+def test_missing_file_is_noop():
+    _fresh(None)
+    _env_file.load_env_file()  # must not raise
+
+
+def test_load_tightens_permissions():
+    if os.name == "nt":
+        return
+    path = _fresh("COGNEE_TEST_PERMS=1\n")
+    path.chmod(0o644)
+    try:
+        _env_file.load_env_file()
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    finally:
+        os.environ.pop("COGNEE_TEST_PERMS", None)
+
+
+def test_env_file_path_override_and_default():
+    override = _fresh("A=1\n")
+    assert _env_file.env_file_path() == override
+    os.environ.pop("COGNEE_ENV_FILE", None)
+    assert _env_file.env_file_path() == pathlib.Path.home() / ".cognee" / ".env"
+
+
+def test_template_not_written_when_override_set():
+    _fresh(None)
+    assert _env_file.ensure_env_file_template() is False
+
+
+def test_template_never_overwrites():
+    # Redirect the default location into the temp dir for this test.
+    os.environ.pop("COGNEE_ENV_FILE", None)
+    orig_home, orig_default = _env_file._COGNEE_HOME, _env_file._DEFAULT_ENV_FILE
+    _env_file._COGNEE_HOME = _TMP / "cognee-home"
+    _env_file._DEFAULT_ENV_FILE = _env_file._COGNEE_HOME / ".env"
+    try:
+        assert _env_file.ensure_env_file_template() is True
+        text = _env_file._DEFAULT_ENV_FILE.read_text(encoding="utf-8")
+        assert "COGNEE_BASE_URL" in text
+        assert all(line.startswith("#") or not line for line in text.splitlines())
+        if os.name != "nt":
+            assert stat.S_IMODE(_env_file._DEFAULT_ENV_FILE.stat().st_mode) == 0o600
+        _env_file._DEFAULT_ENV_FILE.write_text("USER_EDIT=kept\n", encoding="utf-8")
+        assert _env_file.ensure_env_file_template() is False
+        assert _env_file._DEFAULT_ENV_FILE.read_text(encoding="utf-8") == "USER_EDIT=kept\n"
+    finally:
+        _env_file._COGNEE_HOME = orig_home
+        _env_file._DEFAULT_ENV_FILE = orig_default
+
+
+def test_status_reports_names_not_values():
+    _fresh("COGNEE_TEST_SECRET=super-secret\nPATH=/evil\nCOGNEE_TEST_SHADOWED=file-value\n")
+    os.environ["COGNEE_TEST_SHADOWED"] = "shell-value"
+    os.environ.pop("COGNEE_TEST_SECRET", None)
+    try:
+        _env_file.load_env_file()
+        status = _env_file.env_file_status()
+        assert status["exists"] is True
+        assert "COGNEE_TEST_SECRET" in status["keys"]
+        assert "super-secret" not in str(status)
+        assert status["blocked"] == ["PATH"]
+        assert status["overridden"] == ["COGNEE_TEST_SHADOWED"]
+    finally:
+        os.environ.pop("COGNEE_TEST_SECRET", None)
+        os.environ.pop("COGNEE_TEST_SHADOWED", None)
+
+
+def test_status_missing_file():
+    path = _fresh(None)
+    status = _env_file.env_file_status()
+    assert status == {"path": str(path), "exists": False}
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if not _name.startswith("test_") or not callable(_fn):
+            continue
+        try:
+            _fn()
+            print(f"PASS {_name}")
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL {_name}: {e}")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
This PR adds an env file which contains all env vars for customizing the cognee plugin in Claude and Codex.
The user appends variable definitions, in case of duplicates, the newest variable value is taken into account.
Exporting a variable in the terminal takes precedence over the env file.
User can also edit the file manually if they want.