### PR TITLE
fix: fix recall hybrid completion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Cognee"
       },

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Cognee"
   },

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,6 +10,38 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.1]
+
+### Fixed
+- **One graph search per prompt, not two.** The per-prompt recall hook queried
+  both `graph_context` and `graph` as separate scopes — a design from when
+  `graph_context` was a cheap lookup of the distilled `improve()` snapshot. On
+  cognee ≥ 1.4 the server aliases `graph_context` to `graph` (with a deprecation
+  warning), so the pair silently ran the *same* full graph retrieval twice per
+  prompt: once auto-routed to GRAPH_COMPLETION, once as the explicit
+  HYBRID_COMPLETION. The two scopes are now folded into a single `graph` scope
+  using HYBRID_COMPLETION, halving the most expensive part of every recall and
+  removing the server-side deprecation warning. Results from the `graph` scope
+  are still bucketed under the historical `graph_context` label, so the status
+  line counters, `last_recall.json`, and the `g` count render unchanged.
+- **Recall scopes run cheap-first, so agent guidance is never starved.** The
+  scope order was session → trace → graph_context → graph → session_context;
+  with both graph searches routinely consuming their full 2.5s timeout, the
+  4-second recall budget was exhausted before `session_context` — standing agent
+  guidance, ~50ms when it runs — ever fired, and it was silently skipped on
+  every degraded prompt. The order is now session → trace → session_context →
+  graph, so the only call that can eat a whole timeout runs last, against
+  whatever budget remains.
+- **Per-scope timeouts are clamped to the remaining recall budget.** The budget
+  deadline was only checked *between* scopes, so a scope dispatched just before
+  it could run a full `COGNEE_RECALL_TIMEOUT` past it — two slow scopes pushed a
+  "4-second" recall to 5–7s of keystroke-to-answer latency, mathematically
+  guaranteeing a `recall_budget_exceeded` event. Each call now gets
+  `min(recall_timeout, budget remaining)`, and a scope with less than 0.2s of
+  budget left is skipped outright instead of being dispatched with a doomed
+  deadline. The budget is a hard ceiling now; `recall_budget_exceeded` only
+  fires when the budget was genuinely spent on useful work.
+
 ## [1.2.0]
 
 ### Added

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Search session + trace + graph-context for context relevant to the user's prompt.
+"""Search session + trace + agent guidance + graph for context relevant to the user's prompt.
 
-Runs on the Codex UserPromptSubmit hook. Calls ``cognee.recall`` with
-``scope=["session","trace","graph_context"]`` so every layer the
-SessionManager holds (QA entries, agent trace steps, and the distilled
-graph-knowledge snapshot from ``improve()``) flows back into Codex's
-context.
+Runs on the Codex UserPromptSubmit hook. Calls ``cognee.recall`` once per
+scope (``session``, ``trace``, ``session_context``, ``graph``) so every
+layer the SessionManager holds (QA entries, agent trace steps, standing
+agent guidance, and the graph knowledge built by ``improve()``) flows back
+into Codex's context.
 
 Configuration:
     Resolves session state via Cognee HTTP endpoints.
@@ -58,6 +58,9 @@ TRUNCATE_ANSWER = 500
 TRUNCATE_RETURN = 400
 TRUNCATE_GRAPH_CTX = 1500
 RECENT_TRACE_FALLBACK_TOP_K = 5
+# Smallest per-scope timeout worth dispatching; with less budget than this
+# left, remaining scopes are skipped rather than fired with a doomed deadline.
+MIN_SCOPE_TIMEOUT = 0.2
 
 
 def _load_session_id() -> str:
@@ -244,12 +247,19 @@ async def _run(prompt: str) -> dict | None:
     # others. cognee.recall loops over scopes and re-raises on the first failure,
     # so we call it once per scope and collect whatever succeeds.
     results: list = []
+    # Cheap scopes first (tens of ms each), the graph search last: it is the
+    # only call that can consume a full per-call timeout, and running it
+    # earlier starved session_context out of the budget entirely. A single
+    # graph scope on purpose: the server (cognee >= 1.4) aliases the old
+    # graph_context scope to graph, so a graph_context + graph pair ran the
+    # same full graph retrieval twice per prompt. HYBRID_COMPLETION combines
+    # BM25 + vector + graph retrieval (with only_context=True the LLM
+    # completion is skipped server-side either way).
     scope_specs = [
         (["session"], None, None),
         (["trace"], None, None),
-        (["graph_context"], None, None),
-        (["graph"], "HYBRID_COMPLETION", None),
         (["session_context"], None, "agent"),
+        (["graph"], "HYBRID_COMPLETION", None),
     ]
     if not cloud_mode:
         import cognee
@@ -258,7 +268,7 @@ async def _run(prompt: str) -> dict | None:
         user = await resolve_user(_load_user_id())
 
     # Per-scope instrumentation (WS7 observability): capture {hits, elapsed_ms}
-    # for every scope, keyed by its stable label. Pre-seed all 5 scopes as
+    # for every scope, keyed by its stable label. Pre-seed all scopes as
     # skipped, in canonical order and before the breaker-open branch below can
     # blank scope_specs, so the event always carries the full set; the loop
     # overwrites each scope that actually runs. Purely additive: it must not
@@ -289,9 +299,16 @@ async def _run(prompt: str) -> dict | None:
             hook_log("recall_breaker_open", {"retry_in": _bretry})
             scope_specs = []
     for scope_list, qtype, context_profile in scope_specs:
-        if time.monotonic() >= budget_deadline:
+        # Clamp each call to what is left of the budget so a single scope can
+        # never overshoot the deadline (previously a scope dispatched just
+        # before the deadline could run a full recall_timeout past it). Below
+        # the floor a call cannot return anything useful, so skip the
+        # remaining scopes instead of firing a doomed request.
+        remaining = budget_deadline - time.monotonic()
+        if remaining < MIN_SCOPE_TIMEOUT:
             hook_log("recall_budget_exceeded", {"collected": len(results)})
             break
+        scope_timeout = min(recall_timeout, remaining)
         part = None
         t0 = time.monotonic()
         try:
@@ -305,7 +322,7 @@ async def _run(prompt: str) -> dict | None:
                     search_type=qtype,
                     context_profile=context_profile,
                     dataset=get_dataset(config),
-                    timeout=recall_timeout,
+                    timeout=scope_timeout,
                 )
             else:
                 query_type = getattr(SearchType, qtype, None) if qtype else None
@@ -320,7 +337,7 @@ async def _run(prompt: str) -> dict | None:
                         user=user,
                         **({"context_profile": context_profile} if context_profile else {}),
                     ),
-                    timeout=recall_timeout,
+                    timeout=scope_timeout,
                 )
             if part:
                 results.extend(part)
@@ -349,8 +366,9 @@ async def _run(prompt: str) -> dict | None:
         if not isinstance(r, dict):
             continue
         src = r.get("source", "session")
-        # Fold scope=graph (HYBRID_COMPLETION) results into the graph_context
-        # bucket so the displayed `g` counter reflects what was retrieved.
+        # The graph scope tags results source=graph; keep the historical
+        # graph_context bucket name so the status line, last_recall.json
+        # consumers and the `g` counter stay stable.
         if src == "graph":
             r["source"] = "graph_context"
             src = "graph_context"

--- a/integrations/claude-code/tests/test_per_scope_timing.py
+++ b/integrations/claude-code/tests/test_per_scope_timing.py
@@ -1,9 +1,9 @@
 """Unit tests for per-scope recall instrumentation (session-context-lookup.py).
 
-Recall fans out over 5 scopes (session/trace/graph_context/graph/session_context).
+Recall fans out over 4 scopes (session/trace/session_context/graph).
 These tests drive the hook's ``_run`` in cloud mode with a fake ``recall_via_http``
 and assert the emitted recall event carries a per-scope ``{hits, elapsed_ms}``
-breakdown for all 5 scopes — including scopes that return nothing or never run —
+breakdown for all 4 scopes — including scopes that return nothing or never run —
 without changing the existing aggregate ``counts``.
 
 Run: python integrations/claude-code/tests/test_per_scope_timing.py (or via pytest).
@@ -23,7 +23,7 @@ os.environ.setdefault("COGNEE_PLUGIN_IN_VENV", "1")
 SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
-SCOPES = ["session", "trace", "graph_context", "graph", "session_context"]
+SCOPES = ["session", "trace", "session_context", "graph"]
 
 
 def _load_hook_module():
@@ -35,7 +35,7 @@ def _load_hook_module():
     return mod
 
 
-def _drive_run(recall_map, *, breaker=(False, 0)):
+def _drive_run(recall_map, *, breaker=(False, 0), recall_fn=None):
     """Drive _run in cloud mode with a fake recall; return (output, events).
 
     Stubs the module's I/O helpers on a freshly imported hook module, injects a
@@ -52,7 +52,9 @@ def _drive_run(recall_map, *, breaker=(False, 0)):
     mod.server_ready_hint = lambda _url: True
     mod._load_session_id = lambda: "sess-123"
     mod.read_and_reset_save_counter = lambda _sid: {"prompt": 0, "trace": 0, "answer": 0}
-    mod.recall_via_http = lambda prompt, **kw: list(recall_map.get(kw["scope"][0], []))
+    mod.recall_via_http = recall_fn or (
+        lambda prompt, **kw: list(recall_map.get(kw["scope"][0], []))
+    )
 
     # The breaker is imported lazily inside _run (cloud mode); inject a fake so
     # the test is deterministic regardless of any on-disk breaker state.
@@ -88,7 +90,7 @@ def _event(events, name):
 
 
 def _assert_valid_per_scope(per_scope):
-    assert list(per_scope.keys()) == SCOPES, f"expected all 5 scopes in order, got {per_scope}"
+    assert list(per_scope.keys()) == SCOPES, f"expected all 4 scopes in order, got {per_scope}"
     for label, rec in per_scope.items():
         assert isinstance(rec["hits"], int), f"{label} hits not int: {rec}"
         assert isinstance(rec["elapsed_ms"], (int, float)), f"{label} elapsed not numeric: {rec}"
@@ -100,7 +102,6 @@ def test_per_scope_on_hit():
     recall_map = {
         "session": [{"question": "q1", "answer": "a1"}],
         "trace": [],
-        "graph_context": [{"source": "graph_context", "content": "ctx"}],
         "graph": [{"source": "graph", "content": "gg"}],
         "session_context": [],
     }
@@ -114,13 +115,14 @@ def test_per_scope_on_hit():
     # Raw per-scope hit attribution (pre-bucketing): graph is NOT folded here.
     assert per_scope["session"]["hits"] == 1
     assert per_scope["trace"]["hits"] == 0
-    assert per_scope["graph_context"]["hits"] == 1
     assert per_scope["graph"]["hits"] == 1
     assert per_scope["session_context"]["hits"] == 0
+    # Bucketing folds graph results into the stable graph_context counter.
+    assert detail["counts"]["graph_context"] == 1
 
 
 def test_per_scope_on_empty():
-    """A total miss still emits per-scope timing for all 5 scopes (all ran)."""
+    """A total miss still emits per-scope timing for all 4 scopes (all ran)."""
     _out, events = _drive_run({s: [] for s in SCOPES})
 
     detail = _event(events, "context_lookup_empty")
@@ -133,7 +135,7 @@ def test_per_scope_on_empty():
 
 
 def test_all_scopes_skipped_when_breaker_open():
-    """Breaker-open runs no scope, yet all 5 are still reported as skipped."""
+    """Breaker-open runs no scope, yet all 4 are still reported as skipped."""
     _out, events = _drive_run({s: [] for s in SCOPES}, breaker=(True, 30))
 
     detail = _event(events, "context_lookup_empty")
@@ -142,6 +144,51 @@ def test_all_scopes_skipped_when_breaker_open():
     _assert_valid_per_scope(per_scope)
     assert all(rec.get("skipped") for rec in per_scope.values())
     assert all(rec["hits"] == 0 and rec["elapsed_ms"] == 0 for rec in per_scope.values())
+
+
+def test_scope_timeout_clamped_to_remaining_budget():
+    """Per-scope timeouts shrink to the remaining budget; exhausted budget skips.
+
+    With budget=0.8s and timeout=0.5s, a slow ``session`` (0.45s) leaves ~0.35s
+    for ``trace`` — its dispatched timeout must be clamped below the full 0.5s.
+    A slow ``trace`` (0.3s) then leaves less than MIN_SCOPE_TIMEOUT, so the
+    remaining scopes are skipped and recall_budget_exceeded fires —
+    previously each scope could run a full timeout past the deadline.
+    """
+    import time as _time
+
+    dispatched = {}
+    sleeps = {"session": 0.45, "trace": 0.3}
+
+    def _slow_recall(prompt, **kw):
+        scope = kw["scope"][0]
+        dispatched[scope] = kw["timeout"]
+        _time.sleep(sleeps.get(scope, 0))
+        return []
+
+    saved = {k: os.environ.get(k) for k in ("COGNEE_RECALL_TIMEOUT", "COGNEE_RECALL_BUDGET")}
+    os.environ["COGNEE_RECALL_TIMEOUT"] = "0.5"
+    os.environ["COGNEE_RECALL_BUDGET"] = "0.8"
+    try:
+        _out, events = _drive_run({}, recall_fn=_slow_recall)
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    # First scope had the whole budget: full per-call timeout.
+    assert dispatched["session"] == 0.5
+    # Second scope was clamped to the ~0.35s remaining (never the full 0.5).
+    assert 0.2 <= dispatched["trace"] < 0.45, f"expected clamped timeout, got {dispatched}"
+    # Budget exhausted before the remaining scopes: skipped, never dispatched.
+    assert set(dispatched) == {"session", "trace"}
+    assert _event(events, "recall_budget_exceeded") is not None
+    per_scope = _event(events, "context_lookup_empty")["per_scope"]
+    _assert_valid_per_scope(per_scope)
+    for scope in ("session_context", "graph"):
+        assert per_scope[scope].get("skipped"), f"{scope} should have been skipped"
 
 
 if __name__ == "__main__":

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,6 +10,38 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.1]
+
+### Fixed
+- **One graph search per prompt, not two.** The per-prompt recall hook queried
+  both `graph_context` and `graph` as separate scopes — a design from when
+  `graph_context` was a cheap lookup of the distilled `improve()` snapshot. On
+  cognee ≥ 1.4 the server aliases `graph_context` to `graph` (with a deprecation
+  warning), so the pair silently ran the *same* full graph retrieval twice per
+  prompt: once auto-routed to GRAPH_COMPLETION, once as the explicit
+  HYBRID_COMPLETION. The two scopes are now folded into a single `graph` scope
+  using HYBRID_COMPLETION, halving the most expensive part of every recall and
+  removing the server-side deprecation warning. Results from the `graph` scope
+  are still bucketed under the historical `graph_context` label, so the status
+  line counters, `last_recall.json`, and the `g` count render unchanged.
+- **Recall scopes run cheap-first, so agent guidance is never starved.** The
+  scope order was session → trace → graph_context → graph → session_context;
+  with both graph searches routinely consuming their full 2.5s timeout, the
+  4-second recall budget was exhausted before `session_context` — standing agent
+  guidance, ~50ms when it runs — ever fired, and it was silently skipped on
+  every degraded prompt. The order is now session → trace → session_context →
+  graph, so the only call that can eat a whole timeout runs last, against
+  whatever budget remains.
+- **Per-scope timeouts are clamped to the remaining recall budget.** The budget
+  deadline was only checked *between* scopes, so a scope dispatched just before
+  it could run a full `COGNEE_RECALL_TIMEOUT` past it — two slow scopes pushed a
+  "4-second" recall to 5–7s of keystroke-to-answer latency, mathematically
+  guaranteeing a `recall_budget_exceeded` event. Each call now gets
+  `min(recall_timeout, budget remaining)`, and a scope with less than 0.2s of
+  budget left is skipped outright instead of being dispatched with a doomed
+  deadline. The budget is a hard ceiling now; `recall_budget_exceeded` only
+  fires when the budget was genuinely spent on useful work.
+
 ## [1.3.0]
 
 ### Added

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Search session + trace + graph-context for context relevant to the user's prompt.
+"""Search session + trace + agent guidance + graph for context relevant to the user's prompt.
 
-Runs on the Codex UserPromptSubmit hook. Calls ``cognee.recall`` with
-``scope=["session","trace","graph_context"]`` so every layer the
-SessionManager holds (QA entries, agent trace steps, and the distilled
-graph-knowledge snapshot from ``improve()``) flows back into Codex's
-context.
+Runs on the Codex UserPromptSubmit hook. Calls ``cognee.recall`` once per
+scope (``session``, ``trace``, ``session_context``, ``graph``) so every
+layer the SessionManager holds (QA entries, agent trace steps, standing
+agent guidance, and the graph knowledge built by ``improve()``) flows back
+into Codex's context.
 
 Configuration:
     Resolves session state via Cognee HTTP endpoints.
@@ -58,6 +58,9 @@ TRUNCATE_ANSWER = 500
 TRUNCATE_RETURN = 400
 TRUNCATE_GRAPH_CTX = 1500
 RECENT_TRACE_FALLBACK_TOP_K = 5
+# Smallest per-scope timeout worth dispatching; with less budget than this
+# left, remaining scopes are skipped rather than fired with a doomed deadline.
+MIN_SCOPE_TIMEOUT = 0.2
 
 
 def _load_session_id() -> str:
@@ -233,12 +236,19 @@ async def _run(prompt: str) -> dict | None:
     # others. cognee.recall loops over scopes and re-raises on the first failure,
     # so we call it once per scope and collect whatever succeeds.
     results: list = []
+    # Cheap scopes first (tens of ms each), the graph search last: it is the
+    # only call that can consume a full per-call timeout, and running it
+    # earlier starved session_context out of the budget entirely. A single
+    # graph scope on purpose: the server (cognee >= 1.4) aliases the old
+    # graph_context scope to graph, so a graph_context + graph pair ran the
+    # same full graph retrieval twice per prompt. HYBRID_COMPLETION combines
+    # BM25 + vector + graph retrieval (with only_context=True the LLM
+    # completion is skipped server-side either way).
     scope_specs = [
         (["session"], None, None),
         (["trace"], None, None),
-        (["graph_context"], None, None),
-        (["graph"], "HYBRID_COMPLETION", None),
         (["session_context"], None, "agent"),
+        (["graph"], "HYBRID_COMPLETION", None),
     ]
     if not cloud_mode:
         import cognee
@@ -247,7 +257,7 @@ async def _run(prompt: str) -> dict | None:
         user = await resolve_user(_load_user_id())
 
     # Per-scope instrumentation (WS7 observability): capture {hits, elapsed_ms}
-    # for every scope, keyed by its stable label. Pre-seed all 5 scopes as
+    # for every scope, keyed by its stable label. Pre-seed all scopes as
     # skipped, in canonical order and before the breaker-open branch below can
     # blank scope_specs, so the event always carries the full set; the loop
     # overwrites each scope that actually runs. Purely additive: it must not
@@ -277,9 +287,16 @@ async def _run(prompt: str) -> dict | None:
             hook_log("recall_breaker_open", {"retry_in": _bretry})
             scope_specs = []
     for scope_list, qtype, context_profile in scope_specs:
-        if time.monotonic() >= budget_deadline:
+        # Clamp each call to what is left of the budget so a single scope can
+        # never overshoot the deadline (previously a scope dispatched just
+        # before the deadline could run a full recall_timeout past it). Below
+        # the floor a call cannot return anything useful, so skip the
+        # remaining scopes instead of firing a doomed request.
+        remaining = budget_deadline - time.monotonic()
+        if remaining < MIN_SCOPE_TIMEOUT:
             hook_log("recall_budget_exceeded", {"collected": len(results)})
             break
+        scope_timeout = min(recall_timeout, remaining)
         part = None
         t0 = time.monotonic()
         try:
@@ -293,7 +310,7 @@ async def _run(prompt: str) -> dict | None:
                     search_type=qtype,
                     context_profile=context_profile,
                     dataset=get_dataset(config),
-                    timeout=recall_timeout,
+                    timeout=scope_timeout,
                 )
             else:
                 query_type = getattr(SearchType, qtype, None) if qtype else None
@@ -308,7 +325,7 @@ async def _run(prompt: str) -> dict | None:
                         user=user,
                         **({"context_profile": context_profile} if context_profile else {}),
                     ),
-                    timeout=recall_timeout,
+                    timeout=scope_timeout,
                 )
             if part:
                 results.extend(part)
@@ -337,8 +354,9 @@ async def _run(prompt: str) -> dict | None:
         if not isinstance(r, dict):
             continue
         src = r.get("source", "session")
-        # Fold scope=graph (HYBRID_COMPLETION) results into the graph_context
-        # bucket so the displayed `g` counter reflects what was retrieved.
+        # The graph scope tags results source=graph; keep the historical
+        # graph_context bucket name so the status line, last_recall.json
+        # consumers and the `g` counter stay stable.
         if src == "graph":
             r["source"] = "graph_context"
             src = "graph_context"


### PR DESCRIPTION
This PR fixes how recall works. Session context is searched before graph, since it is less expensive.
The graph search via hybrid completion is also fixed, using the correct scope and timeouts.