### PR TITLE
Feature/sdk 323 update hermes integration to match the rest

### DIFF
--- a/.github/workflows/hermes-agent-publish.yml
+++ b/.github/workflows/hermes-agent-publish.yml
@@ -1,0 +1,66 @@
+# Publishes the Hermes memory plugin (integrations/hermes-agent) to PyPI on tag
+# push, using PyPI Trusted Publishing (OIDC) — no long-lived token secrets.
+#
+# Release flow:
+#   1. Bump the version in pyproject.toml, plugin.yaml AND
+#      cognee_integration_hermes/_plugin_root/plugin.yaml (tests enforce they
+#      match), update CHANGELOG.md and integrations/inventory.yml.
+#   2. Tag: git tag hermes-agent-v<version> && git push --tags
+#
+# ─── ONE-TIME SETUP ────────────────────────────────────────────────────────────
+#
+# On pypi.org, for the `cognee-integration-hermes-agent` project (or as a
+# "pending publisher" before the first release), add a Trusted Publisher:
+#   Repository owner: topoteretes
+#   Repository name:  cognee-integrations
+#   Workflow name:    hermes-agent-publish.yml
+#   Environment:      (leave blank)
+
+name: Publish hermes-agent plugin to PyPI
+
+on:
+  push:
+    tags:
+      - "hermes-agent-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC for PyPI Trusted Publishing
+    defaults:
+      run:
+        working-directory: integrations/hermes-agent
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check the tag matches the package version
+        run: |
+          tag_version="${GITHUB_REF_NAME#hermes-agent-v}"
+          pkg_version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "Tag says $tag_version but pyproject.toml says $pkg_version" >&2
+            exit 1
+          fi
+
+      - name: Run the test suite
+        run: |
+          python -m pip install pytest .
+          python -m pytest tests/ -q
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: integrations/hermes-agent/dist

--- a/integrations/hermes-agent/.gitignore
+++ b/integrations/hermes-agent/.gitignore
@@ -1,0 +1,2 @@
+build/
+dist/

--- a/integrations/hermes-agent/CHANGELOG.md
+++ b/integrations/hermes-agent/CHANGELOG.md
@@ -1,0 +1,98 @@
+# Changelog
+
+All notable changes to the Cognee memory plugin for Hermes Agent are documented
+here.
+
+The version must match the `version` field in both `pyproject.toml` and
+`plugin.yaml`, and the `current_version` for `hermes-agent` in
+[`integrations/inventory.yml`](../inventory.yml).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
+project adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.2.0]
+
+Moves the provider onto cognee's REST API, the way the Claude Code, Codex and
+OpenClaw plugins already talk to it. The local cognee server was always there —
+what changed is the client: routing through the SDK's `cognee.serve()` /
+`CloudClient` silently dropped fields the server accepts.
+
+### Changed
+
+- **Breaking — the transport is now direct HTTP.** Requests are built and sent by
+  the plugin (stdlib `urllib` only) instead of going through `cognee.serve()`.
+  `COGNEE_TRANSPORT=sdk` restores the old client; `COGNEE_EMBEDDED=true` still uses
+  the in-process SDK, which is the only transport that can run without a server.
+- **Breaking — the local server moved from port 8000 to 8011.** This matches the
+  other cognee agent plugins and leaves cognee's own default of 8000 to servers you
+  run yourself, so the plugin no longer attaches to one by accident. Memory is
+  unaffected — where it lives depends on the server's data directory, never the
+  port. Set `COGNEE_LOCAL_PORT=8000` to keep the old behaviour, and stop any old
+  plugin-started server on 8000 so two servers do not share one data directory.
+- **Breaking — local storage is now profile-scoped in local-server mode.**
+  `data_root` / `system_root` default to `$HERMES_HOME/cognee/{data,system}`, as the
+  configuration reference always claimed. Previously they were only set in embedded
+  mode, so the spawned server fell back to cognee's global default and every Hermes
+  profile shared one store. Existing repo installs will find their old memory at
+  cognee's default location; point `COGNEE_DATA_ROOT` / `COGNEE_SYSTEM_ROOT` there
+  to keep using it.
+
+### Fixed
+
+- **Session memory now reaches the permanent graph.** `improve()` is called with
+  `session_ids`, which `CloudClient.improve` never forwarded — the session-to-graph
+  bridge had silently become a dataset-wide improve.
+- **An unreachable `COGNEE_BASE_URL` now fails at startup.** `cognee.serve()` logged
+  a warning and returned a client regardless, so a bad URL only surfaced on the
+  first real call.
+- **The spawned server no longer leaks.** The plugin registers an agent connection
+  on connect and unregisters on shutdown, so cognee's idle watchdog can stop a
+  server nobody is using.
+- **Local servers are authenticated.** An owner API key is minted once and cached
+  under `HERMES_HOME`, instead of relying on the server having auth disabled.
+- **A failed initialization now fails closed.** Hermes logs a provider's
+  initialization error and starts anyway, so every entry point now refuses to run
+  rather than operating an unconnected transport — which previously meant quietly
+  falling back to in-process cognee and its single-writer databases.
+- **No more cross-conversation context leak on `/reset`.** A recall still in flight
+  for the previous conversation is discarded instead of landing in the fresh one.
+- **Write gating is uniform.** `on_memory_write` now honours `agent_context`, so a
+  subagent's built-in memory write is suppressed like its conversation turns.
+- **`hermes backup` sees cognee storage.** `backup_paths()` reports roots pointed
+  outside `HERMES_HOME`.
+- **`COGNEE_AUTO_ROUTE=false` is honoured over HTTP**, translated to an explicit
+  `GRAPH_COMPLETION` search type since the endpoint has no `auto_route` field.
+- **Session turns actually reach the session cache.** They are stored as a typed
+  QA entry via `/api/v1/remember/entry`, the endpoint the Claude Code plugin uses
+  for the same purpose. Sending them as a document to `/api/v1/remember` with a
+  `session_id` looked like it worked — the API answered
+  `status: "session_stored"` — but the payload arrives as a multipart file, which
+  cognee coerces to a `[UploadFile]` placeholder and deliberately *skips* for the
+  session cache. Every turn was silently discarded and `improve()` had nothing to
+  promote into the graph. Found by the live round-trip test; no mock could catch it,
+  because the server reported success.
+- The spawned server is also started with `CACHING=true` and `AUTO_FEEDBACK=true`,
+  matching the Claude Code and OpenClaw plugins. Both are already cognee's defaults,
+  so this is insurance against a future default change silently disabling the session
+  tier, not a fix in itself.
+
+### Added
+
+- `COGNEE_TRANSPORT` — `http` (default) or `sdk`.
+- A test suite grown from 34 to 270, including wire-format tests per transport and
+  an opt-in live round trip against a real cognee server
+  (`COGNEE_RUN_INTEGRATION=1`).
+
+### Known limitations
+
+- A *permanent* write cannot be linked to its originating session over HTTP:
+  `/api/v1/remember` has no `session_ids` field. The session-to-graph bridge is
+  unaffected. Logged once per session rather than dropped silently.
+- `pip install cognee-integration-hermes-agent` cannot activate the provider:
+  Hermes discovers memory providers by directory scan only. Install as a directory
+  plugin under `$HERMES_HOME/plugins/cognee`.
+
+## [0.1.0]
+
+Initial standalone plugin: session-aware graph memory with recall, remember,
+forget, and a session-end improve, over the cognee SDK.

--- a/integrations/hermes-agent/CHANGELOG.md
+++ b/integrations/hermes-agent/CHANGELOG.md
@@ -67,6 +67,11 @@ what changed is the client: routing through the SDK's `cognee.serve()` /
 - **The spawned server no longer leaks.** The plugin registers an agent connection
   on connect and unregisters on shutdown, so cognee's idle watchdog can stop a
   server nobody is using.
+- **The exit watcher is safe on Windows.** Its liveness probe no longer uses
+  `os.kill(pid, 0)` there — CPython implements non-console "signals" on Windows
+  as `TerminateProcess`, so probing would have killed the running Hermes — and
+  queries the process handle (`OpenProcess`/`GetExitCodeProcess`) instead.
+  Group/broadcast pids (`<= 0`) are also never treated as watchable.
 - **A crashed Hermes no longer loses its session or strands the server.** In
   server/remote mode the plugin arms a small detached exit watcher (the pattern
   the claude-code/codex/openclaw plugins use) that polls the Hermes PID; on an
@@ -123,6 +128,14 @@ what changed is the client: routing through the SDK's `cognee.serve()` /
 
 ### Added
 
+- **pip is now a working install channel.** The wheel ships the plugin-root
+  files (`plugin.yaml`, the `cli.py` shim, `after-install.md`) as package data,
+  and a new `cognee-hermes-install` console script copies the plugin into
+  `$HERMES_HOME/plugins/cognee` — the only place Hermes' directory scan looks.
+  `hermes cognee status` now shows the installed plugin version and warns when
+  the pip package is newer than the installed copy (after `pip install -U`,
+  re-run `cognee-hermes-install`). Releases publish to PyPI from CI on
+  `hermes-agent-v*` tags.
 - **The dataset is ensured at startup** (idempotent `POST /api/v1/datasets`, the
   other plugins' bootstrap call), so a session that opens with a recall on a
   fresh server or cloud tenant no longer hits a missing dataset. Best-effort:
@@ -137,9 +150,9 @@ what changed is the client: routing through the SDK's `cognee.serve()` /
 - A *permanent* write cannot be linked to its originating session over HTTP:
   `/api/v1/remember` has no `session_ids` field. The session-to-graph bridge is
   unaffected. Logged once per session rather than dropped silently.
-- `pip install cognee-integration-hermes-agent` cannot activate the provider:
-  Hermes discovers memory providers by directory scan only. Install as a directory
-  plugin under `$HERMES_HOME/plugins/cognee`.
+- `pip install` alone cannot activate the provider — Hermes discovers memory
+  providers by directory scan only — which is why `cognee-hermes-install`
+  exists, and why it must be re-run after every `pip install -U`.
 
 ## [0.1.0]
 

--- a/integrations/hermes-agent/CHANGELOG.md
+++ b/integrations/hermes-agent/CHANGELOG.md
@@ -67,6 +67,16 @@ what changed is the client: routing through the SDK's `cognee.serve()` /
 - **The spawned server no longer leaks.** The plugin registers an agent connection
   on connect and unregisters on shutdown, so cognee's idle watchdog can stop a
   server nobody is using.
+- **A crashed Hermes no longer loses its session or strands the server.** In
+  server/remote mode the plugin arms a small detached exit watcher (the pattern
+  the claude-code/codex/openclaw plugins use) that polls the Hermes PID; on an
+  unclean death it runs `improve(session_ids=[...])` synchronously — improve
+  *before* unregister, so the idle watchdog cannot tear the server down
+  mid-promotion — then unregisters the agent connection. A clean shutdown
+  disarms it first, so nothing double-fires; a session end that already bridged
+  stands down only the improve half. State and log live under
+  `~/.cognee-plugin/hermes/`. Embedded mode gets no watcher — there is no server
+  to outlive the process.
 - **Local servers are authenticated.** An owner API key is minted once and cached
   at `~/.cognee-plugin/api_key.json`, instead of relying on the server having
   auth disabled.

--- a/integrations/hermes-agent/CHANGELOG.md
+++ b/integrations/hermes-agent/CHANGELOG.md
@@ -58,6 +58,12 @@ what changed is the client: routing through the SDK's `cognee.serve()` /
 - **An unreachable `COGNEE_BASE_URL` now fails at startup.** `cognee.serve()` logged
   a warning and returned a client regardless, so a bad URL only surfaced on the
   first real call.
+- **A remote `COGNEE_BASE_URL` without `COGNEE_API_KEY` also fails at startup.**
+  Key minting is local-only — remote servers (Cognee Cloud included) expose no
+  login route to mint from, and the claude-code/openclaw plugins require a key
+  for remote targets for the same reason. Previously the plugin continued
+  unauthenticated and every call 401'd one at a time; it also no longer sends
+  the default-user login credentials to non-local hosts.
 - **The spawned server no longer leaks.** The plugin registers an agent connection
   on connect and unregisters on shutdown, so cognee's idle watchdog can stop a
   server nobody is using.

--- a/integrations/hermes-agent/CHANGELOG.md
+++ b/integrations/hermes-agent/CHANGELOG.md
@@ -89,6 +89,21 @@ what changed is the client: routing through the SDK's `cognee.serve()` /
   matching the Claude Code and OpenClaw plugins. Both are already cognee's defaults,
   so this is insurance against a future default change silently disabling the session
   tier, not a fix in itself.
+- **A cold first boot no longer times out.** `COGNEE_SERVER_BOOT_TIMEOUT` now
+  defaults to 600s (was 30s), matching the other plugins' boot deadline — a first
+  boot runs DB migrations and can take minutes, and giving up early left memory
+  off for the whole session. The long deadline is safe because the bootstrap now
+  **fails fast when the spawned server dies**: a crashed child with nothing
+  listening on the port raises immediately (pointing at the server log) instead
+  of stalling the session start, while a child that merely lost the port-bind
+  race to a concurrent starter still waits for the winner to become healthy.
+- **cognee is now bounded to `>=1.2.1,<=1.4.0`** (was the loose
+  `>=1.0.0,<2.0.0`). The wire contract this plugin depends on —
+  `/api/v1/remember/entry` and `improve(session_ids)` — first shipped in 1.2.1,
+  and a 1.0.x server would accept some of these requests and silently do the
+  wrong thing. The 1.4.0 cap is the newest version verified against the full
+  test suite and a live server boot (health, key minting, agent
+  register/unregister); the lockfile resolves to 1.4.0.
 
 ### Added
 

--- a/integrations/hermes-agent/CHANGELOG.md
+++ b/integrations/hermes-agent/CHANGELOG.md
@@ -10,10 +10,10 @@ The version must match the `version` field in both `pyproject.toml` and
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.2.0]
+## [1.0.0]
 
-Moves the provider onto cognee's REST API, the way the Claude Code, Codex and
-OpenClaw plugins already talk to it. The local cognee server was always there —
+First stable release, published to PyPI. Moves the provider onto cognee's REST
+API, the way the Claude Code, Codex and OpenClaw plugins already talk to it. The local cognee server was always there —
 what changed is the client: routing through the SDK's `cognee.serve()` /
 `CloudClient` silently dropped fields the server accepts.
 

--- a/integrations/hermes-agent/CHANGELOG.md
+++ b/integrations/hermes-agent/CHANGELOG.md
@@ -123,6 +123,10 @@ what changed is the client: routing through the SDK's `cognee.serve()` /
 
 ### Added
 
+- **The dataset is ensured at startup** (idempotent `POST /api/v1/datasets`, the
+  other plugins' bootstrap call), so a session that opens with a recall on a
+  fresh server or cloud tenant no longer hits a missing dataset. Best-effort:
+  writes create the dataset implicitly anyway.
 - `COGNEE_TRANSPORT` — `http` (default) or `sdk`.
 - A test suite grown from 34 to 270, including wire-format tests per transport and
   an opt-in live round trip against a real cognee server

--- a/integrations/hermes-agent/CHANGELOG.md
+++ b/integrations/hermes-agent/CHANGELOG.md
@@ -29,13 +29,26 @@ what changed is the client: routing through the SDK's `cognee.serve()` /
   unaffected — where it lives depends on the server's data directory, never the
   port. Set `COGNEE_LOCAL_PORT=8000` to keep the old behaviour, and stop any old
   plugin-started server on 8000 so two servers do not share one data directory.
-- **Breaking — local storage is now profile-scoped in local-server mode.**
-  `data_root` / `system_root` default to `$HERMES_HOME/cognee/{data,system}`, as the
-  configuration reference always claimed. Previously they were only set in embedded
-  mode, so the spawned server fell back to cognee's global default and every Hermes
-  profile shared one store. Existing repo installs will find their old memory at
-  cognee's default location; point `COGNEE_DATA_ROOT` / `COGNEE_SYSTEM_ROOT` there
-  to keep using it.
+- **Breaking — Hermes joins the shared brain.** The default dataset is now
+  `agent_sessions` and local storage defaults to `~/.cognee/{data,system}` — the
+  exact names and roots the Claude Code, Codex and OpenClaw plugins pin — so
+  memory is shared across all cognee agent plugins on the machine, no matter
+  which of them booted the server. `COGNEE_PLUGIN_DATASET` (the name the other
+  plugins read) is the canonical dataset variable; `COGNEE_DATASET` stays as a
+  lower-precedence alias. To keep a Hermes profile apart, set its own dataset, or
+  its own `COGNEE_DATA_ROOT` / `COGNEE_SYSTEM_ROOT` *plus* `COGNEE_LOCAL_PORT`
+  for full isolation. Old 0.1.x memory (dataset `hermes`, cognee's default
+  roots) is not deleted but is no longer found by default —
+  `COGNEE_DATASET=hermes` restores it. Previously roots were only set in embedded
+  mode, so the spawned server fell back to cognee's global default location.
+- **The minted API key is shared too.** It now lives at
+  `~/.cognee-plugin/api_key.json` in the other plugins' exact format (previously
+  `$HERMES_HOME/cognee-api-key.json`): whichever plugin mints first, the rest
+  reuse. The spawned server's environment also mirrors the other plugins'
+  bootstraps (`CACHE_ROOT_DIRECTORY`, `LLM_INSTRUCTOR_MODE=json_schema_mode`,
+  `COGNEE_IMPROVE_SUBMIT_TIMEOUT=420`), and its log moved to
+  `~/.cognee-plugin/hermes/server.log`, so the server behaves identically no
+  matter which plugin starts it.
 
 ### Fixed
 
@@ -49,7 +62,8 @@ what changed is the client: routing through the SDK's `cognee.serve()` /
   on connect and unregisters on shutdown, so cognee's idle watchdog can stop a
   server nobody is using.
 - **Local servers are authenticated.** An owner API key is minted once and cached
-  under `HERMES_HOME`, instead of relying on the server having auth disabled.
+  at `~/.cognee-plugin/api_key.json`, instead of relying on the server having
+  auth disabled.
 - **A failed initialization now fails closed.** Hermes logs a provider's
   initialization error and starts anyway, so every entry point now refuses to run
   rather than operating an unconnected transport — which previously meant quietly

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -73,6 +73,29 @@ initialization raises rather than quietly switching to a different mode — sile
 fallback would either mask a config error (remote → local data divergence) or
 reintroduce the very DB-lock risk this design removes (local-server → embedded).
 To accept the single-process trade-off, set `COGNEE_EMBEDDED=true` explicitly.
+And if initialization does fail, memory stays *off*: Hermes logs the error and
+starts anyway, so the provider refuses every call rather than operating a
+half-connected backend.
+
+### Transports
+
+Mode decides *where* cognee is; the transport decides *how* the plugin talks to it.
+
+| Transport | Selected by | What it does |
+| --- | --- | --- |
+| **http** (default) | nothing to set | builds requests against cognee's REST API directly, using only the standard library |
+| **sdk** | `COGNEE_TRANSPORT=sdk`, or any `COGNEE_EMBEDDED=true` | drives the `cognee` Python package, via `cognee.serve()` when a server is involved |
+
+Direct HTTP is the default because it is what the Claude Code, Codex and OpenClaw
+plugins do, and because the SDK's `CloudClient` drops fields the server accepts —
+most importantly `session_ids` on `improve()`, which is what promotes a session's
+turns into the permanent graph. Two consequences worth knowing:
+
+- The `cognee` package is still required. It is what the local server runs, and it
+  is the only way to run without a server at all (`COGNEE_EMBEDDED=true`).
+- Over HTTP, a `cognee_remember` write cannot be linked to the session it came
+  from — `/api/v1/remember` has no field for it. Session-to-graph bridging is
+  unaffected. The plugin logs this once rather than dropping it silently.
 
 > **Upgrading from 0.1.x — the local port changed from 8000 to 8011.** This
 > matches the other cognee agent plugins (Claude Code, Codex, OpenClaw), which all
@@ -125,6 +148,14 @@ COGNEE_DATASET=hermes
 | `server_boot_timeout` | `COGNEE_SERVER_BOOT_TIMEOUT` | `30` |
 | `data_root` | `COGNEE_DATA_ROOT` | `$HERMES_HOME/cognee/data` |
 | `system_root` | `COGNEE_SYSTEM_ROOT` | `$HERMES_HOME/cognee/system` |
+
+> **Storage is per profile, but a server is per port.** The roots above are scoped
+> to `HERMES_HOME`, so each Hermes profile gets its own store and `hermes backup`
+> can see it. A cognee server, though, belongs to whoever reaches its port first —
+> so two profiles left on the same `COGNEE_LOCAL_PORT` still share one store. Give
+> them separate ports if you want them apart. Roots pointed outside `HERMES_HOME`
+> with `COGNEE_DATA_ROOT` / `COGNEE_SYSTEM_ROOT` are reported to `hermes backup`
+> via `backup_paths()`, so they survive a backup/import cycle too.
 
 > `COGNEE_SERVICE_URL` is a deprecated alias for `COGNEE_BASE_URL`. It still works
 > (with lower precedence) but new setups should use `COGNEE_BASE_URL`.

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -163,7 +163,7 @@ LLM_API_KEY=sk-...
 | `service_url` | `COGNEE_BASE_URL` (canonical) | empty |
 | `embedded` | `COGNEE_EMBEDDED` | `false` |
 | `local_port` | `COGNEE_LOCAL_PORT` | `8011` |
-| `server_boot_timeout` | `COGNEE_SERVER_BOOT_TIMEOUT` | `30` |
+| `server_boot_timeout` | `COGNEE_SERVER_BOOT_TIMEOUT` | `600` |
 | `data_root` | `COGNEE_DATA_ROOT` | `~/.cognee/data` |
 | `system_root` | `COGNEE_SYSTEM_ROOT` | `~/.cognee/system` |
 

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -74,13 +74,23 @@ fallback would either mask a config error (remote → local data divergence) or
 reintroduce the very DB-lock risk this design removes (local-server → embedded).
 To accept the single-process trade-off, set `COGNEE_EMBEDDED=true` explicitly.
 
+> **Upgrading from 0.1.x — the local port changed from 8000 to 8011.** This
+> matches the other cognee agent plugins (Claude Code, Codex, OpenClaw), which all
+> run their own server on 8011 and leave cognee's own default of 8000 to servers you
+> start yourself. Your memory is unaffected — where it lives is decided by the
+> server's data directory, never by the port. But if an old plugin-started server is
+> still
+> listening on 8000, **stop it** — two servers sharing one data directory is exactly
+> the single-writer contention this mode exists to avoid. Set
+> `COGNEE_LOCAL_PORT=8000` to keep the old behaviour.
+
 local-server mode (default — just set your LLM creds):
 
 ```bash
 LLM_API_KEY=sk-...
 LLM_MODEL=gpt-4o-mini
 COGNEE_DATASET=hermes
-# COGNEE_LOCAL_PORT=8000   # optional; point at a shared server for a unified brain
+# COGNEE_LOCAL_PORT=8011   # optional; point at a shared server for a unified brain
 ```
 
 Remote / cloud mode:
@@ -111,7 +121,7 @@ COGNEE_DATASET=hermes
 | `session_prefix` | `COGNEE_SESSION_PREFIX` | `hermes` |
 | `service_url` | `COGNEE_BASE_URL` (canonical) | empty |
 | `embedded` | `COGNEE_EMBEDDED` | `false` |
-| `local_port` | `COGNEE_LOCAL_PORT` | `8000` |
+| `local_port` | `COGNEE_LOCAL_PORT` | `8011` |
 | `server_boot_timeout` | `COGNEE_SERVER_BOOT_TIMEOUT` | `30` |
 | `data_root` | `COGNEE_DATA_ROOT` | `$HERMES_HOME/cognee/data` |
 | `system_root` | `COGNEE_SYSTEM_ROOT` | `$HERMES_HOME/cognee/system` |

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -21,19 +21,75 @@ Python package with the `hermes_agent.plugins` entry point.
   graph and unregisters from the server — so no session is lost and no server
   lingers. It stands down silently on a clean shutdown.
 
-## Install For Local Hermes Development
+## Quick start
 
-From a fresh checkout of this repository:
+### Prerequisites
+
+- [Hermes Agent](https://github.com/NousResearch/hermes-agent) installed
+  (`curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`).
+- **Local mode:** an LLM API key (e.g. OpenAI) — cognee uses it to build the
+  knowledge graph on your machine.
+- **Cloud mode:** a Cognee Cloud tenant URL and API key from your
+  [Cognee Cloud dashboard](https://platform.cognee.ai/). No LLM key needed —
+  the tenant runs the models.
+
+### 1. Install the plugin
+
+Until the PyPI release, install from a checkout of this repository:
 
 ```bash
 git clone https://github.com/topoteretes/cognee-integrations.git
-cd cognee-integrations
 mkdir -p ~/.hermes/plugins/cognee
-cp -R integrations/hermes-agent/. ~/.hermes/plugins/cognee/
+cp -R cognee-integrations/integrations/hermes-agent/. ~/.hermes/plugins/cognee/
+```
+
+### 2a. Connect locally (default)
+
+```bash
 hermes memory setup
 ```
 
-Select `cognee` in the memory provider picker.
+Select `cognee` in the provider picker, choose **Mode: local**, and paste your
+LLM API key when asked. That's the whole setup — the wizard writes non-secrets
+to `~/.hermes/cognee.json` and secrets to `~/.hermes/.env`.
+
+On your next `hermes` session the plugin starts a cognee server on
+`127.0.0.1:8011` — or attaches to one that a sibling cognee plugin (Claude
+Code, Codex, OpenClaw) already runs — with storage in `~/.cognee`. The very
+first boot runs database migrations and can take a couple of minutes; after
+that it's instant.
+
+Verify it's connected:
+
+```bash
+hermes cognee status                    # shows mode, dataset, service URL
+curl -s http://127.0.0.1:8011/health    # the server answers
+```
+
+Then, in a `hermes` chat: *"Remember that my favorite editor is Helix"* — the
+agent should call `cognee_remember`. Start a fresh conversation (`/new`) and
+ask *"What's my favorite editor?"* — it should recall it via `cognee_recall`.
+
+### 2b. Connect to Cognee Cloud
+
+Grab your tenant URL (`https://tenant-xxx.aws.cognee.ai`) and an API key from
+the [Cognee Cloud dashboard](https://platform.cognee.ai/), then run the same
+wizard and choose **Mode: remote**:
+
+```bash
+hermes memory setup     # cognee -> Mode: remote -> tenant URL + API key
+```
+
+Verify: `hermes cognee status` shows your tenant URL, and the same
+remember-`/new`-recall chat round trip works. Nothing runs locally in this
+mode — no server is spawned and no LLM key is used; every request goes to the
+tenant, authenticated with your API key via `X-Api-Key`.
+
+> **Switching modes? Re-run the wizard.** Values in `~/.hermes/cognee.json`
+> take precedence over environment variables, and a local setup records
+> `"service_url": ""` there — so *only* exporting `COGNEE_BASE_URL` will not
+> move an existing local install to the cloud. `hermes memory setup` (or
+> `hermes cognee setup`) rewrites both files consistently.
 
 ## PyPI Availability
 
@@ -49,8 +105,13 @@ cognee = "cognee_integration_hermes"
 
 ## Configuration
 
-The setup wizard writes non-secret settings to `$HERMES_HOME/cognee.json` and
-secrets to `$HERMES_HOME/.env`.
+The quick start above covers the common cases; this section is the full
+reference. Configuration comes from two places: `$HERMES_HOME/.env` (secrets
+and environment variables — Hermes loads it for every session) and
+`$HERMES_HOME/cognee.json` (non-secret settings). The setup wizard writes both.
+When a key appears in both places, **the JSON file wins** — which is why mode
+switches should go through the wizard rather than editing the environment
+alone.
 
 ### Modes
 
@@ -125,6 +186,9 @@ it its own `COGNEE_PLUGIN_DATASET`, or for full isolation its own
 belongs to whoever reaches its port first, so a private store needs a private
 port.
 
+The per-mode settings below live in `~/.hermes/.env` (the wizard puts them
+there; you can also edit the file by hand).
+
 local-server mode (default — just set your LLM creds):
 
 ```bash
@@ -134,10 +198,11 @@ LLM_MODEL=gpt-4o-mini
 # COGNEE_LOCAL_PORT=8011                 # optional; the other plugins' server port
 ```
 
-Remote / cloud mode:
+Remote / cloud mode (tenant URL and API key from the
+[Cognee Cloud dashboard](https://platform.cognee.ai/)):
 
 ```bash
-COGNEE_BASE_URL=https://your-cognee-service.example   # canonical name
+COGNEE_BASE_URL=https://tenant-xxx.aws.cognee.ai   # canonical name
 COGNEE_API_KEY=...
 ```
 

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -35,7 +35,19 @@ Python package with the `hermes_agent.plugins` entry point.
 
 ### 1. Install the plugin
 
-Until the PyPI release, install from a checkout of this repository:
+Via pip (recommended):
+
+```bash
+pip install cognee-integration-hermes-agent
+cognee-hermes-install
+```
+
+Hermes discovers plugins by scanning `~/.hermes/plugins/`, so the second
+command copies the plugin there — `pip install` alone is not enough, and after
+a `pip install -U` you re-run `cognee-hermes-install` to update the copy
+(`hermes cognee status` reminds you when the two drift).
+
+Or from a checkout of this repository:
 
 ```bash
 git clone https://github.com/topoteretes/cognee-integrations.git
@@ -91,17 +103,26 @@ tenant, authenticated with your API key via `X-Api-Key`.
 > move an existing local install to the cloud. `hermes memory setup` (or
 > `hermes cognee setup`) rewrites both files consistently.
 
-## PyPI Availability
+## How the pip install works
 
-`cognee-integration-hermes-agent` is not currently published on PyPI. Use the
-local installation steps above until a release is available.
+Hermes has no entry-point plugin discovery (yet) — it scans
+`$HERMES_HOME/plugins/` for directories with a `plugin.yaml`. The wheel
+therefore ships the plugin-root files as package data and provides the
+`cognee-hermes-install` console script, which materializes the exact directory
+shape the scanner expects. Because Hermes runs that *copy*, upgrading is always
+two steps: `pip install -U cognee-integration-hermes-agent`, then
+`cognee-hermes-install` again.
 
-The project is prepared for future package distribution and exposes:
+The package also declares the entry point Hermes would use if it grows native
+discovery, at which point the copy step becomes unnecessary:
 
 ```toml
 [project.entry-points."hermes_agent.plugins"]
 cognee = "cognee_integration_hermes"
 ```
+
+Releases are published from CI on `hermes-agent-v*` tags
+(`.github/workflows/hermes-agent-publish.yml`).
 
 ## Configuration
 

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -137,6 +137,12 @@ COGNEE_BASE_URL=https://your-cognee-service.example   # canonical name
 COGNEE_API_KEY=...
 ```
 
+> **`COGNEE_API_KEY` is mandatory for any remote server.** On a local server the
+> plugin mints a key on first use (a one-time login as the default user); remote
+> servers — Cognee Cloud included — expose no login route, so there is nothing to
+> mint with. A remote `COGNEE_BASE_URL` without a key fails at startup with a
+> clear error rather than a 401 on every call.
+
 Embedded (in-process) mode — single-process / offline only:
 
 ```bash

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -16,6 +16,10 @@ Python package with the `hermes_agent.plugins` entry point.
 - Runs `cognee.improve()` at Hermes session end to bridge session memory into the graph.
 - Mirrors explicit Hermes memory writes through `on_memory_write`.
 - Supports local embedded Cognee and remote Cognee service mode.
+- Survives crashes: a detached exit watcher (the same pattern the other cognee
+  plugins use) notices an uncleanly-died Hermes, bridges the session into the
+  graph and unregisters from the server — so no session is lost and no server
+  lingers. It stands down silently on a clean shutdown.
 
 ## Install For Local Hermes Development
 

--- a/integrations/hermes-agent/README.md
+++ b/integrations/hermes-agent/README.md
@@ -97,23 +97,37 @@ turns into the permanent graph. Two consequences worth knowing:
   from — `/api/v1/remember` has no field for it. Session-to-graph bridging is
   unaffected. The plugin logs this once rather than dropping it silently.
 
-> **Upgrading from 0.1.x — the local port changed from 8000 to 8011.** This
-> matches the other cognee agent plugins (Claude Code, Codex, OpenClaw), which all
-> run their own server on 8011 and leave cognee's own default of 8000 to servers you
-> start yourself. Your memory is unaffected — where it lives is decided by the
-> server's data directory, never by the port. But if an old plugin-started server is
-> still
-> listening on 8000, **stop it** — two servers sharing one data directory is exactly
-> the single-writer contention this mode exists to avoid. Set
-> `COGNEE_LOCAL_PORT=8000` to keep the old behaviour.
+> **Upgrading from 0.1.x — three defaults moved to match the other cognee
+> plugins.** The local port changed from 8000 to 8011 (leaving cognee's own
+> default of 8000 to servers you start yourself); the default dataset changed
+> from `hermes` to the shared `agent_sessions`; and local storage now defaults to
+> the shared `~/.cognee/{data,system}` instead of cognee's global default. Your
+> old memory is not deleted, but a recall against the new dataset/roots will not
+> see it — set `COGNEE_DATASET=hermes` (or migrate the data) and, if an old
+> plugin-started server is still listening on 8000, **stop it**: two servers
+> sharing one data directory is exactly the single-writer contention this mode
+> exists to avoid. `COGNEE_LOCAL_PORT=8000` restores the old port.
+
+### One brain across agents
+
+By default this plugin joins the same memory the Claude Code, Codex and OpenClaw
+cognee plugins share: the same dataset (`agent_sessions`), the same local storage
+(`~/.cognee/{data,system}`), the same server port (8011) and the same minted API
+key (`~/.cognee-plugin/api_key.json`). Whichever plugin boots the server first,
+the rest attach to it — and a fact remembered in Claude Code is recallable in
+Hermes, and vice versa. To keep Hermes (or one Hermes profile) apart instead, give
+it its own `COGNEE_PLUGIN_DATASET`, or for full isolation its own
+`COGNEE_DATA_ROOT` / `COGNEE_SYSTEM_ROOT` *and* `COGNEE_LOCAL_PORT` — a server
+belongs to whoever reaches its port first, so a private store needs a private
+port.
 
 local-server mode (default — just set your LLM creds):
 
 ```bash
 LLM_API_KEY=sk-...
 LLM_MODEL=gpt-4o-mini
-COGNEE_DATASET=hermes
-# COGNEE_LOCAL_PORT=8011   # optional; point at a shared server for a unified brain
+# COGNEE_PLUGIN_DATASET=agent_sessions   # optional; the default is shared with the other plugins
+# COGNEE_LOCAL_PORT=8011                 # optional; the other plugins' server port
 ```
 
 Remote / cloud mode:
@@ -121,7 +135,6 @@ Remote / cloud mode:
 ```bash
 COGNEE_BASE_URL=https://your-cognee-service.example   # canonical name
 COGNEE_API_KEY=...
-COGNEE_DATASET=hermes
 ```
 
 Embedded (in-process) mode — single-process / offline only:
@@ -129,14 +142,19 @@ Embedded (in-process) mode — single-process / offline only:
 ```bash
 COGNEE_EMBEDDED=true
 LLM_API_KEY=sk-...
-COGNEE_DATASET=hermes
 ```
+
+> **Embedded mode and the shared store do not mix.** Embedded drives the local
+> single-writer databases from inside the Hermes process; if another plugin's
+> server (or another process) is using `~/.cognee` at the same time, that is
+> exactly the contention embedded mode is warned about. For embedded use, point
+> `COGNEE_DATA_ROOT` / `COGNEE_SYSTEM_ROOT` at a private location.
 
 ### Optional settings
 
 | Setting | Env var | Default |
 | --- | --- | --- |
-| `dataset` | `COGNEE_DATASET` | `hermes` |
+| `dataset` | `COGNEE_PLUGIN_DATASET` (canonical) | `agent_sessions` |
 | `top_k` | `COGNEE_TOP_K` | `5` |
 | `auto_route` | `COGNEE_AUTO_ROUTE` | `true` |
 | `improve_on_end` | `COGNEE_IMPROVE_ON_END` | `true` |
@@ -146,19 +164,21 @@ COGNEE_DATASET=hermes
 | `embedded` | `COGNEE_EMBEDDED` | `false` |
 | `local_port` | `COGNEE_LOCAL_PORT` | `8011` |
 | `server_boot_timeout` | `COGNEE_SERVER_BOOT_TIMEOUT` | `30` |
-| `data_root` | `COGNEE_DATA_ROOT` | `$HERMES_HOME/cognee/data` |
-| `system_root` | `COGNEE_SYSTEM_ROOT` | `$HERMES_HOME/cognee/system` |
+| `data_root` | `COGNEE_DATA_ROOT` | `~/.cognee/data` |
+| `system_root` | `COGNEE_SYSTEM_ROOT` | `~/.cognee/system` |
 
-> **Storage is per profile, but a server is per port.** The roots above are scoped
-> to `HERMES_HOME`, so each Hermes profile gets its own store and `hermes backup`
-> can see it. A cognee server, though, belongs to whoever reaches its port first —
-> so two profiles left on the same `COGNEE_LOCAL_PORT` still share one store. Give
-> them separate ports if you want them apart. Roots pointed outside `HERMES_HOME`
-> with `COGNEE_DATA_ROOT` / `COGNEE_SYSTEM_ROOT` are reported to `hermes backup`
-> via `backup_paths()`, so they survive a backup/import cycle too.
+> **Storage is shared, and a server is per port.** The roots above are the ones
+> every cognee agent plugin pins, so the store is the same no matter which plugin
+> booted the server on 8011. Because the default roots live outside
+> `HERMES_HOME`, `backup_paths()` reports them to `hermes backup` — a profile
+> backup deliberately includes the machine's shared memory store. Roots you point
+> elsewhere with `COGNEE_DATA_ROOT` / `COGNEE_SYSTEM_ROOT` are reported the same
+> way (unless they sit inside `HERMES_HOME`, which `hermes backup` walks anyway).
 
-> `COGNEE_SERVICE_URL` is a deprecated alias for `COGNEE_BASE_URL`. It still works
-> (with lower precedence) but new setups should use `COGNEE_BASE_URL`.
+> `COGNEE_SERVICE_URL` is a deprecated alias for `COGNEE_BASE_URL`, and
+> `COGNEE_DATASET` (the 0.1.x name) a lower-precedence alias for
+> `COGNEE_PLUGIN_DATASET`. Both still work; new setups should use the canonical
+> names.
 
 > **`improve_background`** controls whether the session-end graph build
 > (`improve()`) runs in the background. Default `auto`: it backgrounds in

--- a/integrations/hermes-agent/after-install.md
+++ b/integrations/hermes-agent/after-install.md
@@ -8,6 +8,14 @@ Run:
 hermes memory setup
 ```
 
-Then select `cognee`. The setup flow can configure local embedded Cognee or a
-remote Cognee service.
+Then select `cognee` and pick a mode:
 
+- **local** — the plugin runs a cognee server on your machine (shared with the
+  Claude Code / Codex / OpenClaw cognee plugins, if you use them). You'll be
+  asked for an LLM API key, which cognee uses to build the knowledge graph.
+- **remote** — connect to Cognee Cloud or a self-hosted server. You'll be asked
+  for the service URL and an API key (for Cognee Cloud, both come from
+  https://platform.cognee.ai/).
+
+Start a new `hermes` session afterwards to activate memory, then verify with
+`hermes cognee status`.

--- a/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/after-install.md
+++ b/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/after-install.md
@@ -1,0 +1,21 @@
+# Cognee Hermes Memory Plugin
+
+The Cognee memory plugin has been installed.
+
+Run:
+
+```bash
+hermes memory setup
+```
+
+Then select `cognee` and pick a mode:
+
+- **local** — the plugin runs a cognee server on your machine (shared with the
+  Claude Code / Codex / OpenClaw cognee plugins, if you use them). You'll be
+  asked for an LLM API key, which cognee uses to build the knowledge graph.
+- **remote** — connect to Cognee Cloud or a self-hosted server. You'll be asked
+  for the service URL and an API key (for Cognee Cloud, both come from
+  https://platform.cognee.ai/).
+
+Start a new `hermes` session afterwards to activate memory, then verify with
+`hermes cognee status`.

--- a/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/cli.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/cli.py
@@ -1,0 +1,14 @@
+"""Directory-plugin CLI shim for Hermes Agent."""
+
+try:
+    from .cognee_integration_hermes.cli import cognee_command, register_cli
+except ImportError:  # pragma: no cover - supports direct path imports.
+    import sys
+    from pathlib import Path
+
+    plugin_dir = Path(__file__).resolve().parent
+    if str(plugin_dir) not in sys.path:
+        sys.path.insert(0, str(plugin_dir))
+    from cognee_integration_hermes.cli import cognee_command, register_cli
+
+__all__ = ["cognee_command", "register_cli"]

--- a/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/plugin.yaml
+++ b/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/plugin.yaml
@@ -1,0 +1,14 @@
+name: cognee
+kind: exclusive
+version: 0.2.0
+description: "Cognee memory provider for Hermes Agent: session-aware graph memory, recall, forget, and session-end improvement."
+pip_dependencies:
+  # Floor 1.2.1: the HTTP wire contract this plugin depends on
+  # (/api/v1/remember/entry, improve(session_ids)) first shipped there.
+  # Cap 1.4.0: the newest version verified against the test suite and a live
+  # server boot. Repo policy (scripts/check_version_pins.py) requires a bounded
+  # range rather than an exact pin; the lockfile resolves to 1.4.0.
+  - cognee>=1.2.1,<=1.4.0
+hooks:
+  - on_session_end
+  - on_memory_write

--- a/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/plugin.yaml
+++ b/integrations/hermes-agent/cognee_integration_hermes/_plugin_root/plugin.yaml
@@ -1,6 +1,6 @@
 name: cognee
 kind: exclusive
-version: 0.2.0
+version: 1.0.0
 description: "Cognee memory provider for Hermes Agent: session-aware graph memory, recall, forget, and session-end improvement."
 pip_dependencies:
   # Floor 1.2.1: the HTTP wire contract this plugin depends on

--- a/integrations/hermes-agent/cognee_integration_hermes/backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/backend.py
@@ -71,6 +71,14 @@ class MemoryBackend:
         """
         return None
 
+    def ensure_dataset(self, *, dataset: str, timeout: float) -> None:
+        """Make sure *dataset* exists (server transports only).
+
+        In-process transports need nothing: the SDK creates datasets on write,
+        and grants live in the same process. On a server, a recall-first session
+        against a fresh instance would otherwise hit a missing dataset.
+        """
+
     # -- operations --------------------------------------------------------
 
     def recall(

--- a/integrations/hermes-agent/cognee_integration_hermes/backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/backend.py
@@ -1,0 +1,483 @@
+"""The transport seam between the Hermes provider and cognee.
+
+The provider owns everything Hermes-shaped — scope routing, session-id
+derivation, tool envelopes, the circuit breaker, the write gating. A backend owns
+only *how the bytes reach cognee*. Keeping the split at exactly that line is what
+lets the transport change without touching a single Hermes semantic.
+
+The protocol is **synchronous** on purpose. cognee's SDK is async, so
+:class:`SdkBackend` owns the event-loop thread; an HTTP backend needs no loop at
+all. The provider therefore never learns that one of its transports happens to be
+async, and the bridge disappears with the backend that needs it.
+
+``SdkBackend`` is the in-process/served-SDK transport: it drives ``cognee.*``
+directly, and in served mode routes through the SDK's own ``CloudClient``. Note
+that this path silently drops ``session_ids`` on ``improve()`` (a CloudClient
+limitation) — the reason a direct-HTTP backend exists.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import logging
+import threading
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def has_cognee() -> bool:
+    """True when the cognee package is importable. Never imports it."""
+    return importlib.util.find_spec("cognee") is not None
+
+
+class MemoryBackend:
+    """How the provider reaches cognee.
+
+    Operations are required. The configuration hooks default to no-ops because
+    they only mean something to an in-process SDK: an HTTP transport has no local
+    model config, no local data roots, and no local user table.
+    """
+
+    # -- connection / lifecycle -------------------------------------------
+
+    def configure_models(self, *, llm_api_key: str, llm_model: str) -> None:
+        """Point the transport at an LLM (in-process transports only)."""
+
+    def configure_local_roots(self, *, data_root: str, system_root: str) -> None:
+        """Point the transport at local storage (in-process transports only)."""
+
+    def connect(self, *, url: str, api_key: str, timeout: float) -> None:
+        """Attach to a cognee instance at *url*."""
+        raise NotImplementedError
+
+    def resolve_identity(self, *, email: str, password: str, timeout: float) -> Any:
+        """Resolve the principal this transport writes as, if it owns one."""
+        return None
+
+    def close(self, *, timeout: float = 5.0) -> None:
+        """Release connections and background resources."""
+
+    # -- operations --------------------------------------------------------
+
+    def recall(
+        self,
+        *,
+        query: str,
+        session_id: Optional[str],
+        datasets: Optional[list[str]],
+        top_k: int,
+        auto_route: bool,
+        query_type: Optional[str],
+        timeout: float,
+    ) -> list[Any]:
+        raise NotImplementedError
+
+    def remember_session(self, *, text: str, session_id: str, dataset: str, timeout: float) -> Any:
+        """Store a turn in the session cache (cheap, no graph extraction)."""
+        raise NotImplementedError
+
+    def remember_permanent(
+        self, *, text: str, dataset: str, session_ids: list[str], timeout: float
+    ) -> Any:
+        """Store content in the permanent graph."""
+        raise NotImplementedError
+
+    def forget(
+        self,
+        *,
+        dataset: Optional[str],
+        everything: bool,
+        memory_only: bool,
+        timeout: float,
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def improve(
+        self, *, dataset: str, session_ids: list[str], background: bool, timeout: float
+    ) -> Any:
+        """Bridge session-cache content into the permanent graph."""
+        raise NotImplementedError
+
+    # -- diagnostics -------------------------------------------------------
+
+    def empty_recall_hint(self, *, timeout: float = 5.0) -> Optional[str]:
+        """A reason recall *structurally* could not match, or None.
+
+        Called only when a recall comes back empty, to distinguish a genuine miss
+        from a misconfiguration. Best-effort: never raises.
+        """
+        return None
+
+
+class _AsyncBridge:
+    """Run cognee's async SDK from the provider's synchronous interface."""
+
+    def __init__(self) -> None:
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+
+    def _ensure_loop(self) -> None:
+        with self._lock:
+            if self._loop is not None and self._loop.is_running():
+                return
+            self._loop = asyncio.new_event_loop()
+            self._thread = threading.Thread(
+                target=self._loop.run_forever,
+                daemon=True,
+                name="cognee-hermes-event-loop",
+            )
+            self._thread.start()
+
+    def run(self, coro, timeout: float):
+        self._ensure_loop()
+        assert self._loop is not None
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result(timeout=timeout)
+
+    def shutdown(self) -> None:
+        with self._lock:
+            if self._loop and self._loop.is_running():
+                self._loop.call_soon_threadsafe(self._loop.stop)
+            if self._thread and self._thread.is_alive():
+                self._thread.join(timeout=5.0)
+            self._loop = None
+            self._thread = None
+
+
+class SdkBackend(MemoryBackend):
+    """Drives the cognee Python SDK, either in-process or via ``cognee.serve()``.
+
+    ``served`` records whether :meth:`connect` ran. It gates two things that only
+    make sense in-process: the local user identity (a served instance owns
+    identity via the api-key principal) and the embedding-dimension probe (a
+    served instance owns the vector store).
+    """
+
+    def __init__(self) -> None:
+        self._bridge = _AsyncBridge()
+        self._user: Any = None
+        self.served = False
+
+    @property
+    def user(self) -> Any:
+        return self._user
+
+    # -- connection / lifecycle -------------------------------------------
+
+    def configure_models(self, *, llm_api_key: str, llm_model: str) -> None:
+        try:
+            import cognee
+
+            if llm_api_key:
+                cognee.config.set_llm_api_key(str(llm_api_key))
+            if llm_model:
+                cognee.config.set_llm_model(str(llm_model))
+        except Exception as exc:
+            logger.debug("Cognee model configuration failed: %s", exc)
+
+    def configure_local_roots(self, *, data_root: str, system_root: str) -> None:
+        try:
+            import cognee
+
+            cognee.config.data_root_directory(str(data_root))
+            cognee.config.system_root_directory(str(system_root))
+        except Exception as exc:
+            logger.debug("Cognee root configuration failed: %s", exc)
+
+    def connect(self, *, url: str, api_key: str, timeout: float) -> None:
+        self._bridge.run(self._do_serve(url, api_key), timeout=timeout)
+        self.served = True
+
+    def resolve_identity(self, *, email: str, password: str, timeout: float) -> Any:
+        self._user = self._bridge.run(self._ensure_identity(email, password), timeout=timeout)
+        return self._user
+
+    def close(self, *, timeout: float = 5.0) -> None:
+        if self.served:
+            try:
+                self._bridge.run(self._do_disconnect(), timeout=timeout)
+            except Exception:
+                pass
+        self._bridge.shutdown()
+
+    # -- operations --------------------------------------------------------
+
+    def recall(
+        self,
+        *,
+        query,
+        session_id,
+        datasets,
+        top_k,
+        auto_route,
+        query_type,
+        timeout,
+    ) -> list[Any]:
+        return self._bridge.run(
+            self._do_recall(query, session_id, datasets, top_k, auto_route, query_type),
+            timeout=timeout,
+        )
+
+    def remember_session(self, *, text, session_id, dataset, timeout) -> Any:
+        return self._bridge.run(
+            self._do_remember_session(text, session_id, dataset), timeout=timeout
+        )
+
+    def remember_permanent(self, *, text, dataset, session_ids, timeout) -> Any:
+        return self._bridge.run(
+            self._do_remember_permanent(text, dataset, session_ids), timeout=timeout
+        )
+
+    def forget(self, *, dataset, everything, memory_only, timeout) -> dict[str, Any]:
+        return self._bridge.run(
+            self._do_forget(dataset, everything=everything, memory_only=memory_only),
+            timeout=timeout,
+        )
+
+    def improve(self, *, dataset, session_ids, background, timeout) -> Any:
+        return self._bridge.run(
+            self._do_improve(dataset, session_ids, run_in_background=background),
+            timeout=timeout,
+        )
+
+    # -- diagnostics -------------------------------------------------------
+
+    def empty_recall_hint(self, *, timeout: float = 5.0) -> Optional[str]:
+        """Confirmed embedding-dimension mismatch, or None. In-process only.
+
+        A served instance owns the vector store, so introspecting the local
+        in-process engine would be meaningless — skip.
+        """
+        if self.served:
+            return None
+        try:
+            return self._bridge.run(dimension_mismatch_hint(), timeout=timeout)
+        except Exception:
+            return None
+
+    # -- the async SDK surface ---------------------------------------------
+
+    def _add_user_kwarg(self, kwargs: dict[str, Any]) -> None:
+        """Inject the local user only when running in-process.
+
+        In served mode the instance owns identity (api-key principal) and
+        ``self._user`` is None. Passing ``user=None`` is not the same as omitting
+        the key — the SDK may treat an explicit None differently (overriding a
+        default, affecting tenant scoping) — so we omit it entirely instead.
+        """
+        if not self.served and self._user is not None:
+            kwargs["user"] = self._user
+
+    async def _ensure_identity(self, email: str, password: str):
+        try:
+            from cognee.modules.users.methods import (
+                create_user,
+                get_default_user,
+                get_user_by_email,
+            )
+        except Exception:
+            return None
+
+        user = await get_user_by_email(email)
+        if user:
+            return user
+        try:
+            return await create_user(
+                email=email,
+                password=password,
+                is_verified=True,
+                is_active=True,
+            )
+        except Exception:
+            user = await get_user_by_email(email)
+            if user:
+                return user
+            return await get_default_user()
+
+    async def _do_serve(self, url: str, api_key: str):
+        import cognee
+
+        kwargs = {"url": url}
+        if api_key:
+            kwargs["api_key"] = api_key
+        return await cognee.serve(**kwargs)
+
+    async def _do_disconnect(self):
+        import cognee
+
+        return await cognee.disconnect()
+
+    async def _do_recall(
+        self,
+        query: str,
+        session_id: Optional[str],
+        datasets: Optional[list[str]],
+        top_k: int,
+        auto_route: bool,
+        query_type: Optional[str],
+    ) -> list[Any]:
+        import cognee
+
+        kwargs: dict[str, Any] = {
+            "top_k": top_k,
+            "auto_route": auto_route,
+        }
+        self._add_user_kwarg(kwargs)
+        if session_id is not None:
+            kwargs["session_id"] = session_id
+        if datasets is not None:
+            kwargs["datasets"] = datasets
+        if query_type:
+            kwargs["query_type"] = resolve_search_type(query_type)
+
+        return await cognee.recall(query_text=query, **kwargs)
+
+    async def _do_remember_session(self, content: str, session_id: str, dataset: str):
+        import cognee
+
+        kwargs: dict[str, Any] = {
+            "data": content,
+            "dataset_name": dataset,
+            "session_id": session_id,
+            "self_improvement": False,
+        }
+        self._add_user_kwarg(kwargs)
+        return await cognee.remember(**kwargs)
+
+    async def _do_remember_permanent(self, content: str, dataset: str, session_ids: list[str]):
+        import cognee
+
+        kwargs: dict[str, Any] = {
+            "data": content,
+            "dataset_name": dataset,
+            "self_improvement": True,
+            "session_ids": session_ids,
+        }
+        self._add_user_kwarg(kwargs)
+        return await cognee.remember(**kwargs)
+
+    async def _do_forget(
+        self,
+        dataset: Optional[str],
+        *,
+        everything: bool = False,
+        memory_only: bool = False,
+    ) -> dict[str, Any]:
+        import cognee
+
+        kwargs: dict[str, Any] = {
+            "everything": everything,
+            "memory_only": memory_only,
+        }
+        if dataset and not everything:
+            kwargs["dataset"] = dataset
+        self._add_user_kwarg(kwargs)
+        return await cognee.forget(**kwargs)
+
+    async def _do_improve(
+        self, dataset: str, session_ids: list[str], run_in_background: bool = False
+    ):
+        import cognee
+
+        kwargs: dict[str, Any] = {
+            "dataset": dataset,
+            "session_ids": session_ids,
+            "run_in_background": run_in_background,
+        }
+        self._add_user_kwarg(kwargs)
+        return await cognee.improve(**kwargs)
+
+
+# --- Embedding-dimension mismatch detection ---------------------------------
+# When the embedding model changes between writing and reading, stored vectors
+# and query vectors differ in size, so recall silently matches nothing. These
+# helpers turn that silent miss into a one-line actionable error naming both
+# dimensions and the active embedder. Best-effort and fail-safe (any uncertainty
+# returns None). Only valid in-process, where this process owns the vector store;
+# a served instance owns it and the in-process engine here would not reflect it.
+
+
+async def sample_stored_vector_dim(engine) -> Optional[int]:
+    """Sample the dimension of a stored vector from any populated collection, or None.
+
+    Enumerates the store's actual collections via the vector interface's
+    ``get_connection().table_names()`` (the same path cognee's own ``has_collection``
+    uses) rather than assuming fixed collection names, so it also covers custom
+    pipelines. Never raises: each collection is probed independently and any
+    unreadable one is skipped. Covers cognee's default local backend (LanceDB); other
+    backends whose connection can't enumerate return None and fall back to the normal
+    empty-recall path.
+    """
+    try:
+        connection = await engine.get_connection()
+        names = await connection.table_names()
+    except Exception:
+        return None
+    for name in names:
+        try:
+            collection = await engine.get_collection(name)
+            rows = await collection.query().limit(1).to_list()
+            if rows:
+                vector = rows[0].get("vector")
+                if vector is not None:
+                    return len(vector)
+        except Exception:
+            continue
+    return None
+
+
+async def dimension_mismatch_hint(engine=None) -> Optional[str]:
+    """One-line diagnostic when the stored vectors differ in size from the active
+    embedder's query vectors (so recall can never match), else None.
+
+    ``engine`` is injectable for testing. Best-effort and fail-safe: any error, or
+    an indeterminate/matching dimension, returns None so the caller keeps the
+    normal empty-recall behavior.
+    """
+    try:
+        if engine is None:
+            from cognee.infrastructure.databases.vector import get_vector_engine
+
+            engine = get_vector_engine()
+        embed = getattr(engine, "embedding_engine", None)
+        if embed is None:
+            return None
+        query_dim = int(embed.get_vector_size())
+        stored_dim = await sample_stored_vector_dim(engine)
+        if not stored_dim or not query_dim or stored_dim == query_dim:
+            return None
+        model = getattr(embed, "model", None) or "unknown-model"
+        provider = getattr(embed, "provider", None) or "unknown-provider"
+        return (
+            "Cognee recall found nothing because the embedder changed: stored vectors are "
+            f"{stored_dim}-d but the active embedder '{model}' (provider '{provider}') produces "
+            f"{query_dim}-d queries. Re-index this data with the current embedder, or set "
+            f"EMBEDDING_MODEL/EMBEDDING_DIMENSIONS back to the {stored_dim}-d model that wrote it."
+        )
+    except Exception:
+        return None
+
+
+def resolve_search_type(search_type: str):
+    """Map a search-type name onto cognee's ``SearchType``, defaulting sanely.
+
+    An unrecognized name falls back to ``GRAPH_COMPLETION`` rather than failing the
+    recall. Kept in the backend so the provider needs no cognee import — and so a
+    future cognee search type keeps working without a provider change.
+    """
+    from cognee.modules.search.types import SearchType
+
+    key = str(search_type).upper().strip()
+    return getattr(SearchType, key, SearchType.GRAPH_COMPLETION)
+
+
+def default_backend() -> MemoryBackend:
+    """The transport used when none is injected.
+
+    Step 3 turns this into a config-driven choice between the SDK and a direct
+    HTTP backend; today there is only one.
+    """
+    return SdkBackend()

--- a/integrations/hermes-agent/cognee_integration_hermes/backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/backend.py
@@ -24,6 +24,8 @@ import logging
 import threading
 from typing import Any, Optional
 
+from .config import str_to_bool
+
 logger = logging.getLogger(__name__)
 
 
@@ -477,22 +479,35 @@ def resolve_search_type(search_type: str):
 def build_backend(config: Optional[dict[str, Any]] = None, *, hermes_home: str = ""):
     """Pick a transport from config.
 
-    ``COGNEE_TRANSPORT=http`` selects the direct-HTTP transport, which is the one
-    the other cognee plugins use and the only one that sends ``session_ids`` on
-    ``improve()``. The SDK transport remains the default until it has been
-    verified against a live server; it is also the only one that can run cognee
-    in-process (``COGNEE_EMBEDDED=true``).
+    Direct HTTP is the default: it is what the other cognee plugins use, and the
+    only transport that sends ``session_ids`` on ``improve()`` — the SDK's
+    ``CloudClient`` drops them, so the session-to-graph bridge silently becomes a
+    dataset-wide improve.
+
+    The SDK transport is selected by ``COGNEE_EMBEDDED=true``, which it is the only
+    one able to serve (it runs cognee in this process, with no server involved), or
+    explicitly by ``COGNEE_TRANSPORT=sdk`` for a like-for-like comparison.
     """
     config = config or {}
     transport = str(config.get("transport") or "").strip().lower()
-    if transport in {"http", "direct"}:
-        from .http_backend import HttpBackend
+    if transport in {"sdk", "cognee"}:
+        return SdkBackend()
+    # Embedded means "no server" — only the in-process SDK can do that, so it wins
+    # over the default regardless of transport.
+    if str_to_bool(config.get("embedded"), False):
+        return SdkBackend()
 
-        # cache_dir keeps a minted API key profile-scoped.
-        return HttpBackend(cache_dir=hermes_home or None)
-    return SdkBackend()
+    from .http_backend import HttpBackend
+
+    # cache_dir keeps a minted API key profile-scoped.
+    return HttpBackend(cache_dir=hermes_home or None)
 
 
 def default_backend() -> MemoryBackend:
-    """The transport used when the provider is constructed without one."""
+    """The transport used before config is loaded, or when none is injected.
+
+    Deliberately the SDK: it needs no URL, no key and no reachable server, so
+    constructing a provider is side-effect free. ``initialize()`` replaces it with
+    the configured transport once it knows what to build.
+    """
     return SdkBackend()

--- a/integrations/hermes-agent/cognee_integration_hermes/backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/backend.py
@@ -474,10 +474,25 @@ def resolve_search_type(search_type: str):
     return getattr(SearchType, key, SearchType.GRAPH_COMPLETION)
 
 
-def default_backend() -> MemoryBackend:
-    """The transport used when none is injected.
+def build_backend(config: Optional[dict[str, Any]] = None, *, hermes_home: str = ""):
+    """Pick a transport from config.
 
-    Step 3 turns this into a config-driven choice between the SDK and a direct
-    HTTP backend; today there is only one.
+    ``COGNEE_TRANSPORT=http`` selects the direct-HTTP transport, which is the one
+    the other cognee plugins use and the only one that sends ``session_ids`` on
+    ``improve()``. The SDK transport remains the default until it has been
+    verified against a live server; it is also the only one that can run cognee
+    in-process (``COGNEE_EMBEDDED=true``).
     """
+    config = config or {}
+    transport = str(config.get("transport") or "").strip().lower()
+    if transport in {"http", "direct"}:
+        from .http_backend import HttpBackend
+
+        # cache_dir keeps a minted API key profile-scoped.
+        return HttpBackend(cache_dir=hermes_home or None)
+    return SdkBackend()
+
+
+def default_backend() -> MemoryBackend:
+    """The transport used when the provider is constructed without one."""
     return SdkBackend()

--- a/integrations/hermes-agent/cognee_integration_hermes/backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/backend.py
@@ -62,6 +62,15 @@ class MemoryBackend:
     def close(self, *, timeout: float = 5.0) -> None:
         """Release connections and background resources."""
 
+    def connection_info(self) -> Optional[dict[str, Any]]:
+        """How to reach the server this transport is attached to, if that server
+        outlives this process (``url``, ``api_key``, ``agent_session_name``).
+
+        None for in-process transports — there is nothing to close out after the
+        process dies. The provider uses this to arm the crash-safe exit watcher.
+        """
+        return None
+
     # -- operations --------------------------------------------------------
 
     def recall(

--- a/integrations/hermes-agent/cognee_integration_hermes/backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/backend.py
@@ -484,7 +484,7 @@ def resolve_search_type(search_type: str):
     return getattr(SearchType, key, SearchType.GRAPH_COMPLETION)
 
 
-def build_backend(config: Optional[dict[str, Any]] = None, *, hermes_home: str = ""):
+def build_backend(config: Optional[dict[str, Any]] = None):
     """Pick a transport from config.
 
     Direct HTTP is the default: it is what the other cognee plugins use, and the
@@ -507,8 +507,7 @@ def build_backend(config: Optional[dict[str, Any]] = None, *, hermes_home: str =
 
     from .http_backend import HttpBackend
 
-    # cache_dir keeps a minted API key profile-scoped.
-    return HttpBackend(cache_dir=hermes_home or None)
+    return HttpBackend()
 
 
 def default_backend() -> MemoryBackend:

--- a/integrations/hermes-agent/cognee_integration_hermes/backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/backend.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import logging
+import os
 import threading
 from typing import Any, Optional
 
@@ -181,6 +182,13 @@ class SdkBackend(MemoryBackend):
             logger.debug("Cognee model configuration failed: %s", exc)
 
     def configure_local_roots(self, *, data_root: str, system_root: str) -> None:
+        # Embedded mode runs cognee's session manager in *this* process, and it is
+        # gated on CACHING: without it a session write is silently dropped while
+        # still reporting success, so turns never reach the graph. The spawned
+        # server gets the same flags in server_bootstrap._spawn. setdefault so an
+        # explicit user value wins.
+        for key, value in (("CACHING", "true"), ("AUTO_FEEDBACK", "true")):
+            os.environ.setdefault(key, value)
         try:
             import cognee
 

--- a/integrations/hermes-agent/cognee_integration_hermes/cli.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/cli.py
@@ -20,13 +20,38 @@ def _provider_active() -> bool:
         return False
 
 
+def _installed_plugin_version() -> str:
+    """The version of the plugin copy this code runs from (its plugin.yaml)."""
+    manifest = Path(__file__).resolve().parents[1] / "plugin.yaml"
+    try:
+        for line in manifest.read_text(encoding="utf-8").splitlines():
+            if line.startswith("version:"):
+                return line.split(":", 1)[1].strip().strip("\"'")
+    except OSError:
+        pass
+    return ""
+
+
+def _pip_package_version() -> str:
+    """The pip-installed package version, if the package is in this env."""
+    try:
+        from importlib.metadata import version
+
+        return version("cognee-integration-hermes-agent")
+    except Exception:
+        return ""
+
+
 def _print_status(args) -> None:
     cfg = load_config()
     path = config_path()
+    plugin_version = _installed_plugin_version()
+    pip_version = _pip_package_version()
     print("\nCognee memory")
     print("-" * 40)
     print(f"  Active provider: {'yes' if _provider_active() else 'no'}")
     print(f"  Cognee package:  {'installed' if importlib.util.find_spec('cognee') else 'missing'}")
+    print(f"  Plugin version:  {plugin_version or '(unknown)'}")
     print(f"  Mode:            {'remote' if cfg.get('service_url') else 'local'}")
     print(f"  Dataset:         {cfg.get('dataset')}")
     print(f"  Config:          {path or '(unknown)'}")
@@ -34,6 +59,13 @@ def _print_status(args) -> None:
     print(f"  LLM key:         {'set' if cfg.get('llm_api_key') else 'missing'}")
     print(f"  API key:         {'set' if cfg.get('api_key') else 'missing'}")
     print(f"  Improve on end:  {cfg.get('improve_on_end')}")
+    if pip_version and plugin_version and pip_version != plugin_version:
+        # Hermes runs the copy under HERMES_HOME/plugins, so `pip install -U`
+        # alone changes nothing until the installer refreshes that copy.
+        print(
+            f"  Update:          pip package is {pip_version} but this installed copy "
+            f"is {plugin_version} — run `cognee-hermes-install` to update"
+        )
     print()
 
 
@@ -57,15 +89,13 @@ def _run_setup(args) -> None:
 
 def _print_install(args) -> None:
     here = Path(__file__).resolve().parents[1]
-    print("\nInstall as a local Hermes directory plugin:")
+    print("\nInstall via pip (recommended):")
+    print("  pip install cognee-integration-hermes-agent")
+    print("  cognee-hermes-install     # copies the plugin into $HERMES_HOME/plugins")
+    print("  hermes memory setup")
+    print("\nInstall as a local Hermes directory plugin (from a checkout):")
     print("  mkdir -p ~/.hermes/plugins/cognee")
     print(f"  cp -R {here}/. ~/.hermes/plugins/cognee/")
-    print("  hermes memory setup")
-    print("\nInstall from a standalone git repo once published:")
-    print("  hermes plugins install <owner>/<repo>")
-    print("  hermes memory setup")
-    print("\nInstall via pip:")
-    print("  pip install cognee-integration-hermes-agent")
     print("  hermes memory setup\n")
 
 

--- a/integrations/hermes-agent/cognee_integration_hermes/config.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/config.py
@@ -18,6 +18,13 @@ SHARED_COGNEE_HOME = Path.home() / ".cognee"
 # and deliberately avoids cognee's own default of 8000, so we never attach to —
 # or contend with — a server the user is running themselves.
 DEFAULT_LOCAL_PORT = 8011
+# How long a boot may take before giving up, matching the other plugins'
+# COGNEE_SERVER_BOOT_DEADLINE. A *first* boot runs DB migrations and store
+# initialization and can take minutes on a slow machine; giving up early leaves
+# memory off for the whole session even though the server finishes booting
+# moments later. A genuinely broken spawn never waits this out — the bootstrap
+# fails fast once the child is dead and nothing owns the port.
+DEFAULT_SERVER_BOOT_TIMEOUT = 600
 DEFAULT_IDENTITY_EMAIL = "hermes-agent@cognee.local"
 DEFAULT_IDENTITY_PASSWORD = "hermes-agent-plugin"
 
@@ -95,7 +102,9 @@ def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
         # direct REST client the other cognee plugins use. See backend.build_backend.
         "transport": os.environ.get("COGNEE_TRANSPORT", ""),
         "local_port": str_to_int(os.environ.get("COGNEE_LOCAL_PORT"), DEFAULT_LOCAL_PORT),
-        "server_boot_timeout": str_to_int(os.environ.get("COGNEE_SERVER_BOOT_TIMEOUT"), 30),
+        "server_boot_timeout": str_to_int(
+            os.environ.get("COGNEE_SERVER_BOOT_TIMEOUT"), DEFAULT_SERVER_BOOT_TIMEOUT
+        ),
         # COGNEE_PLUGIN_DATASET is the name the other cognee plugins read;
         # COGNEE_DATASET is this plugin's 0.1.x name, kept as an alias.
         "dataset": os.environ.get("COGNEE_PLUGIN_DATASET")
@@ -137,7 +146,9 @@ def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
     config["local_port"] = min(
         65535, max(1, str_to_int(config.get("local_port"), DEFAULT_LOCAL_PORT))
     )
-    config["server_boot_timeout"] = max(1, str_to_int(config.get("server_boot_timeout"), 30))
+    config["server_boot_timeout"] = max(
+        1, str_to_int(config.get("server_boot_timeout"), DEFAULT_SERVER_BOOT_TIMEOUT)
+    )
     config["auto_route"] = str_to_bool(config.get("auto_route"), True)
     config["improve_on_end"] = str_to_bool(config.get("improve_on_end"), True)
     config["embedded"] = str_to_bool(config.get("embedded"), False)

--- a/integrations/hermes-agent/cognee_integration_hermes/config.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/config.py
@@ -62,6 +62,9 @@ def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
         # embedded=true runs cognee in-process (single-process/offline only);
         # otherwise local mode ensures a local server on local_port (DB-safe).
         "embedded": str_to_bool(os.environ.get("COGNEE_EMBEDDED"), False),
+        # Which transport reaches cognee: "" / "sdk" (default) or "http" for the
+        # direct REST client the other cognee plugins use. See backend.build_backend.
+        "transport": os.environ.get("COGNEE_TRANSPORT", ""),
         "local_port": str_to_int(os.environ.get("COGNEE_LOCAL_PORT"), 8000),
         "server_boot_timeout": str_to_int(os.environ.get("COGNEE_SERVER_BOOT_TIMEOUT"), 30),
         "dataset": os.environ.get("COGNEE_DATASET", DEFAULT_DATASET),

--- a/integrations/hermes-agent/cognee_integration_hermes/config.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/config.py
@@ -8,6 +8,11 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_DATASET = "hermes"
+# Port for the local cognee server this plugin spawns and owns. 8011 matches the
+# other cognee agent plugins (claude-code, codex, openclaw) and deliberately avoids
+# cognee's own default of 8000, so we never attach to — or contend with — a server
+# the user is running themselves.
+DEFAULT_LOCAL_PORT = 8011
 DEFAULT_IDENTITY_EMAIL = "hermes-agent@cognee.local"
 DEFAULT_IDENTITY_PASSWORD = "hermes-agent-plugin"
 
@@ -65,7 +70,7 @@ def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
         # Which transport reaches cognee: "" / "sdk" (default) or "http" for the
         # direct REST client the other cognee plugins use. See backend.build_backend.
         "transport": os.environ.get("COGNEE_TRANSPORT", ""),
-        "local_port": str_to_int(os.environ.get("COGNEE_LOCAL_PORT"), 8000),
+        "local_port": str_to_int(os.environ.get("COGNEE_LOCAL_PORT"), DEFAULT_LOCAL_PORT),
         "server_boot_timeout": str_to_int(os.environ.get("COGNEE_SERVER_BOOT_TIMEOUT"), 30),
         "dataset": os.environ.get("COGNEE_DATASET", DEFAULT_DATASET),
         "top_k": str_to_int(os.environ.get("COGNEE_TOP_K"), 5),
@@ -102,7 +107,9 @@ def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
     config["recall_timeout"] = max(1, str_to_int(config.get("recall_timeout"), 120))
     config["write_timeout"] = max(1, str_to_int(config.get("write_timeout"), 120))
     config["improve_timeout"] = max(1, str_to_int(config.get("improve_timeout"), 300))
-    config["local_port"] = min(65535, max(1, str_to_int(config.get("local_port"), 8000)))
+    config["local_port"] = min(
+        65535, max(1, str_to_int(config.get("local_port"), DEFAULT_LOCAL_PORT))
+    )
     config["server_boot_timeout"] = max(1, str_to_int(config.get("server_boot_timeout"), 30))
     config["auto_route"] = str_to_bool(config.get("auto_route"), True)
     config["improve_on_end"] = str_to_bool(config.get("improve_on_end"), True)

--- a/integrations/hermes-agent/cognee_integration_hermes/config.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/config.py
@@ -53,6 +53,35 @@ def config_path(hermes_home: str | Path | None = None) -> Path | None:
     return home / "cognee.json" if home else None
 
 
+def resolve_local_roots(
+    config: dict[str, Any], hermes_home: str | Path | None = None
+) -> tuple[str, str]:
+    """Where cognee should keep its data and system directories.
+
+    Explicit ``COGNEE_DATA_ROOT`` / ``COGNEE_SYSTEM_ROOT`` win. Otherwise both are
+    scoped under ``HERMES_HOME``, which Hermes requires of plugin storage: two
+    profiles must not share one store, and ``hermes backup`` only walks
+    ``HERMES_HOME``.
+
+    Returns ``("", "")`` when there is nothing to say — no explicit config and no
+    resolvable home — leaving cognee's own defaults in place.
+
+    Note this is per *profile*, not per process. A cognee server is shared by
+    whoever reaches its port first, so two profiles on the same
+    ``COGNEE_LOCAL_PORT`` still end up on one store; give them separate ports to
+    keep them apart.
+    """
+    home = resolve_hermes_home(hermes_home)
+    data_root = str(config.get("data_root") or "")
+    system_root = str(config.get("system_root") or "")
+    if home is not None:
+        if not data_root:
+            data_root = str(home / "cognee" / "data")
+        if not system_root:
+            system_root = str(home / "cognee" / "system")
+    return data_root, system_root
+
+
 def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
     """Load plugin config from environment variables and HERMES_HOME/cognee.json."""
     # COGNEE_BASE_URL is the canonical name; COGNEE_SERVICE_URL is a deprecated alias

--- a/integrations/hermes-agent/cognee_integration_hermes/config.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/config.py
@@ -7,11 +7,16 @@ import os
 from pathlib import Path
 from typing import Any
 
-DEFAULT_DATASET = "hermes"
-# Port for the local cognee server this plugin spawns and owns. 8011 matches the
-# other cognee agent plugins (claude-code, codex, openclaw) and deliberately avoids
-# cognee's own default of 8000, so we never attach to — or contend with — a server
-# the user is running themselves.
+# The other cognee agent plugins (claude-code, codex, openclaw) share one brain:
+# one dataset, one store under ~/.cognee, one server on 8011, one minted API key
+# under ~/.cognee-plugin. Hermes joins that convention — same names, same paths —
+# so memory written in any of them is recalled in all of them.
+DEFAULT_DATASET = "agent_sessions"
+SHARED_PLUGIN_STATE_DIR = Path.home() / ".cognee-plugin"
+SHARED_COGNEE_HOME = Path.home() / ".cognee"
+# Port for the local cognee server. 8011 matches the other cognee agent plugins
+# and deliberately avoids cognee's own default of 8000, so we never attach to —
+# or contend with — a server the user is running themselves.
 DEFAULT_LOCAL_PORT = 8011
 DEFAULT_IDENTITY_EMAIL = "hermes-agent@cognee.local"
 DEFAULT_IDENTITY_PASSWORD = "hermes-agent-plugin"
@@ -53,32 +58,22 @@ def config_path(hermes_home: str | Path | None = None) -> Path | None:
     return home / "cognee.json" if home else None
 
 
-def resolve_local_roots(
-    config: dict[str, Any], hermes_home: str | Path | None = None
-) -> tuple[str, str]:
+def resolve_local_roots(config: dict[str, Any]) -> tuple[str, str]:
     """Where cognee should keep its data and system directories.
 
-    Explicit ``COGNEE_DATA_ROOT`` / ``COGNEE_SYSTEM_ROOT`` win. Otherwise both are
-    scoped under ``HERMES_HOME``, which Hermes requires of plugin storage: two
-    profiles must not share one store, and ``hermes backup`` only walks
-    ``HERMES_HOME``.
+    Explicit ``COGNEE_DATA_ROOT`` / ``COGNEE_SYSTEM_ROOT`` win. Otherwise both
+    default to ``~/.cognee/{data,system}`` — the exact roots the claude-code,
+    codex and openclaw plugins pin — so every plugin's server serves the same
+    store no matter which of them booted it first.
 
-    Returns ``("", "")`` when there is nothing to say — no explicit config and no
-    resolvable home — leaving cognee's own defaults in place.
-
-    Note this is per *profile*, not per process. A cognee server is shared by
-    whoever reaches its port first, so two profiles on the same
-    ``COGNEE_LOCAL_PORT`` still end up on one store; give them separate ports to
-    keep them apart.
+    The trade-off is deliberate: memory is shared across agents *and* across
+    Hermes profiles by default. To isolate a profile, point
+    ``COGNEE_DATA_ROOT`` / ``COGNEE_SYSTEM_ROOT`` somewhere else and give it its
+    own ``COGNEE_LOCAL_PORT`` — a server belongs to whoever reaches its port
+    first, so shared port means shared store regardless of these roots.
     """
-    home = resolve_hermes_home(hermes_home)
-    data_root = str(config.get("data_root") or "")
-    system_root = str(config.get("system_root") or "")
-    if home is not None:
-        if not data_root:
-            data_root = str(home / "cognee" / "data")
-        if not system_root:
-            system_root = str(home / "cognee" / "system")
+    data_root = str(config.get("data_root") or "") or str(SHARED_COGNEE_HOME / "data")
+    system_root = str(config.get("system_root") or "") or str(SHARED_COGNEE_HOME / "system")
     return data_root, system_root
 
 
@@ -101,7 +96,10 @@ def load_config(hermes_home: str | Path | None = None) -> dict[str, Any]:
         "transport": os.environ.get("COGNEE_TRANSPORT", ""),
         "local_port": str_to_int(os.environ.get("COGNEE_LOCAL_PORT"), DEFAULT_LOCAL_PORT),
         "server_boot_timeout": str_to_int(os.environ.get("COGNEE_SERVER_BOOT_TIMEOUT"), 30),
-        "dataset": os.environ.get("COGNEE_DATASET", DEFAULT_DATASET),
+        # COGNEE_PLUGIN_DATASET is the name the other cognee plugins read;
+        # COGNEE_DATASET is this plugin's 0.1.x name, kept as an alias.
+        "dataset": os.environ.get("COGNEE_PLUGIN_DATASET")
+        or os.environ.get("COGNEE_DATASET", DEFAULT_DATASET),
         "top_k": str_to_int(os.environ.get("COGNEE_TOP_K"), 5),
         "auto_route": str_to_bool(os.environ.get("COGNEE_AUTO_ROUTE"), True),
         "improve_on_end": str_to_bool(os.environ.get("COGNEE_IMPROVE_ON_END"), True),

--- a/integrations/hermes-agent/cognee_integration_hermes/exit_watcher.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/exit_watcher.py
@@ -38,6 +38,7 @@ _SHARED_KEY_CACHE = Path.home() / ".cognee-plugin" / "api_key.json"
 
 _DEFAULT_POLL_SECONDS = 2.0
 _UNREGISTER_TIMEOUT = 15.0
+_WINDOWS = os.name == "nt"
 
 
 # --- state file ---------------------------------------------------------------
@@ -65,8 +66,25 @@ def write_state(state_path, state):
 
 
 def pid_alive(pid):
+    """True when *pid* is a live process.
+
+    POSIX probes with signal 0, which touches nothing. Windows MUST NOT go
+    through ``os.kill``: CPython implements non-console signals there as
+    ``OpenProcess`` + ``TerminateProcess`` — "probing" would kill the very
+    Hermes this watcher is guarding — so it queries the process handle instead.
+    """
     try:
-        os.kill(int(pid), 0)
+        pid = int(pid)
+    except (TypeError, ValueError):
+        return False
+    if pid <= 0:
+        # POSIX gives pid<=0 group/broadcast semantics; never treat those as
+        # "a process worth waiting on".
+        return False
+    if _WINDOWS:
+        return _pid_alive_windows(pid)
+    try:
+        os.kill(pid, 0)
     except ProcessLookupError:
         return False
     except PermissionError:
@@ -74,6 +92,37 @@ def pid_alive(pid):
     except Exception:
         return False
     return True
+
+
+def _pid_alive_windows(pid):
+    import ctypes
+    from ctypes import wintypes
+
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    STILL_ACTIVE = 259
+    ERROR_ACCESS_DENIED = 5
+
+    try:
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            # Access denied means the pid exists but belongs to someone else.
+            return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+        try:
+            exit_code = wintypes.DWORD()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return False
+            # Documented Windows ambiguity: a process that exited with the
+            # literal code 259 reads as alive. Acceptable for a 2s poll —
+            # the watcher just fires one poll later than it could have.
+            return exit_code.value == STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
+    except Exception:
+        # An identity we cannot determine is treated as alive: firing improve/
+        # unregister against a session that is still running is worse than
+        # firing late.
+        return True
 
 
 # --- the provider-facing API ---------------------------------------------------

--- a/integrations/hermes-agent/cognee_integration_hermes/exit_watcher.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/exit_watcher.py
@@ -1,0 +1,271 @@
+"""Crash insurance for a Hermes session: improve-then-unregister on unclean death.
+
+The provider already closes a session properly — ``on_session_end`` bridges the
+session cache into the graph and ``shutdown`` unregisters the agent connection.
+But none of that runs when Hermes crashes or is killed, and then two things leak:
+the agent registration (so the server's ``COGNEE_AGENT_MODE`` idle watchdog never
+sees zero agents and the server lingers forever) and the session's turns (nothing
+ever promotes them into the permanent graph).
+
+So ``arm()`` spawns this file as a small detached process — the same pattern the
+claude-code, codex and openclaw plugins use — that polls the Hermes PID and, when
+it dies without a clean shutdown, runs ``improve(session_ids=[...])``
+synchronously and then unregisters. A clean shutdown ``disarm()``s the watcher by
+deleting its state file, and the watcher exits without acting.
+
+The watcher half of this module runs as a plain script (``python exit_watcher.py
+--state <path>``), outside the package, so nothing here may import from the
+package — everything it needs travels in the state file, plus the API key, which
+stays out of world-readable places: it is handed over via the child's
+environment and falls back to the shared ``~/.cognee-plugin/api_key.json`` cache.
+"""
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Duplicated from config.SHARED_PLUGIN_STATE_DIR (this file must run without the
+# package): the key cache shared with the other cognee plugins.
+_SHARED_KEY_CACHE = Path.home() / ".cognee-plugin" / "api_key.json"
+
+_DEFAULT_POLL_SECONDS = 2.0
+_UNREGISTER_TIMEOUT = 15.0
+
+
+# --- state file ---------------------------------------------------------------
+
+
+def read_state(state_path):
+    """The parsed state dict, or None when missing/unreadable (i.e. disarmed)."""
+    try:
+        data = json.loads(Path(state_path).read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def write_state(state_path, state):
+    path = Path(state_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state), encoding="utf-8")
+    try:
+        tmp.chmod(0o600)
+    except OSError:
+        pass
+    os.replace(tmp, path)
+
+
+def pid_alive(pid):
+    try:
+        os.kill(int(pid), 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except Exception:
+        return False
+    return True
+
+
+# --- the provider-facing API ---------------------------------------------------
+
+
+def arm(
+    *,
+    state_path,
+    log_path,
+    parent_pid,
+    url,
+    api_key,
+    agent_session_name,
+    dataset,
+    session_id,
+    improve,
+    improve_timeout,
+    poll_interval=_DEFAULT_POLL_SECONDS,
+):
+    """Write the watcher's state file and spawn the detached watcher process.
+
+    The state file deliberately carries no API key — the key goes through the
+    child's environment instead, and the watcher can re-read the shared cache at
+    fire time (the key may not even exist yet when Hermes starts).
+    """
+    write_state(
+        state_path,
+        {
+            "parent_pid": int(parent_pid),
+            "url": str(url),
+            "agent_session_name": str(agent_session_name),
+            "dataset": str(dataset),
+            "session_id": str(session_id),
+            "improve": bool(improve),
+            "improve_timeout": float(improve_timeout),
+            "poll_interval": float(poll_interval),
+        },
+    )
+    env = dict(os.environ)
+    if api_key:
+        env["COGNEE_API_KEY"] = str(api_key)
+    try:
+        log = open(log_path, "ab", buffering=0)  # noqa: SIM115 — handed to the child
+    except Exception:
+        log = subprocess.DEVNULL
+    try:
+        subprocess.Popen(
+            [sys.executable, str(Path(__file__).resolve()), "--state", str(state_path)],
+            env=env,
+            stdout=log,
+            stderr=log,
+            start_new_session=True,  # detach: must outlive Hermes to be of any use
+        )
+    finally:
+        if log is not subprocess.DEVNULL:
+            log.close()
+
+
+def update(state_path, **fields):
+    """Merge *fields* into the state file (e.g. a new session id on switch).
+
+    Best-effort and never raises: the watcher is insurance, and no memory
+    operation should fail because insurance paperwork did.
+    """
+    try:
+        state = read_state(state_path)
+        if state is None:
+            return
+        state.update(fields)
+        write_state(state_path, state)
+    except Exception as exc:
+        logger.debug("could not update the cognee exit watcher state: %s", exc)
+
+
+def disarm(state_path):
+    """Delete the state file; the watcher notices and exits without acting."""
+    try:
+        Path(state_path).unlink(missing_ok=True)
+    except Exception as exc:
+        logger.debug("could not disarm the cognee exit watcher: %s", exc)
+
+
+# --- the watcher process --------------------------------------------------------
+
+
+def _log(message):
+    print(time.strftime("[%Y-%m-%d %H:%M:%S] ") + message, flush=True)
+
+
+def _cached_api_key(url):
+    """The shared single-principal key, matching the other plugins' cache rules."""
+    try:
+        data = json.loads(_SHARED_KEY_CACHE.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    key = str(data.get("api_key") or "").strip()
+    cached_url = str(data.get("base_url") or "").strip().rstrip("/")
+    wanted = str(url or "").strip().rstrip("/")
+    if wanted and cached_url and cached_url != wanted:
+        return ""
+    return key
+
+
+def _post(url, path, payload, *, api_key, timeout):
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["X-Api-Key"] = api_key
+    request = urllib.request.Request(
+        url.rstrip("/") + path,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return getattr(response, "status", None) or response.getcode()
+
+
+def fire(state):
+    """The unclean-death path: improve first, then unregister.
+
+    That order is load-bearing (and matches openclaw's exit watcher): the improve
+    must finish while this connection still counts as a registered agent, or the
+    server's idle watchdog could tear the server down mid-promotion.
+    """
+    url = str(state.get("url") or "")
+    api_key = os.environ.get("COGNEE_API_KEY", "").strip() or _cached_api_key(url)
+    session_id = str(state.get("session_id") or "")
+    if state.get("improve") and session_id:
+        try:
+            _post(
+                url,
+                "/api/v1/improve",
+                {
+                    "dataset_name": str(state.get("dataset") or ""),
+                    "session_ids": [session_id],
+                    "run_in_background": False,
+                },
+                api_key=api_key,
+                timeout=float(state.get("improve_timeout") or 300.0),
+            )
+            _log("improve submitted for session %s" % session_id)
+        except Exception as exc:
+            _log("improve failed for session %s: %s" % (session_id, exc))
+    try:
+        _post(
+            url,
+            "/api/v1/agents/unregister",
+            {"agent_session_name": str(state.get("agent_session_name") or "hermes")},
+            api_key=api_key,
+            timeout=_UNREGISTER_TIMEOUT,
+        )
+        _log("agent connection unregistered")
+    except Exception as exc:
+        _log("unregister failed: %s" % exc)
+
+
+def watch(state_path):
+    """Poll until disarmed, superseded, or the parent dies (then act)."""
+    state = read_state(state_path)
+    if state is None:
+        return 0
+    # Claim the state file. A later arm() for the same path overwrites this, and
+    # the superseded watcher sees a foreign pid below and bows out.
+    state["watcher_pid"] = os.getpid()
+    write_state(state_path, state)
+    _log(
+        "watching hermes pid %s for session %s" % (state.get("parent_pid"), state.get("session_id"))
+    )
+    while True:
+        state = read_state(state_path)
+        if state is None:
+            _log("disarmed (clean shutdown); exiting")
+            return 0
+        if state.get("watcher_pid") != os.getpid():
+            _log("superseded by a newer watcher; exiting")
+            return 0
+        if not pid_alive(state.get("parent_pid", -1)):
+            _log("hermes pid %s is gone; closing the session" % state.get("parent_pid"))
+            fire(state)
+            disarm(state_path)
+            return 0
+        time.sleep(float(state.get("poll_interval") or _DEFAULT_POLL_SECONDS))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="cognee-hermes exit watcher")
+    parser.add_argument("--state", required=True)
+    args = parser.parse_args(argv)
+    return watch(args.state)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
@@ -257,6 +257,15 @@ class HttpBackend(MemoryBackend):
         except Exception as exc:
             logger.debug("cognee agent registration failed (continuing): %s", exc)
 
+    def connection_info(self) -> Optional[dict[str, Any]]:
+        if not self.url:
+            return None
+        return {
+            "url": self.url,
+            "api_key": self.api_key,
+            "agent_session_name": self._agent_session_name,
+        }
+
     def close(self, *, timeout: float = 5.0) -> None:
         if not self.registered:
             return

--- a/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
@@ -78,6 +78,13 @@ class CogneeUnreachable(RuntimeError):
     """The server could not be reached at all (DNS, connection, timeout)."""
 
 
+def _is_local_url(url: str) -> bool:
+    """True when *url* points at this machine (same hosts the other plugins treat
+    as local in their ``_is_local_url`` / ``isLocalUrl`` helpers)."""
+    host = urllib.parse.urlsplit(url).hostname or ""
+    return host in {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
+
+
 class RememberResponse:
     """A remember result that exposes ``.status`` like the SDK's ``RememberResult``.
 
@@ -316,19 +323,35 @@ class HttpBackend(MemoryBackend):
             logger.debug("could not cache the cognee API key: %s", exc)
 
     def _resolve_api_key(self, provided: str, *, timeout: float) -> str:
-        """Configured key, else a cached one, else mint one from the default user."""
+        """Configured key, else a cached one, else — locally only — mint one.
+
+        Minting logs in as the default user, which only a server this plugin (or a
+        sibling plugin) bootstrapped is known to allow. A *remote* server — Cognee
+        Cloud included — exposes no such login, so a missing key there is a hard
+        configuration error: the claude-code and openclaw plugins require
+        ``COGNEE_API_KEY`` for any remote target for the same reason, and
+        proceeding unauthenticated would only smear one clear startup error into
+        a 401 on every later call.
+        """
         key = (provided or os.environ.get("COGNEE_API_KEY", "")).strip()
         if key:
             return key
         key = self._cached_key()
         if key:
             return key
+        if not _is_local_url(self.url):
+            raise RuntimeError(
+                f"COGNEE_API_KEY is required for a remote cognee server ({self.url}): "
+                "remote servers expose no login route to mint a key from, and every "
+                "request authenticates via X-Api-Key. Set COGNEE_API_KEY, or unset "
+                "COGNEE_BASE_URL to use the local server."
+            )
         try:
             key = self._mint_api_key(timeout=timeout)
         except Exception as exc:
-            # A server with authentication disabled needs no key at all, so this
-            # is not fatal — proceed unauthenticated and let the first real call
-            # report a 401 if the server does want one.
+            # A local server with authentication disabled needs no key at all, so
+            # this is not fatal — proceed unauthenticated and let the first real
+            # call report a 401 if the server does want one.
             logger.debug("could not mint a cognee API key (continuing without): %s", exc)
             return ""
         if key:

--- a/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
@@ -1,0 +1,421 @@
+"""Direct-HTTP transport to a cognee server — stdlib only.
+
+This is the transport the other cognee plugins use (claude-code's
+``scripts/_cognee_client.py``, openclaw's ``src/client.ts``): talk to the server's
+own REST API and own the request bodies. The alternative, routing through
+``cognee.serve()``'s ``CloudClient``, silently drops fields the server accepts —
+most importantly ``session_ids`` on ``improve()``, which is what bridges session
+memory into the permanent graph.
+
+**Wire contract** (verified against cognee 1.2.1's routers):
+
+===================  =========================================================
+``recall``           ``POST /api/v1/recall``   JSON: ``query``, ``search_type``,
+                     ``datasets``, ``top_k``, ``session_id``
+``remember_session`` ``POST /api/v1/remember`` multipart: ``data``,
+                     ``datasetName``, ``session_id``
+``remember_permanent`` ``POST /api/v1/remember`` multipart: ``data``,
+                     ``datasetName`` (no session -> direct add+cognify)
+``improve``          ``POST /api/v1/improve``  JSON: ``dataset_name``,
+                     ``session_ids``, ``run_in_background``
+``forget``           ``POST /api/v1/forget``   JSON: ``dataset``, ``everything``,
+                     ``memory_only``
+===================  =========================================================
+
+Note the field-name differences from the SDK: the endpoint calls them ``query``
+and ``search_type`` where the SDK says ``query_text`` and ``query_type``.
+
+**Two things the HTTP API cannot express**, both logged once rather than dropped
+silently (see :meth:`recall` and :meth:`remember_permanent`):
+
+* ``auto_route`` — no such field on ``/api/v1/recall``; the server always uses
+  cognee's default (on).
+* ``session_ids`` on a *permanent* write — no such field on ``/api/v1/remember``.
+  ``improve`` does accept it, so the session-to-graph bridge is unaffected.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import ssl
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+from .backend import MemoryBackend
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_USER_EMAIL = "default_user@example.com"
+DEFAULT_USER_PASSWORD = "default_password"
+_API_KEY_NAME = "hermes-owner-bootstrap"
+
+
+class CogneeHttpError(RuntimeError):
+    """The server was reached and rejected the request.
+
+    ``status`` is carried so a caller can eventually distinguish a
+    misconfiguration (4xx — waiting will not help) from server trouble (5xx).
+    """
+
+    def __init__(self, status: int, message: str):
+        super().__init__(message)
+        self.status = status
+
+
+class CogneeUnreachable(RuntimeError):
+    """The server could not be reached at all (DNS, connection, timeout)."""
+
+
+class RememberResponse:
+    """A remember result that exposes ``.status`` like the SDK's ``RememberResult``.
+
+    The provider reads ``getattr(result, "status", "completed")``, so returning the
+    raw response dict here would silently report "completed" for every write.
+    """
+
+    def __init__(self, payload: dict[str, Any]):
+        self.raw = payload
+        self.status = str(payload.get("status") or "completed")
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"RememberResponse(status={self.status!r})"
+
+
+def _multipart_body(fields: dict[str, str], files: dict[str, tuple[str, bytes]]):
+    """Encode a multipart/form-data body. Returns ``(content_type, body_bytes)``."""
+    boundary = f"----cognee-hermes-{uuid.uuid4().hex}"
+    parts: list[bytes] = []
+    for name, value in fields.items():
+        parts.append(
+            (
+                f'--{boundary}\r\nContent-Disposition: form-data; name="{name}"\r\n\r\n{value}\r\n'
+            ).encode("utf-8")
+        )
+    for name, (filename, content) in files.items():
+        parts.append(
+            (
+                f"--{boundary}\r\n"
+                f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'
+                "Content-Type: text/plain\r\n\r\n"
+            ).encode("utf-8")
+        )
+        parts.append(content)
+        parts.append(b"\r\n")
+    parts.append(f"--{boundary}--\r\n".encode("utf-8"))
+    return f"multipart/form-data; boundary={boundary}", b"".join(parts)
+
+
+class HttpBackend(MemoryBackend):
+    """Talks to a cognee server over its REST API.
+
+    ``cache_dir`` is where a minted API key is remembered. It should be the active
+    ``HERMES_HOME`` so the key stays profile-scoped — the provider passes it when
+    it builds the transport.
+    """
+
+    def __init__(
+        self,
+        *,
+        cache_dir: Optional[str] = None,
+        opener=None,
+        agent_session_name: str = "hermes",
+    ):
+        self.url = ""
+        self.api_key = ""
+        self.registered = False
+        self._cache_dir = Path(cache_dir).expanduser() if cache_dir else None
+        self._opener = opener
+        self._agent_session_name = agent_session_name
+        self._ssl_context: Optional[ssl.SSLContext] = None
+        self._warned: set[str] = set()
+
+    # -- transport ---------------------------------------------------------
+
+    def _context(self) -> ssl.SSLContext:
+        if self._ssl_context is None:
+            self._ssl_context = ssl.create_default_context()
+        return self._ssl_context
+
+    def _open(self, request: urllib.request.Request, timeout: float):
+        if self._opener is not None:
+            return self._opener(request, timeout=timeout)
+        return urllib.request.urlopen(request, timeout=timeout, context=self._context())
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        timeout: float,
+        json_body: Optional[dict[str, Any]] = None,
+        form_body: Optional[dict[str, str]] = None,
+        multipart: Optional[tuple[str, bytes]] = None,
+        cookies: Optional[dict[str, str]] = None,
+        base_url: str = "",
+    ) -> Any:
+        """Make one request and return its parsed JSON body (``None`` if empty)."""
+        url = (base_url or self.url).rstrip("/") + path
+        headers: dict[str, str] = {}
+        data: Optional[bytes] = None
+
+        if json_body is not None:
+            headers["Content-Type"] = "application/json"
+            data = json.dumps(json_body).encode("utf-8")
+        elif form_body is not None:
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+            data = urllib.parse.urlencode(form_body).encode("utf-8")
+        elif multipart is not None:
+            headers["Content-Type"], data = multipart
+
+        # Always send the key when we have one: cognee enforces auth on its API
+        # routes even on localhost, and a server with auth disabled ignores it.
+        if self.api_key:
+            headers["X-Api-Key"] = self.api_key
+        if cookies:
+            headers["Cookie"] = "; ".join(f"{k}={v}" for k, v in cookies.items())
+
+        request = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with self._open(request, timeout) as response:
+                raw = response.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            detail = ""
+            try:
+                detail = exc.read().decode("utf-8")[:300]
+            except Exception:
+                pass
+            raise CogneeHttpError(
+                exc.code, f"{method} {path} failed (HTTP {exc.code}): {detail or exc.reason}"
+            ) from exc
+        except Exception as exc:  # URLError / timeout / OSError
+            raise CogneeUnreachable(f"cognee unreachable at {url}: {str(exc)[:200]}") from exc
+
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, ValueError) as exc:
+            # A body we cannot parse is a server-side problem, not unreachability.
+            raise CogneeHttpError(200, f"malformed JSON from {path}: {str(exc)[:160]}") from exc
+
+    def _warn_once(self, key: str, message: str) -> None:
+        if key not in self._warned:
+            self._warned.add(key)
+            logger.warning(message)
+
+    # -- connection / lifecycle -------------------------------------------
+
+    def connect(self, *, url: str, api_key: str, timeout: float) -> None:
+        """Health-check *url*, resolve an API key, and register this connection.
+
+        The health check is what makes an unreachable target a hard failure.
+        ``cognee.serve()`` only logged a warning and handed back a client, so a bad
+        ``COGNEE_BASE_URL`` looked like success until the first real call.
+        """
+        self.url = url.rstrip("/")
+        self.api_key = ""
+
+        health = self._request("GET", "/health", timeout=min(timeout, 10.0))
+        del health  # any 2xx is healthy; body shape is not part of the contract
+
+        self.api_key = self._resolve_api_key(api_key, timeout=timeout)
+
+        # Registration drives the server's idle-shutdown watchdog. Useful, but not
+        # required for correctness — never fail a session over it.
+        try:
+            self._request(
+                "POST",
+                "/api/v1/agents/register",
+                timeout=timeout,
+                json_body={
+                    "agent_session_name": self._agent_session_name,
+                    "type": "api",
+                    "source": "api",
+                },
+            )
+            self.registered = True
+        except Exception as exc:
+            logger.debug("cognee agent registration failed (continuing): %s", exc)
+
+    def close(self, *, timeout: float = 5.0) -> None:
+        if not self.registered:
+            return
+        try:
+            self._request(
+                "POST",
+                "/api/v1/agents/unregister",
+                timeout=timeout,
+                json_body={"agent_session_name": self._agent_session_name},
+            )
+        except Exception as exc:
+            logger.debug("cognee agent unregistration failed: %s", exc)
+        finally:
+            self.registered = False
+
+    # -- auth --------------------------------------------------------------
+
+    def _key_cache_path(self) -> Optional[Path]:
+        if self._cache_dir is None:
+            return None
+        return self._cache_dir / "cognee-api-key.json"
+
+    def _cached_key(self) -> str:
+        path = self._key_cache_path()
+        if path is None or not path.exists():
+            return ""
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return ""
+        if not isinstance(data, dict) or data.get("url") != self.url:
+            return ""
+        return str(data.get("api_key") or "")
+
+    def _cache_key(self, api_key: str) -> None:
+        path = self._key_cache_path()
+        if path is None:
+            return
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps({"url": self.url, "api_key": api_key}), encoding="utf-8")
+            path.chmod(0o600)
+        except OSError as exc:
+            logger.debug("could not cache the cognee API key: %s", exc)
+
+    def _resolve_api_key(self, provided: str, *, timeout: float) -> str:
+        """Configured key, else a cached one, else mint one from the default user."""
+        key = (provided or os.environ.get("COGNEE_API_KEY", "")).strip()
+        if key:
+            return key
+        key = self._cached_key()
+        if key:
+            return key
+        try:
+            key = self._mint_api_key(timeout=timeout)
+        except Exception as exc:
+            # A server with authentication disabled needs no key at all, so this
+            # is not fatal — proceed unauthenticated and let the first real call
+            # report a 401 if the server does want one.
+            logger.debug("could not mint a cognee API key (continuing without): %s", exc)
+            return ""
+        if key:
+            self._cache_key(key)
+        return key
+
+    def _mint_api_key(self, *, timeout: float) -> str:
+        """Log in as the default user and reuse or create an owner API key."""
+        email = os.environ.get("COGNEE_USER_EMAIL", DEFAULT_USER_EMAIL)
+        password = os.environ.get("COGNEE_USER_PASSWORD", DEFAULT_USER_PASSWORD)
+
+        login = self._request(
+            "POST",
+            "/api/v1/auth/login",
+            timeout=timeout,
+            form_body={"username": email, "password": password},
+        )
+        token = str((login or {}).get("access_token") or "")
+        if not token:
+            raise CogneeHttpError(200, "login returned no access token")
+        cookies = {"auth_token": token}
+
+        existing = self._request("GET", "/api/v1/auth/api-keys", timeout=timeout, cookies=cookies)
+        if isinstance(existing, list) and existing:
+            key = str(existing[0].get("key") or "")
+            if key:
+                return key
+
+        created = self._request(
+            "POST",
+            "/api/v1/auth/api-keys",
+            timeout=timeout,
+            json_body={"name": _API_KEY_NAME},
+            cookies=cookies,
+        )
+        return str((created or {}).get("key") or "")
+
+    # -- operations --------------------------------------------------------
+
+    def recall(
+        self,
+        *,
+        query,
+        session_id,
+        datasets,
+        top_k,
+        auto_route,
+        query_type,
+        timeout,
+    ) -> list[Any]:
+        if not auto_route:
+            self._warn_once(
+                "auto_route",
+                "COGNEE_AUTO_ROUTE=false is not supported over HTTP: /api/v1/recall has "
+                "no auto_route field, so the server's default routing is used.",
+            )
+        body: dict[str, Any] = {"query": query, "top_k": top_k}
+        if session_id:
+            body["session_id"] = session_id
+        if datasets:
+            body["datasets"] = datasets
+        if query_type:
+            # The endpoint calls this ``search_type``; an unknown name is rejected
+            # by the server's enum, so fall back the way the SDK transport does.
+            body["search_type"] = str(query_type).upper().strip()
+
+        result = self._request("POST", "/api/v1/recall", timeout=timeout, json_body=body)
+        if isinstance(result, dict):
+            if result.get("error"):
+                raise CogneeHttpError(200, str(result["error"])[:200])
+            return [result]
+        return result or []
+
+    def _remember(
+        self, *, text: str, dataset: str, session_id: str, timeout: float
+    ) -> RememberResponse:
+        fields = {"datasetName": dataset}
+        if session_id:
+            fields["session_id"] = session_id
+        multipart = _multipart_body(fields, {"data": ("memory.txt", text.encode("utf-8"))})
+        payload = self._request("POST", "/api/v1/remember", timeout=timeout, multipart=multipart)
+        return RememberResponse(payload if isinstance(payload, dict) else {})
+
+    def remember_session(self, *, text, session_id, dataset, timeout) -> RememberResponse:
+        # A session_id routes the write into the session cache, which is the
+        # cheap tier — no graph extraction up front.
+        return self._remember(text=text, dataset=dataset, session_id=session_id, timeout=timeout)
+
+    def remember_permanent(self, *, text, dataset, session_ids, timeout) -> RememberResponse:
+        if session_ids:
+            self._warn_once(
+                "remember_session_ids",
+                "session_ids on a permanent write is not supported over HTTP: "
+                "/api/v1/remember has no such field, so the graph write is not linked "
+                "to the session. The session-to-graph bridge (improve) is unaffected.",
+            )
+        # No session_id -> the server does a direct add + cognify.
+        return self._remember(text=text, dataset=dataset, session_id="", timeout=timeout)
+
+    def forget(self, *, dataset, everything, memory_only, timeout) -> dict[str, Any]:
+        body: dict[str, Any] = {"everything": everything, "memory_only": memory_only}
+        if dataset and not everything:
+            body["dataset"] = dataset
+        result = self._request("POST", "/api/v1/forget", timeout=timeout, json_body=body)
+        return result if isinstance(result, dict) else {}
+
+    def improve(self, *, dataset, session_ids, background, timeout) -> Any:
+        # ``session_ids`` is the whole point of this transport: it is what bridges
+        # session-cache content into the permanent graph, and the SDK's CloudClient
+        # never sends it.
+        body: dict[str, Any] = {
+            "dataset_name": dataset,
+            "run_in_background": background,
+        }
+        if session_ids:
+            body["session_ids"] = session_ids
+        return self._request("POST", "/api/v1/improve", timeout=timeout, json_body=body)

--- a/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
@@ -7,7 +7,8 @@ own REST API and own the request bodies. The alternative, routing through
 most importantly ``session_ids`` on ``improve()``, which is what bridges session
 memory into the permanent graph.
 
-**Wire contract** (verified against cognee 1.2.1's routers):
+**Wire contract** (verified against cognee 1.2.1's routers, live-checked on the
+pinned 1.4.0):
 
 ===================  =========================================================
 ``recall``           ``POST /api/v1/recall``   JSON: ``query``, ``search_type``,

--- a/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
@@ -25,13 +25,16 @@ memory into the permanent graph.
 Note the field-name differences from the SDK: the endpoint calls them ``query``
 and ``search_type`` where the SDK says ``query_text`` and ``query_type``.
 
-**Two things the HTTP API cannot express**, both logged once rather than dropped
-silently (see :meth:`recall` and :meth:`remember_permanent`):
+**Fields the HTTP API does not have:**
 
-* ``auto_route`` — no such field on ``/api/v1/recall``; the server always uses
-  cognee's default (on).
-* ``session_ids`` on a *permanent* write — no such field on ``/api/v1/remember``.
-  ``improve`` does accept it, so the session-to-graph bridge is unaffected.
+* ``auto_route`` — no such field on ``/api/v1/recall``, but the setting is still
+  honoured: ``auto_route=False`` is translated into an explicit
+  ``search_type=GRAPH_COMPLETION``, which is what it means server-side. See
+  :meth:`recall`.
+* ``session_ids`` on a *permanent* write — no such field on ``/api/v1/remember``
+  and no equivalent, so a graph write cannot be linked to its session. Logged
+  once rather than dropped silently. ``improve`` does accept ``session_ids``, so
+  the session-to-graph bridge itself is unaffected.
 """
 
 from __future__ import annotations
@@ -352,12 +355,15 @@ class HttpBackend(MemoryBackend):
         query_type,
         timeout,
     ) -> list[Any]:
-        if not auto_route:
-            self._warn_once(
-                "auto_route",
-                "COGNEE_AUTO_ROUTE=false is not supported over HTTP: /api/v1/recall has "
-                "no auto_route field, so the server's default routing is used.",
-            )
+        if not auto_route and not query_type:
+            # /api/v1/recall has no auto_route field, but the setting is still
+            # expressible: server-side, ``auto_route=False`` with no explicit type
+            # means "skip the query classifier and use GRAPH_COMPLETION"
+            # (recall.py:519). Naming that type directly bypasses the classifier
+            # too, so this is the same retrieval path — only cognee's
+            # router-override counter differs, which is pure telemetry.
+            query_type = "GRAPH_COMPLETION"
+
         body: dict[str, Any] = {"query": query, "top_k": top_k}
         if session_id:
             body["session_id"] = session_id

--- a/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
@@ -392,9 +392,33 @@ class HttpBackend(MemoryBackend):
         return RememberResponse(payload if isinstance(payload, dict) else {})
 
     def remember_session(self, *, text, session_id, dataset, timeout) -> RememberResponse:
-        # A session_id routes the write into the session cache, which is the
-        # cheap tier — no graph extraction up front.
-        return self._remember(text=text, dataset=dataset, session_id=session_id, timeout=timeout)
+        """Store a turn in the session cache as a typed QA entry.
+
+        This has to go through ``/api/v1/remember/entry``, not ``/api/v1/remember``
+        with a ``session_id``. Live-diagnosed: the document endpoint takes its
+        payload as a multipart file, which the server coerces to a placeholder
+        (``[UploadFile]``), and ``_add_to_session`` deliberately skips those
+        because they are useless in a session cache. The write reported
+        ``status: "session_stored"`` and stored nothing, so turns silently vanished
+        and ``improve()`` had nothing to promote. The typed-entry endpoint is what
+        the Claude Code plugin uses for the same purpose.
+
+        The turn arrives pre-framed as ``User: …\\nAssistant: …``, which the QA
+        shape cannot split back apart, so it goes in the ``answer`` field — exactly
+        what cognee's own SDK does for a session write (``add_qa`` with an empty
+        question).
+        """
+        payload = self._request(
+            "POST",
+            "/api/v1/remember/entry",
+            timeout=timeout,
+            json_body={
+                "entry": {"type": "qa", "question": "", "answer": text, "context": ""},
+                "dataset_name": dataset,
+                "session_id": session_id,
+            },
+        )
+        return RememberResponse(payload if isinstance(payload, dict) else {})
 
     def remember_permanent(self, *, text, dataset, session_ids, timeout) -> RememberResponse:
         if session_ids:

--- a/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
@@ -266,6 +266,24 @@ class HttpBackend(MemoryBackend):
             "agent_session_name": self._agent_session_name,
         }
 
+    def ensure_dataset(self, *, dataset: str, timeout: float) -> None:
+        """Create-or-return the dataset, as the other plugins do at bootstrap.
+
+        The endpoint is idempotent — it creates the dataset or returns the
+        existing one, granting the calling principal access either way. Some
+        deployments route the collection at ``/datasets/`` and answer the
+        non-slash POST with a 307/308, which urllib refuses to follow for a
+        request with a body — retried once at the slashed path.
+        """
+        if not dataset:
+            return
+        try:
+            self._request("POST", "/api/v1/datasets", timeout=timeout, json_body={"name": dataset})
+        except CogneeHttpError as exc:
+            if exc.status not in (301, 302, 307, 308):
+                raise
+            self._request("POST", "/api/v1/datasets/", timeout=timeout, json_body={"name": dataset})
+
     def close(self, *, timeout: float = 5.0) -> None:
         if not self.registered:
             return

--- a/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/http_backend.py
@@ -47,10 +47,12 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
 from .backend import MemoryBackend
+from .config import SHARED_PLUGIN_STATE_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -117,9 +119,10 @@ def _multipart_body(fields: dict[str, str], files: dict[str, tuple[str, bytes]])
 class HttpBackend(MemoryBackend):
     """Talks to a cognee server over its REST API.
 
-    ``cache_dir`` is where a minted API key is remembered. It should be the active
-    ``HERMES_HOME`` so the key stays profile-scoped — the provider passes it when
-    it builds the transport.
+    ``cache_dir`` is where a minted API key is remembered. It defaults to
+    ``~/.cognee-plugin``, the state dir the claude-code/codex/openclaw plugins
+    share — one principal key (``api_key.json``) serves every cognee plugin on
+    the machine, in their exact file format. Override it only in tests.
     """
 
     def __init__(
@@ -132,7 +135,7 @@ class HttpBackend(MemoryBackend):
         self.url = ""
         self.api_key = ""
         self.registered = False
-        self._cache_dir = Path(cache_dir).expanduser() if cache_dir else None
+        self._cache_dir = Path(cache_dir).expanduser() if cache_dir else SHARED_PLUGIN_STATE_DIR
         self._opener = opener
         self._agent_session_name = agent_session_name
         self._ssl_context: Optional[ssl.SSLContext] = None
@@ -263,30 +266,50 @@ class HttpBackend(MemoryBackend):
 
     # -- auth --------------------------------------------------------------
 
-    def _key_cache_path(self) -> Optional[Path]:
-        if self._cache_dir is None:
-            return None
-        return self._cache_dir / "cognee-api-key.json"
+    def _key_cache_path(self) -> Path:
+        # Name and shape are shared with the other cognee plugins (claude-code's
+        # ``_API_KEY_CACHE``): whichever plugin mints first, the rest reuse.
+        return self._cache_dir / "api_key.json"
+
+    @staticmethod
+    def _normalize_url(value: str) -> str:
+        return str(value or "").strip().rstrip("/")
 
     def _cached_key(self) -> str:
         path = self._key_cache_path()
-        if path is None or not path.exists():
+        if not path.exists():
             return ""
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except Exception:
             return ""
-        if not isinstance(data, dict) or data.get("url") != self.url:
+        if not isinstance(data, dict):
             return ""
-        return str(data.get("api_key") or "")
+        key = str(data.get("api_key") or "").strip()
+        if not key:
+            return ""
+        # Same match rule as the other plugins: a recorded base_url only
+        # invalidates the key when both sides are non-empty and differ.
+        cached_url = self._normalize_url(str(data.get("base_url") or ""))
+        wanted = self._normalize_url(self.url)
+        if wanted and cached_url and cached_url != wanted:
+            return ""
+        return key
 
     def _cache_key(self, api_key: str) -> None:
         path = self._key_cache_path()
-        if path is None:
-            return
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(json.dumps({"url": self.url, "api_key": api_key}), encoding="utf-8")
+            path.write_text(
+                json.dumps(
+                    {
+                        "base_url": self._normalize_url(self.url),
+                        "api_key": api_key.strip(),
+                        "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                    }
+                ),
+                encoding="utf-8",
+            )
             path.chmod(0o600)
         except OSError as exc:
             logger.debug("could not cache the cognee API key: %s", exc)

--- a/integrations/hermes-agent/cognee_integration_hermes/installer.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/installer.py
@@ -1,0 +1,85 @@
+"""Materialize the Hermes directory plugin from the installed pip package.
+
+Hermes discovers memory providers by scanning ``$HERMES_HOME/plugins/`` — a pip
+install alone puts this package in site-packages, where Hermes never looks. The
+``cognee-hermes-install`` console script bridges that gap: it lays down the
+exact directory shape the scanner expects (``plugin.yaml`` and the ``cli.py``
+shim at the plugin root, this package beside them), copied from the installed
+wheel. The full flow:
+
+    pip install cognee-integration-hermes-agent
+    cognee-hermes-install
+    hermes memory setup
+
+Because Hermes runs the *copy*, ``pip install -U`` alone changes nothing —
+re-run ``cognee-hermes-install`` after upgrading. ``hermes cognee status``
+warns when the pip package is newer than the installed copy.
+
+The plugin-root files ship inside the package under ``_plugin_root/`` (a wheel
+cannot carry files outside its packages); a test pins them byte-identical to
+the repository's canonical copies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+from .config import resolve_hermes_home
+
+_ROOT_FILES = ("plugin.yaml", "cli.py", "after-install.md")
+
+
+def install(hermes_home: str | Path | None = None) -> Path:
+    """Copy the plugin into ``$HERMES_HOME/plugins/cognee``; return that path."""
+    home = resolve_hermes_home(hermes_home)
+    if home is None:
+        # No Hermes on the path to ask; the documented default.
+        home = Path.home() / ".hermes"
+    package_src = Path(__file__).resolve().parent
+    root_src = package_src / "_plugin_root"
+    missing = [name for name in _ROOT_FILES if not (root_src / name).is_file()]
+    if missing:
+        raise RuntimeError(
+            "packaged plugin files missing (%s) — this looks like a broken or "
+            "source-tree install; reinstall the package from PyPI" % ", ".join(missing)
+        )
+
+    target = home / "plugins" / "cognee"
+    target.mkdir(parents=True, exist_ok=True)
+    for name in _ROOT_FILES:
+        shutil.copyfile(root_src / name, target / name)
+
+    # Replace the package wholesale so removed modules never linger.
+    dest_package = target / package_src.name
+    if dest_package.exists():
+        shutil.rmtree(dest_package)
+    shutil.copytree(
+        package_src,
+        dest_package,
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+    )
+    return target
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="cognee-hermes-install",
+        description="Install the Cognee memory plugin into a Hermes Agent home.",
+    )
+    parser.add_argument(
+        "--home",
+        default=None,
+        help="HERMES_HOME to install into (default: auto-detect, else ~/.hermes)",
+    )
+    args = parser.parse_args(argv)
+    target = install(args.home)
+    print(f"Cognee memory plugin installed at {target}")
+    print("Next: run `hermes memory setup` and select `cognee`.")
+    print("After a `pip install -U`, re-run `cognee-hermes-install` to update this copy.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -14,6 +14,7 @@ from .config import (
     DEFAULT_DATASET,
     DEFAULT_IDENTITY_EMAIL,
     DEFAULT_IDENTITY_PASSWORD,
+    DEFAULT_LOCAL_PORT,
     load_config,
     str_to_bool,
     write_env_vars,
@@ -298,7 +299,7 @@ class CogneeMemoryProvider(MemoryProvider):
         else:
             try:
                 local_url = ensure_local_server(
-                    int(self._config.get("local_port") or 8000),
+                    int(self._config.get("local_port") or DEFAULT_LOCAL_PORT),
                     data_root=str(self._config.get("data_root") or ""),
                     system_root=str(self._config.get("system_root") or ""),
                     boot_timeout=float(self._config.get("server_boot_timeout", 30)),
@@ -309,7 +310,8 @@ class CogneeMemoryProvider(MemoryProvider):
                 raise RuntimeError(
                     "cognee local server failed to start, which is required for safe "
                     "concurrent DB access. Check for a port conflict on "
-                    f"{self._config.get('local_port') or 8000}, missing dependencies "
+                    f"{self._config.get('local_port') or DEFAULT_LOCAL_PORT}, "
+                    "missing dependencies "
                     "(uvicorn/cognee), or permissions. To run single-process in-process "
                     "instead (no concurrency safety), set COGNEE_EMBEDDED=true."
                 ) from exc

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -115,6 +115,10 @@ class CogneeMemoryProvider(MemoryProvider):
         # flight — see queue_prefetch / on_session_switch.
         self._prefetch_generation = 0
         self._sync_thread: Optional[threading.Thread] = None
+        # The breaker is touched from the main thread and every worker thread
+        # (prefetch, sync, memory-write); the lock keeps the failure counter's
+        # read-modify-writes from losing updates under that concurrency.
+        self._breaker_lock = threading.Lock()
         self._consecutive_failures = 0
         self._breaker_open_until = 0.0
         # Set when a crash-safe exit watcher is armed (server modes only).
@@ -836,23 +840,29 @@ class CogneeMemoryProvider(MemoryProvider):
         return lines
 
     def _is_breaker_open(self) -> bool:
-        if self._consecutive_failures < _BREAKER_THRESHOLD:
-            return False
-        if time.monotonic() >= self._breaker_open_until:
-            self._consecutive_failures = 0
-            return False
-        return True
+        with self._breaker_lock:
+            if self._consecutive_failures < _BREAKER_THRESHOLD:
+                return False
+            if time.monotonic() >= self._breaker_open_until:
+                self._consecutive_failures = 0
+                return False
+            return True
 
     def _record_success(self) -> None:
-        self._consecutive_failures = 0
+        with self._breaker_lock:
+            self._consecutive_failures = 0
 
     def _record_failure(self) -> None:
-        self._consecutive_failures += 1
-        if self._consecutive_failures >= _BREAKER_THRESHOLD:
-            self._breaker_open_until = time.monotonic() + _BREAKER_COOLDOWN_SECS
+        with self._breaker_lock:
+            self._consecutive_failures += 1
+            tripped = self._consecutive_failures >= _BREAKER_THRESHOLD
+            if tripped:
+                self._breaker_open_until = time.monotonic() + _BREAKER_COOLDOWN_SECS
+                failures = self._consecutive_failures
+        if tripped:
             logger.warning(
                 "Cognee circuit breaker tripped after %d consecutive failures; pausing for %ds.",
-                self._consecutive_failures,
+                failures,
                 _BREAKER_COOLDOWN_SECS,
             )
 

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -335,7 +335,33 @@ class CogneeMemoryProvider(MemoryProvider):
 
         self._initialized = True
 
+    def _is_usable(self) -> bool:
+        """False when initialization never completed, so nothing may touch cognee.
+
+        ``MemoryManager.initialize_all`` catches and logs whatever ``initialize()``
+        raises, then carries on — Hermes starts either way and the tool schemas
+        stay registered. Without this gate the provider would keep serving calls
+        against an unconnected transport: for the SDK that means falling back to
+        in-process cognee, which is exactly the single-writer DB risk local-server
+        mode exists to avoid. Fail closed and say so instead.
+        """
+        return self._initialized
+
+    def _unavailable_envelope(self) -> str:
+        return json.dumps(
+            {
+                "error": (
+                    "Cognee memory is unavailable: initialization did not complete. "
+                    "Check the Hermes logs for the cause and `hermes cognee status` "
+                    "for the current configuration."
+                )
+            }
+        )
+
     def system_prompt_block(self) -> str:
+        # Never advertise memory the model cannot actually use.
+        if not self._is_usable():
+            return ""
         mode = "remote" if self._remote_mode else "local"
         return (
             "# Cognee Memory\n"
@@ -345,6 +371,8 @@ class CogneeMemoryProvider(MemoryProvider):
         )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not self._is_usable():
+            return ""
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
@@ -355,7 +383,7 @@ class CogneeMemoryProvider(MemoryProvider):
         return f"## Cognee Memory\n{result}"
 
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
-        if not query or self._is_breaker_open():
+        if not self._is_usable() or not query or self._is_breaker_open():
             return
 
         cognee_session_id = self._session_cognee_id_for(session_id)
@@ -395,7 +423,7 @@ class CogneeMemoryProvider(MemoryProvider):
         self._prefetch_thread.start()
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
-        if not self._writes_enabled or self._is_breaker_open():
+        if not self._is_usable() or not self._writes_enabled or self._is_breaker_open():
             return
 
         cognee_session_id = self._session_cognee_id_for(session_id)
@@ -428,6 +456,8 @@ class CogneeMemoryProvider(MemoryProvider):
         return [RECALL_SCHEMA, REMEMBER_SCHEMA, FORGET_SCHEMA]
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
+        if not self._is_usable():
+            return self._unavailable_envelope()
         if self._is_breaker_open():
             return json.dumps(
                 {
@@ -448,7 +478,12 @@ class CogneeMemoryProvider(MemoryProvider):
     def on_session_end(self, messages: list[dict[str, Any]]) -> None:
         if self._sync_thread and self._sync_thread.is_alive():
             self._sync_thread.join(timeout=10.0)
-        if not self._writes_enabled or not self._improve_on_end or self._is_breaker_open():
+        if (
+            not self._is_usable()
+            or not self._writes_enabled
+            or not self._improve_on_end
+            or self._is_breaker_open()
+        ):
             return
         # When to background the graph-build: only when a server will outlive this
         # process and finish the job. In embedded mode the work runs in-process, so
@@ -500,7 +535,8 @@ class CogneeMemoryProvider(MemoryProvider):
         # Without it a subagent's built-in memory write still reached the graph
         # while its conversation turns were correctly suppressed.
         if (
-            not self._writes_enabled
+            not self._is_usable()
+            or not self._writes_enabled
             or action not in {"add", "replace"}
             or not content
             or self._is_breaker_open()

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -349,8 +349,22 @@ class CogneeMemoryProvider(MemoryProvider):
                     "Cognee identity initialization failed; using backend default user: %s", exc
                 )
 
+        self._ensure_dataset()
         self._arm_exit_watcher()
         self._initialized = True
+
+    def _ensure_dataset(self) -> None:
+        """Create-or-return the dataset up front, like the other plugins do.
+
+        A fresh server or cloud tenant has no datasets, so a session that opens
+        with a recall would otherwise hit a missing dataset. Best-effort: a write
+        creates the dataset implicitly anyway, so failing here only costs the
+        recall-first case — not the session.
+        """
+        try:
+            self._backend.ensure_dataset(dataset=self._dataset, timeout=30)
+        except Exception as exc:
+            logger.warning("Cognee dataset ensure failed (continuing): %s", exc)
 
     def _arm_exit_watcher(self) -> None:
         """Crash insurance: a detached process that closes the session if we can't.

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -16,6 +16,8 @@ from .config import (
     DEFAULT_IDENTITY_PASSWORD,
     DEFAULT_LOCAL_PORT,
     load_config,
+    resolve_hermes_home,
+    resolve_local_roots,
     str_to_bool,
     write_env_vars,
 )
@@ -298,10 +300,15 @@ class CogneeMemoryProvider(MemoryProvider):
             self._remote_mode = False
         else:
             try:
+                # Profile-scoped storage matters here too, not just embedded: without
+                # it the spawned server falls back to cognee's global default and every
+                # Hermes profile shares one store — which Hermes' plugin contract
+                # forbids, and which puts the data outside `hermes backup`'s reach.
+                data_root, system_root = self._local_roots()
                 local_url = ensure_local_server(
                     int(self._config.get("local_port") or DEFAULT_LOCAL_PORT),
-                    data_root=str(self._config.get("data_root") or ""),
-                    system_root=str(self._config.get("system_root") or ""),
+                    data_root=data_root,
+                    system_root=system_root,
                     boot_timeout=float(self._config.get("server_boot_timeout", 30)),
                 )
                 self._backend.connect(url=local_url, api_key="", timeout=30)
@@ -589,17 +596,39 @@ class CogneeMemoryProvider(MemoryProvider):
             return self._session_cognee_id
         return self._build_cognee_session_id(session_id)
 
+    def _local_roots(self) -> tuple[str, str]:
+        return resolve_local_roots(self._config, self._hermes_home)
+
     def _configure_local_roots(self) -> None:
-        """Point the backend at profile-scoped storage (embedded mode only)."""
-        if not self._hermes_home:
+        """Point the backend at profile-scoped storage (in-process transports only)."""
+        data_root, system_root = self._local_roots()
+        if not data_root and not system_root:
             return
-        data_root = self._config.get("data_root") or str(
-            Path(self._hermes_home) / "cognee" / "data"
-        )
-        system_root = self._config.get("system_root") or str(
-            Path(self._hermes_home) / "cognee" / "system"
-        )
-        self._backend.configure_local_roots(data_root=str(data_root), system_root=str(system_root))
+        self._backend.configure_local_roots(data_root=data_root, system_root=system_root)
+
+    def backup_paths(self) -> list[str]:
+        """Cognee storage that ``hermes backup`` would otherwise miss.
+
+        ``hermes backup`` walks ``HERMES_HOME`` on its own, so profile-scoped roots
+        need no declaring — only roots pointed somewhere else by
+        ``COGNEE_DATA_ROOT`` / ``COGNEE_SYSTEM_ROOT``. Must work without
+        ``initialize()`` and without network, so it reads config directly.
+
+        Roots left to cognee's own defaults (no explicit config, no resolvable
+        home) are not reported: finding them would mean importing cognee, and this
+        is called on a fast, side-effect-free path.
+        """
+        config = load_config()
+        home = resolve_hermes_home()
+        external: list[str] = []
+        for root in resolve_local_roots(config):
+            if not root:
+                continue
+            path = Path(root).expanduser()
+            if home is not None and path.is_relative_to(home):
+                continue
+            external.append(str(path))
+        return external
 
     def _timeout(self, key: str, default: float) -> float:
         """A named, bounded timeout read from config at call time."""

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -9,7 +9,7 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
-from .backend import MemoryBackend, default_backend, has_cognee
+from .backend import MemoryBackend, build_backend, default_backend, has_cognee
 from .config import (
     DEFAULT_DATASET,
     DEFAULT_IDENTITY_EMAIL,
@@ -87,7 +87,9 @@ class CogneeMemoryProvider(MemoryProvider):
 
     def __init__(self, backend: Optional[MemoryBackend] = None) -> None:
         self._config: dict[str, Any] = {}
-        # How we reach cognee. Injectable for tests; see backend.default_backend.
+        # How we reach cognee. An explicitly injected transport always wins;
+        # otherwise initialize() picks one from config (see backend.build_backend).
+        self._injected_backend = backend
         self._backend: MemoryBackend = backend or default_backend()
         self._initialized = False
         self._remote_mode = False
@@ -254,6 +256,10 @@ class CogneeMemoryProvider(MemoryProvider):
         self._improve_on_end = str_to_bool(self._config.get("improve_on_end"), True)
         self._writes_enabled = kwargs.get("agent_context", "primary") in {"", "primary", None}
         self._session_cognee_id = self._build_cognee_session_id(session_id, **kwargs)
+
+        # Now that config is loaded, choose the transport (unless one was injected).
+        if self._injected_backend is None:
+            self._backend = build_backend(self._config, hermes_home=self._hermes_home or "")
 
         self._backend.configure_models(
             llm_api_key=str(self._config.get("llm_api_key") or ""),

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-import importlib.util
 import json
 import logging
 import threading
@@ -11,8 +9,11 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
+from .backend import MemoryBackend, default_backend, has_cognee
 from .config import (
     DEFAULT_DATASET,
+    DEFAULT_IDENTITY_EMAIL,
+    DEFAULT_IDENTITY_PASSWORD,
     load_config,
     str_to_bool,
     write_env_vars,
@@ -37,46 +38,6 @@ logger = logging.getLogger(__name__)
 
 _BREAKER_THRESHOLD = 5
 _BREAKER_COOLDOWN_SECS = 120
-
-
-class _AsyncBridge:
-    """Run Cognee async SDK calls from Hermes' sync MemoryProvider interface."""
-
-    def __init__(self) -> None:
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
-        self._thread: Optional[threading.Thread] = None
-        self._lock = threading.Lock()
-
-    def _ensure_loop(self) -> None:
-        with self._lock:
-            if self._loop is not None and self._loop.is_running():
-                return
-            self._loop = asyncio.new_event_loop()
-            self._thread = threading.Thread(
-                target=self._loop.run_forever,
-                daemon=True,
-                name="cognee-hermes-event-loop",
-            )
-            self._thread.start()
-
-    def run(self, coro, timeout: float):
-        self._ensure_loop()
-        assert self._loop is not None
-        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
-        return future.result(timeout=timeout)
-
-    def shutdown(self) -> None:
-        with self._lock:
-            if self._loop and self._loop.is_running():
-                self._loop.call_soon_threadsafe(self._loop.stop)
-            if self._thread and self._thread.is_alive():
-                self._thread.join(timeout=5.0)
-            self._loop = None
-            self._thread = None
-
-
-def _has_cognee() -> bool:
-    return importlib.util.find_spec("cognee") is not None
 
 
 def _safe_session_component(value: str) -> str:
@@ -124,12 +85,12 @@ def _result_text(value: Any) -> str:
 class CogneeMemoryProvider(MemoryProvider):
     """Cognee V2/V1.1 knowledge graph memory for Hermes Agent."""
 
-    def __init__(self) -> None:
+    def __init__(self, backend: Optional[MemoryBackend] = None) -> None:
         self._config: dict[str, Any] = {}
-        self._bridge = _AsyncBridge()
+        # How we reach cognee. Injectable for tests; see backend.default_backend.
+        self._backend: MemoryBackend = backend or default_backend()
         self._initialized = False
         self._remote_mode = False
-        self._user = None
         self._session_id = ""
         self._session_cognee_id = ""
         self._dataset = DEFAULT_DATASET
@@ -153,7 +114,9 @@ class CogneeMemoryProvider(MemoryProvider):
         return "cognee"
 
     def is_available(self) -> bool:
-        if not _has_cognee():
+        # Must stay network-free: Hermes calls this for every provider during
+        # discovery, before anything is started.
+        if not has_cognee():
             return False
         cfg = load_config()
         return bool(cfg.get("service_url") or cfg.get("llm_api_key"))
@@ -292,7 +255,10 @@ class CogneeMemoryProvider(MemoryProvider):
         self._writes_enabled = kwargs.get("agent_context", "primary") in {"", "primary", None}
         self._session_cognee_id = self._build_cognee_session_id(session_id, **kwargs)
 
-        self._configure_cognee_models()
+        self._backend.configure_models(
+            llm_api_key=str(self._config.get("llm_api_key") or ""),
+            llm_model=str(self._config.get("llm_model") or ""),
+        )
 
         # Connection mode (see README "Modes"):
         #   remote        — service_url set: thin client to a managed/cloud cognee.
@@ -313,7 +279,7 @@ class CogneeMemoryProvider(MemoryProvider):
         if service_url:
             try:
                 api_key = str(self._config.get("api_key") or "")
-                self._bridge.run(self._do_serve(service_url, api_key), timeout=30)
+                self._backend.connect(url=service_url, api_key=api_key, timeout=30)
                 self._remote_mode = True
             except Exception as exc:
                 raise RuntimeError(
@@ -321,7 +287,7 @@ class CogneeMemoryProvider(MemoryProvider):
                     "Fix the URL/network/credentials, or unset it to use local mode."
                 ) from exc
         elif embedded:
-            self._configure_cognee_local_roots()
+            self._configure_local_roots()
             self._remote_mode = False
         else:
             try:
@@ -331,7 +297,7 @@ class CogneeMemoryProvider(MemoryProvider):
                     system_root=str(self._config.get("system_root") or ""),
                     boot_timeout=float(self._config.get("server_boot_timeout", 30)),
                 )
-                self._bridge.run(self._do_serve(local_url, ""), timeout=30)
+                self._backend.connect(url=local_url, api_key="", timeout=30)
                 self._remote_mode = True
             except Exception as exc:
                 raise RuntimeError(
@@ -345,15 +311,20 @@ class CogneeMemoryProvider(MemoryProvider):
         # Identity only matters in embedded mode (a local relational DB exists to
         # hold the user). In server/remote mode the server owns identity via the
         # api-key principal, and touching the local DB here would be meaningless.
-        if self._remote_mode:
-            self._user = None
-        else:
+        # The backend owns whatever principal it resolves; the provider never
+        # handles it.
+        if not self._remote_mode:
             try:
-                self._user = self._bridge.run(self._ensure_identity(), timeout=30)
+                self._backend.resolve_identity(
+                    email=str(self._config.get("identity_email") or DEFAULT_IDENTITY_EMAIL),
+                    password=str(
+                        self._config.get("identity_password") or DEFAULT_IDENTITY_PASSWORD
+                    ),
+                    timeout=30,
+                )
             except Exception as exc:
-                self._user = None
                 logger.warning(
-                    "Cognee identity initialization failed; using SDK default user: %s", exc
+                    "Cognee identity initialization failed; using backend default user: %s", exc
                 )
 
         self._initialized = True
@@ -391,9 +362,12 @@ class CogneeMemoryProvider(MemoryProvider):
 
         def _run() -> None:
             try:
-                results = self._bridge.run(
-                    self._do_recall(query, None, min(self._top_k, 5), "auto", cognee_session_id),
-                    timeout=float(self._config.get("recall_timeout", 120)),
+                results = self._recall(
+                    query,
+                    scope="auto",
+                    search_type=None,
+                    top_k=min(self._top_k, 5),
+                    session_id=cognee_session_id,
                 )
                 lines = self._format_recall_lines(results, limit=5)
                 if lines:
@@ -423,9 +397,11 @@ class CogneeMemoryProvider(MemoryProvider):
 
         def _sync() -> None:
             try:
-                self._bridge.run(
-                    self._do_remember_session(content, cognee_session_id),
-                    timeout=float(self._config.get("write_timeout", 120)),
+                self._backend.remember_session(
+                    text=content,
+                    session_id=cognee_session_id,
+                    dataset=self._dataset,
+                    timeout=self._timeout("write_timeout", 120),
                 )
                 self._record_success()
             except Exception as exc:
@@ -475,9 +451,11 @@ class CogneeMemoryProvider(MemoryProvider):
         raw_bg = str(self._config.get("improve_background") or "").strip()
         background = str_to_bool(raw_bg, self._remote_mode) if raw_bg else self._remote_mode
         try:
-            self._bridge.run(
-                self._do_improve(run_in_background=background),
-                timeout=float(self._config.get("improve_timeout", 300)),
+            self._backend.improve(
+                dataset=self._dataset,
+                session_ids=[self._session_cognee_id],
+                background=background,
+                timeout=self._timeout("improve_timeout", 300),
             )
             self._record_success()
         except Exception as exc:
@@ -528,10 +506,7 @@ class CogneeMemoryProvider(MemoryProvider):
 
         def _sync() -> None:
             try:
-                self._bridge.run(
-                    self._do_remember_permanent(payload, self._dataset),
-                    timeout=float(self._config.get("write_timeout", 120)),
-                )
+                self._remember_permanent(payload, self._dataset)
                 self._record_success()
             except Exception as exc:
                 self._record_failure()
@@ -556,12 +531,7 @@ class CogneeMemoryProvider(MemoryProvider):
         for thread in (self._prefetch_thread, self._sync_thread):
             if thread and thread.is_alive():
                 thread.join(timeout=5.0)
-        if self._remote_mode:
-            try:
-                self._bridge.run(self._do_disconnect(), timeout=5)
-            except Exception:
-                pass
-        self._bridge.shutdown()
+        self._backend.close(timeout=5)
 
     def _build_cognee_session_id(self, session_id: str, **kwargs) -> str:
         # Convention across integrations: "{agent}_{native_session_id}" —
@@ -575,170 +545,68 @@ class CogneeMemoryProvider(MemoryProvider):
             return self._session_cognee_id
         return self._build_cognee_session_id(session_id)
 
-    def _configure_cognee_local_roots(self) -> None:
+    def _configure_local_roots(self) -> None:
+        """Point the backend at profile-scoped storage (embedded mode only)."""
         if not self._hermes_home:
             return
-        try:
-            import cognee
+        data_root = self._config.get("data_root") or str(
+            Path(self._hermes_home) / "cognee" / "data"
+        )
+        system_root = self._config.get("system_root") or str(
+            Path(self._hermes_home) / "cognee" / "system"
+        )
+        self._backend.configure_local_roots(data_root=str(data_root), system_root=str(system_root))
 
-            data_root = self._config.get("data_root") or str(
-                Path(self._hermes_home) / "cognee" / "data"
-            )
-            system_root = self._config.get("system_root") or str(
-                Path(self._hermes_home) / "cognee" / "system"
-            )
-            cognee.config.data_root_directory(str(data_root))
-            cognee.config.system_root_directory(str(system_root))
-        except Exception as exc:
-            logger.debug("Cognee root configuration failed: %s", exc)
+    def _timeout(self, key: str, default: float) -> float:
+        """A named, bounded timeout read from config at call time."""
+        return float(self._config.get(key, default))
 
-    def _configure_cognee_models(self) -> None:
-        try:
-            import cognee
+    def _recall_scope_params(
+        self, scope: str, search_type: Any, session_id: str
+    ) -> tuple[Optional[str], Optional[list[str]], Optional[str]]:
+        """Map the tool's ``scope`` onto the backend's explicit targets.
 
-            if self._config.get("llm_api_key"):
-                cognee.config.set_llm_api_key(str(self._config["llm_api_key"]))
-            if self._config.get("llm_model"):
-                cognee.config.set_llm_model(str(self._config["llm_model"]))
-        except Exception as exc:
-            logger.debug("Cognee model configuration failed: %s", exc)
-
-    async def _ensure_identity(self):
-        email = str(self._config.get("identity_email") or "hermes-agent@cognee.local")
-        password = str(self._config.get("identity_password") or "hermes-agent-plugin")
-        try:
-            from cognee.modules.users.methods import (
-                create_user,
-                get_default_user,
-                get_user_by_email,
-            )
-        except Exception:
-            return None
-
-        user = await get_user_by_email(email)
-        if user:
-            return user
-        try:
-            return await create_user(
-                email=email,
-                password=password,
-                is_verified=True,
-                is_active=True,
-            )
-        except Exception:
-            user = await get_user_by_email(email)
-            if user:
-                return user
-            return await get_default_user()
-
-    async def _do_serve(self, url: str, api_key: str):
-        import cognee
-
-        kwargs = {"url": url}
-        if api_key:
-            kwargs["api_key"] = api_key
-        return await cognee.serve(**kwargs)
-
-    async def _do_disconnect(self):
-        import cognee
-
-        return await cognee.disconnect()
-
-    def _add_user_kwarg(self, kwargs: dict[str, Any]) -> None:
-        """Inject the local user only in embedded mode.
-
-        In server/remote mode the server owns identity (api-key principal) and
-        ``self._user`` is None. Passing ``user=None`` is not the same as omitting
-        the key — the SDK may treat an explicit None differently (overriding a
-        default, affecting tenant scoping) — so we omit it entirely instead.
+        ``session`` searches only this conversation's cache, ``graph`` only the
+        permanent dataset, ``auto`` both. A ``search_type`` override is
+        meaningless for a pure session lookup, so it is dropped there.
         """
-        if not self._remote_mode and self._user is not None:
-            kwargs["user"] = self._user
+        normalized = (scope or "auto").lower()
+        if normalized == "session":
+            return session_id, None, None
+        query_type = search_type or None
+        if normalized == "graph":
+            return None, [self._dataset], query_type
+        return session_id, [self._dataset], query_type
 
-    async def _do_recall(
+    def _recall(
         self,
         query: str,
-        search_type: Optional[str],
-        top_k: int,
+        *,
         scope: str,
+        search_type: Any,
+        top_k: int,
         session_id: str,
     ) -> list[Any]:
-        import cognee
+        target_session, datasets, query_type = self._recall_scope_params(
+            scope, search_type, session_id
+        )
+        return self._backend.recall(
+            query=query,
+            session_id=target_session,
+            datasets=datasets,
+            top_k=top_k,
+            auto_route=self._auto_route,
+            query_type=query_type,
+            timeout=self._timeout("recall_timeout", 120),
+        )
 
-        kwargs: dict[str, Any] = {
-            "top_k": top_k,
-            "auto_route": self._auto_route,
-        }
-        self._add_user_kwarg(kwargs)
-
-        normalized_scope = (scope or "auto").lower()
-        if normalized_scope == "session":
-            kwargs["session_id"] = session_id
-        elif normalized_scope == "graph":
-            kwargs["datasets"] = [self._dataset]
-        else:
-            kwargs["session_id"] = session_id
-            kwargs["datasets"] = [self._dataset]
-
-        if search_type and normalized_scope != "session":
-            kwargs["query_type"] = _resolve_search_type(search_type)
-
-        return await cognee.recall(query_text=query, **kwargs)
-
-    async def _do_remember_session(self, content: str, session_id: str):
-        import cognee
-
-        kwargs: dict[str, Any] = {
-            "data": content,
-            "dataset_name": self._dataset,
-            "session_id": session_id,
-            "self_improvement": False,
-        }
-        self._add_user_kwarg(kwargs)
-        return await cognee.remember(**kwargs)
-
-    async def _do_remember_permanent(self, content: str, dataset: str):
-        import cognee
-
-        kwargs: dict[str, Any] = {
-            "data": content,
-            "dataset_name": dataset,
-            "self_improvement": True,
-            "session_ids": [self._session_cognee_id],
-        }
-        self._add_user_kwarg(kwargs)
-        return await cognee.remember(**kwargs)
-
-    async def _do_forget(
-        self,
-        dataset: Optional[str],
-        *,
-        everything: bool = False,
-        memory_only: bool = False,
-    ) -> dict[str, Any]:
-        import cognee
-
-        kwargs: dict[str, Any] = {
-            "everything": everything,
-            "memory_only": memory_only,
-        }
-        if dataset and not everything:
-            kwargs["dataset"] = dataset
-        self._add_user_kwarg(kwargs)
-        return await cognee.forget(**kwargs)
-
-    async def _do_improve(self, run_in_background: bool = False):
-        # Default stays False (synchronous) so the method contract is unchanged for
-        # any caller that relies on completion. on_session_end() chooses the flag.
-        import cognee
-
-        kwargs: dict[str, Any] = {
-            "dataset": self._dataset,
-            "session_ids": [self._session_cognee_id],
-            "run_in_background": run_in_background,
-        }
-        self._add_user_kwarg(kwargs)
-        return await cognee.improve(**kwargs)
+    def _remember_permanent(self, content: str, dataset: str) -> Any:
+        return self._backend.remember_permanent(
+            text=content,
+            dataset=dataset,
+            session_ids=[self._session_cognee_id],
+            timeout=self._timeout("write_timeout", 120),
+        )
 
     def _handle_recall(self, args: dict[str, Any]) -> str:
         query = str(args.get("query") or "").strip()
@@ -749,18 +617,21 @@ class CogneeMemoryProvider(MemoryProvider):
         search_type = args.get("search_type")
 
         try:
-            results = self._bridge.run(
-                self._do_recall(query, search_type, top_k, scope, self._session_cognee_id),
-                timeout=float(self._config.get("recall_timeout", 120)),
+            results = self._recall(
+                query,
+                scope=scope,
+                search_type=search_type,
+                top_k=top_k,
+                session_id=self._session_cognee_id,
             )
             self._record_success()
             items = [self._normalize_recall_item(item) for item in results]
             if not items:
-                # Distinguish a genuine miss from an embedding-model change that
-                # makes recall structurally unable to match (stored vs query
-                # vectors differ in size). Embedded mode only; a confirmed
-                # mismatch is a hard error.
-                dim_message = self._embedding_dimension_mismatch_hint()
+                # Distinguish a genuine miss from a backend condition that makes
+                # recall structurally unable to match (e.g. an embedder change
+                # leaving stored and query vectors different sizes). A confirmed
+                # cause is a hard error rather than a silent empty result.
+                dim_message = self._backend.empty_recall_hint()
                 if dim_message:
                     return json.dumps({"error": dim_message, "count": 0})
                 return json.dumps({"result": "No relevant Cognee memory found.", "count": 0})
@@ -776,10 +647,7 @@ class CogneeMemoryProvider(MemoryProvider):
         dataset = str(args.get("dataset") or self._dataset)
 
         try:
-            result = self._bridge.run(
-                self._do_remember_permanent(content, dataset),
-                timeout=float(self._config.get("write_timeout", 120)),
-            )
+            result = self._remember_permanent(content, dataset)
             self._record_success()
             status = getattr(result, "status", "completed")
             return json.dumps({"result": "Content stored in Cognee.", "status": str(status)})
@@ -795,9 +663,11 @@ class CogneeMemoryProvider(MemoryProvider):
             return json.dumps({"error": "Specify dataset or set everything=true."})
 
         try:
-            result = self._bridge.run(
-                self._do_forget(dataset, everything=everything, memory_only=memory_only),
-                timeout=float(self._config.get("write_timeout", 120)),
+            result = self._backend.forget(
+                dataset=dataset,
+                everything=everything,
+                memory_only=memory_only,
+                timeout=self._timeout("write_timeout", 120),
             )
             self._record_success()
             return json.dumps({"result": "Cognee memory deleted.", "details": result})
@@ -827,20 +697,6 @@ class CogneeMemoryProvider(MemoryProvider):
             lines.append(f"- [{source}] {text[:500]}")
         return lines
 
-    def _embedding_dimension_mismatch_hint(self) -> Optional[str]:
-        """Confirmed embedding-dimension mismatch diagnostic (embedded mode only), or None.
-
-        In server/remote mode the server owns the vector store, so introspecting
-        the local in-process engine would be meaningless — skip. Best-effort;
-        never raises.
-        """
-        if self._remote_mode:
-            return None
-        try:
-            return self._bridge.run(_dimension_mismatch_hint(), timeout=5.0)
-        except Exception:
-            return None
-
     def _is_breaker_open(self) -> bool:
         if self._consecutive_failures < _BREAKER_THRESHOLD:
             return False
@@ -861,89 +717,6 @@ class CogneeMemoryProvider(MemoryProvider):
                 self._consecutive_failures,
                 _BREAKER_COOLDOWN_SECS,
             )
-
-
-# --- Embedding-dimension mismatch detection ---------------------------------
-# When the embedding model changes between writing and reading, stored vectors
-# and query vectors differ in size, so recall silently matches nothing. These
-# helpers turn that silent miss into a one-line actionable error naming both
-# dimensions and the active embedder. Best-effort and fail-safe (any uncertainty
-# returns None). Only valid in embedded mode, where this process owns the vector
-# store; in server/remote mode the server owns it and the in-process engine here
-# would not reflect it.
-
-
-async def _sample_stored_vector_dim(engine) -> Optional[int]:
-    """Sample the dimension of a stored vector from any populated collection, or None.
-
-    Enumerates the store's actual collections via the vector interface's
-    ``get_connection().table_names()`` (the same path cognee's own ``has_collection``
-    uses) rather than assuming fixed collection names, so it also covers custom
-    pipelines. Never raises: each collection is probed independently and any
-    unreadable one is skipped. Covers cognee's default local backend (LanceDB); other
-    backends whose connection can't enumerate return None and fall back to the normal
-    empty-recall path.
-    """
-    try:
-        connection = await engine.get_connection()
-        names = await connection.table_names()
-    except Exception:
-        return None
-    for name in names:
-        try:
-            collection = await engine.get_collection(name)
-            rows = await collection.query().limit(1).to_list()
-            if rows:
-                vector = rows[0].get("vector")
-                if vector is not None:
-                    return len(vector)
-        except Exception:
-            continue
-    return None
-
-
-async def _dimension_mismatch_hint(engine=None) -> Optional[str]:
-    """One-line diagnostic when the stored vectors differ in size from the active
-    embedder's query vectors (so recall can never match), else None.
-
-    ``engine`` is injectable for testing. Best-effort and fail-safe: any error, or
-    an indeterminate/matching dimension, returns None so the caller keeps the
-    normal empty-recall behavior.
-    """
-    try:
-        if engine is None:
-            from cognee.infrastructure.databases.vector import get_vector_engine
-
-            engine = get_vector_engine()
-        embed = getattr(engine, "embedding_engine", None)
-        if embed is None:
-            return None
-        query_dim = int(embed.get_vector_size())
-        stored_dim = await _sample_stored_vector_dim(engine)
-        if not stored_dim or not query_dim or stored_dim == query_dim:
-            return None
-        model = getattr(embed, "model", None) or "unknown-model"
-        provider = getattr(embed, "provider", None) or "unknown-provider"
-        return (
-            "Cognee recall found nothing because the embedder changed: stored vectors are "
-            f"{stored_dim}-d but the active embedder '{model}' (provider '{provider}') produces "
-            f"{query_dim}-d queries. Re-index this data with the current embedder, or set "
-            f"EMBEDDING_MODEL/EMBEDDING_DIMENSIONS back to the {stored_dim}-d model that wrote it."
-        )
-    except Exception:
-        return None
-
-
-def _resolve_search_type(search_type: str):
-    try:
-        from cognee.modules.search.types import SearchType
-
-        key = str(search_type).upper().strip()
-        return getattr(SearchType, key)
-    except Exception:
-        from cognee.modules.search.types import SearchType
-
-        return SearchType.GRAPH_COMPLETION
 
 
 def _prompt(label: str, default: str | None = None) -> str:

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -15,6 +15,7 @@ from .config import (
     DEFAULT_IDENTITY_EMAIL,
     DEFAULT_IDENTITY_PASSWORD,
     DEFAULT_LOCAL_PORT,
+    DEFAULT_SERVER_BOOT_TIMEOUT,
     load_config,
     resolve_hermes_home,
     resolve_local_roots,
@@ -308,7 +309,9 @@ class CogneeMemoryProvider(MemoryProvider):
                     int(self._config.get("local_port") or DEFAULT_LOCAL_PORT),
                     data_root=data_root,
                     system_root=system_root,
-                    boot_timeout=float(self._config.get("server_boot_timeout", 30)),
+                    boot_timeout=float(
+                        self._config.get("server_boot_timeout", DEFAULT_SERVER_BOOT_TIMEOUT)
+                    ),
                 )
                 self._backend.connect(url=local_url, api_key="", timeout=30)
                 self._remote_mode = True

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -141,6 +141,9 @@ class CogneeMemoryProvider(MemoryProvider):
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: Optional[threading.Thread] = None
+        # Bumped on a reset session switch to invalidate prefetches still in
+        # flight — see queue_prefetch / on_session_switch.
+        self._prefetch_generation = 0
         self._sync_thread: Optional[threading.Thread] = None
         self._consecutive_failures = 0
         self._breaker_open_until = 0.0
@@ -379,6 +382,12 @@ class CogneeMemoryProvider(MemoryProvider):
             return
 
         cognee_session_id = self._session_cognee_id_for(session_id)
+        # Snapshot the generation this prefetch belongs to. A reset session
+        # switch bumps it, so a recall that was already in flight for the
+        # previous conversation discards its result instead of landing in the
+        # fresh one. Joining the worker on switch is not enough: a recall slower
+        # than any bounded join would still write after the clear.
+        generation = self._prefetch_generation
 
         def _run() -> None:
             try:
@@ -389,7 +398,10 @@ class CogneeMemoryProvider(MemoryProvider):
                 lines = self._format_recall_lines(results, limit=5)
                 if lines:
                     with self._prefetch_lock:
-                        self._prefetch_result = "\n".join(lines)
+                        # Drop the result if a reset invalidated it mid-recall.
+                        if generation == self._prefetch_generation:
+                            self._prefetch_result = "\n".join(lines)
+                # The backend answered, so this is a success either way.
                 self._record_success()
             except Exception as exc:
                 self._record_failure()
@@ -487,6 +499,10 @@ class CogneeMemoryProvider(MemoryProvider):
         if reset:
             with self._prefetch_lock:
                 self._prefetch_result = ""
+                # Invalidate any recall still in flight for the old conversation.
+                # Only on reset: /resume, /branch and compression continue the same
+                # logical conversation, so a prefetch issued for it stays valid.
+                self._prefetch_generation += 1
 
     def on_memory_write(
         self,
@@ -495,7 +511,16 @@ class CogneeMemoryProvider(MemoryProvider):
         content: str,
         metadata: Optional[dict[str, Any]] = None,
     ) -> None:
-        if action not in {"add", "replace"} or not content or self._is_breaker_open():
+        # ``_writes_enabled`` is checked here for the same reason sync_turn checks
+        # it: a non-primary agent_context (a subagent) must not write to memory.
+        # Without it a subagent's built-in memory write still reached the graph
+        # while its conversation turns were correctly suppressed.
+        if (
+            not self._writes_enabled
+            or action not in {"add", "replace"}
+            or not content
+            or self._is_breaker_open()
+        ):
             return
         metadata = dict(metadata or {})
         source = metadata.get("write_origin") or "hermes_memory_tool"

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import threading
 import time
 from pathlib import Path
 from typing import Any, Optional
 
+from . import exit_watcher
 from .backend import MemoryBackend, build_backend, default_backend, has_cognee
 from .config import (
     DEFAULT_DATASET,
@@ -16,6 +18,7 @@ from .config import (
     DEFAULT_IDENTITY_PASSWORD,
     DEFAULT_LOCAL_PORT,
     DEFAULT_SERVER_BOOT_TIMEOUT,
+    SHARED_PLUGIN_STATE_DIR,
     load_config,
     resolve_hermes_home,
     resolve_local_roots,
@@ -114,6 +117,8 @@ class CogneeMemoryProvider(MemoryProvider):
         self._sync_thread: Optional[threading.Thread] = None
         self._consecutive_failures = 0
         self._breaker_open_until = 0.0
+        # Set when a crash-safe exit watcher is armed (server modes only).
+        self._watcher_state_path: Optional[Path] = None
 
     @property
     def name(self) -> str:
@@ -344,7 +349,41 @@ class CogneeMemoryProvider(MemoryProvider):
                     "Cognee identity initialization failed; using backend default user: %s", exc
                 )
 
+        self._arm_exit_watcher()
         self._initialized = True
+
+    def _arm_exit_watcher(self) -> None:
+        """Crash insurance: a detached process that closes the session if we can't.
+
+        Only meaningful when a server outlives this process (the transport says so
+        via ``connection_info``); embedded mode has nothing to unregister from and
+        nobody left to run an improve. Best-effort: a session must not fail to
+        start because its insurance did.
+        """
+        try:
+            info = self._backend.connection_info()
+        except Exception:
+            info = None
+        if not info or not info.get("url"):
+            return
+        state_dir = SHARED_PLUGIN_STATE_DIR / "hermes"
+        state_path = state_dir / "exit-watchers" / f"{os.getpid()}.json"
+        try:
+            exit_watcher.arm(
+                state_path=state_path,
+                log_path=state_dir / "exit-watcher.log",
+                parent_pid=os.getpid(),
+                url=str(info.get("url") or ""),
+                api_key=str(info.get("api_key") or ""),
+                agent_session_name=str(info.get("agent_session_name") or "hermes"),
+                dataset=self._dataset,
+                session_id=self._session_cognee_id,
+                improve=bool(self._writes_enabled and self._improve_on_end),
+                improve_timeout=self._timeout("improve_timeout", 300),
+            )
+            self._watcher_state_path = state_path
+        except Exception as exc:
+            logger.debug("could not arm the cognee exit watcher: %s", exc)
 
     def _is_usable(self) -> bool:
         """False when initialization never completed, so nothing may touch cognee.
@@ -510,6 +549,10 @@ class CogneeMemoryProvider(MemoryProvider):
                 timeout=self._timeout("improve_timeout", 300),
             )
             self._record_success()
+            # The bridge ran; a crash after this point should not improve again.
+            # The watcher stays armed for the unregister half.
+            if self._watcher_state_path is not None:
+                exit_watcher.update(self._watcher_state_path, improve=False)
         except Exception as exc:
             self._record_failure()
             logger.warning("Cognee session-end improve failed: %s", exc)
@@ -526,6 +569,14 @@ class CogneeMemoryProvider(MemoryProvider):
             self._sync_thread.join(timeout=5.0)
         self._session_id = new_session_id
         self._session_cognee_id = self._build_cognee_session_id(new_session_id, **kwargs)
+        if self._watcher_state_path is not None:
+            # Re-point the crash insurance at the new session (and re-enable the
+            # improve half in case a previous session end disabled it).
+            exit_watcher.update(
+                self._watcher_state_path,
+                session_id=self._session_cognee_id,
+                improve=bool(self._writes_enabled and self._improve_on_end),
+            )
         if reset:
             with self._prefetch_lock:
                 self._prefetch_result = ""
@@ -584,6 +635,11 @@ class CogneeMemoryProvider(MemoryProvider):
         for thread in (self._prefetch_thread, self._sync_thread):
             if thread and thread.is_alive():
                 thread.join(timeout=5.0)
+        if self._watcher_state_path is not None:
+            # This is the clean path — stand the insurance down BEFORE closing the
+            # backend, so the watcher can never race the orderly unregister.
+            exit_watcher.disarm(self._watcher_state_path)
+            self._watcher_state_path = None
         self._backend.close(timeout=5)
 
     def _build_cognee_session_id(self, session_id: str, **kwargs) -> str:

--- a/integrations/hermes-agent/cognee_integration_hermes/provider.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/provider.py
@@ -156,9 +156,9 @@ class CogneeMemoryProvider(MemoryProvider):
             },
             {
                 "key": "dataset",
-                "description": "Default Cognee dataset",
+                "description": "Default Cognee dataset (shared with the other cognee plugins)",
                 "default": DEFAULT_DATASET,
-                "env_var": "COGNEE_DATASET",
+                "env_var": "COGNEE_PLUGIN_DATASET",
             },
             {
                 "key": "auto_route",
@@ -262,7 +262,7 @@ class CogneeMemoryProvider(MemoryProvider):
 
         # Now that config is loaded, choose the transport (unless one was injected).
         if self._injected_backend is None:
-            self._backend = build_backend(self._config, hermes_home=self._hermes_home or "")
+            self._backend = build_backend(self._config)
 
         self._backend.configure_models(
             llm_api_key=str(self._config.get("llm_api_key") or ""),
@@ -300,10 +300,9 @@ class CogneeMemoryProvider(MemoryProvider):
             self._remote_mode = False
         else:
             try:
-                # Profile-scoped storage matters here too, not just embedded: without
-                # it the spawned server falls back to cognee's global default and every
-                # Hermes profile shares one store — which Hermes' plugin contract
-                # forbids, and which puts the data outside `hermes backup`'s reach.
+                # Pin the roots the other cognee plugins pin (~/.cognee by default),
+                # so the store is the same no matter which plugin spawned the server
+                # on this port first.
                 data_root, system_root = self._local_roots()
                 local_url = ensure_local_server(
                     int(self._config.get("local_port") or DEFAULT_LOCAL_PORT),
@@ -597,33 +596,26 @@ class CogneeMemoryProvider(MemoryProvider):
         return self._build_cognee_session_id(session_id)
 
     def _local_roots(self) -> tuple[str, str]:
-        return resolve_local_roots(self._config, self._hermes_home)
+        return resolve_local_roots(self._config)
 
     def _configure_local_roots(self) -> None:
-        """Point the backend at profile-scoped storage (in-process transports only)."""
+        """Point the backend at local storage (in-process transports only)."""
         data_root, system_root = self._local_roots()
-        if not data_root and not system_root:
-            return
         self._backend.configure_local_roots(data_root=data_root, system_root=system_root)
 
     def backup_paths(self) -> list[str]:
         """Cognee storage that ``hermes backup`` would otherwise miss.
 
-        ``hermes backup`` walks ``HERMES_HOME`` on its own, so profile-scoped roots
-        need no declaring — only roots pointed somewhere else by
-        ``COGNEE_DATA_ROOT`` / ``COGNEE_SYSTEM_ROOT``. Must work without
-        ``initialize()`` and without network, so it reads config directly.
-
-        Roots left to cognee's own defaults (no explicit config, no resolvable
-        home) are not reported: finding them would mean importing cognee, and this
-        is called on a fast, side-effect-free path.
+        ``hermes backup`` walks ``HERMES_HOME`` on its own, so only roots living
+        elsewhere need declaring. By default that is all of them: local storage
+        sits in the shared ``~/.cognee`` (see ``resolve_local_roots``), so a
+        backup deliberately includes the machine's shared memory store. Must work
+        without ``initialize()`` and without network, so it reads config directly.
         """
         config = load_config()
         home = resolve_hermes_home()
         external: list[str] = []
         for root in resolve_local_roots(config):
-            if not root:
-                continue
             path = Path(root).expanduser()
             if home is not None and path.is_relative_to(home):
                 continue

--- a/integrations/hermes-agent/cognee_integration_hermes/server_bootstrap.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/server_bootstrap.py
@@ -38,6 +38,14 @@ def _spawn(port, data_root, system_root, log_path):
     env = dict(os.environ)
     env["COGNEE_AGENT_MODE"] = "true"  # server tears itself down once idle / no clients
     env["HTTP_API_PORT"] = str(port)
+    # The session cache is gated on CACHING. Without it cognee's session manager
+    # reports ``is_available = False``, and a session write is *silently dropped*
+    # while the API still answers ``status: "session_stored"`` — so every turn
+    # vanished and improve() had nothing to promote into the graph. Live-diagnosed;
+    # claude-code and openclaw set the same flag when they spawn their servers.
+    # setdefault semantics: an explicit user value always wins.
+    for key, value in (("CACHING", "true"), ("AUTO_FEEDBACK", "true")):
+        env.setdefault(key, value)
     if data_root:
         env["DATA_ROOT_DIRECTORY"] = data_root
     if system_root:

--- a/integrations/hermes-agent/cognee_integration_hermes/server_bootstrap.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/server_bootstrap.py
@@ -21,6 +21,8 @@ import time
 import urllib.error
 import urllib.request
 
+from .config import SHARED_COGNEE_HOME, SHARED_PLUGIN_STATE_DIR
+
 logger = logging.getLogger(__name__)
 
 
@@ -38,13 +40,24 @@ def _spawn(port, data_root, system_root, log_path):
     env = dict(os.environ)
     env["COGNEE_AGENT_MODE"] = "true"  # server tears itself down once idle / no clients
     env["HTTP_API_PORT"] = str(port)
-    # The session cache is gated on CACHING. Without it cognee's session manager
-    # reports ``is_available = False``, and a session write is *silently dropped*
-    # while the API still answers ``status: "session_stored"`` — so every turn
-    # vanished and improve() had nothing to promote into the graph. Live-diagnosed;
-    # claude-code and openclaw set the same flag when they spawn their servers.
-    # setdefault semantics: an explicit user value always wins.
-    for key, value in (("CACHING", "true"), ("AUTO_FEEDBACK", "true")):
+    # The server must behave identically no matter which cognee plugin booted it,
+    # so this mirrors the env the claude-code/codex/openclaw bootstraps set
+    # (claude-code's apply_cognee_env). setdefault: an explicit user value wins.
+    #
+    # CACHING gates the session cache: without it cognee's session manager reports
+    # ``is_available = False`` and a session write is *silently dropped* while the
+    # API still answers ``status: "session_stored"`` — so every turn vanished and
+    # improve() had nothing to promote into the graph (live-diagnosed).
+    # LLM_INSTRUCTOR_MODE=json_schema_mode uses grammar-constrained decoding for
+    # structured output — small local models fail schema-in-prompt mode so often
+    # that every improve() timed out (diagnosed in the claude-code plugin).
+    for key, value in (
+        ("CACHING", "true"),
+        ("AUTO_FEEDBACK", "true"),
+        ("CACHE_ROOT_DIRECTORY", str(SHARED_COGNEE_HOME / "cache")),
+        ("LLM_INSTRUCTOR_MODE", "json_schema_mode"),
+        ("COGNEE_IMPROVE_SUBMIT_TIMEOUT", "420"),
+    ):
         env.setdefault(key, value)
     if data_root:
         env["DATA_ROOT_DIRECTORY"] = data_root
@@ -94,7 +107,14 @@ def ensure_local_server(
     if health_ok(url):
         return url
     if log_path is None:
-        log_path = os.path.join(os.path.expanduser("~"), ".cognee-hermes-server.log")
+        # Same state root as the other cognee plugins (they keep per-host logs in
+        # ~/.cognee-plugin/<host>/), so diagnostics live in one predictable place.
+        log_dir = SHARED_PLUGIN_STATE_DIR / "hermes"
+        try:
+            log_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass  # _spawn falls back to DEVNULL if the file cannot be opened
+        log_path = str(log_dir / "server.log")
     try:
         _spawn(port, data_root, system_root, log_path)
     except Exception as exc:

--- a/integrations/hermes-agent/cognee_integration_hermes/server_bootstrap.py
+++ b/integrations/hermes-agent/cognee_integration_hermes/server_bootstrap.py
@@ -15,13 +15,14 @@ the port, so concurrent spawns simply lose the bind and then observe health.
 
 import logging
 import os
+import socket
 import subprocess
 import sys
 import time
 import urllib.error
 import urllib.request
 
-from .config import SHARED_COGNEE_HOME, SHARED_PLUGIN_STATE_DIR
+from .config import DEFAULT_SERVER_BOOT_TIMEOUT, SHARED_COGNEE_HOME, SHARED_PLUGIN_STATE_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,20 @@ def health_ok(url, timeout=2.0):
             status = getattr(resp, "status", None) or resp.getcode()
             return 200 <= int(status) < 300
     except Exception:
+        return False
+
+
+def port_bound(port, timeout=1.0):
+    """True when something accepts TCP connections on the local port.
+
+    Weaker than :func:`health_ok` on purpose: uvicorn binds the port well before
+    the app is ready, so this distinguishes "a server is coming up" from "nothing
+    is there at all".
+    """
+    try:
+        with socket.create_connection(("127.0.0.1", int(port)), timeout=timeout):
+            return True
+    except OSError:
         return False
 
 
@@ -68,7 +83,7 @@ def _spawn(port, data_root, system_root, log_path):
     except Exception:
         log = subprocess.DEVNULL
     try:
-        subprocess.Popen(
+        return subprocess.Popen(
             [
                 sys.executable,
                 "-m",
@@ -97,11 +112,18 @@ def ensure_local_server(
     data_root="",
     system_root="",
     log_path=None,
-    boot_timeout=30.0,
+    boot_timeout=float(DEFAULT_SERVER_BOOT_TIMEOUT),
 ):
     """Return the URL of a healthy local cognee server, starting one if needed.
 
-    Raises RuntimeError if the server does not become healthy within boot_timeout.
+    The deadline is generous (matching the other plugins' 600s) because a *first*
+    boot runs migrations and can take minutes — but it is only ever waited out
+    for a server that is actually coming up. A dead spawn with nothing listening
+    on the port raises immediately: waiting cannot fix a missing dependency or a
+    crash, and a 10-minute hang would stall every Hermes session start.
+
+    Raises RuntimeError when the spawn is dead and the port unowned, or when the
+    server does not become healthy within boot_timeout.
     """
     url = "http://127.0.0.1:%d" % int(port)
     if health_ok(url):
@@ -115,18 +137,36 @@ def ensure_local_server(
         except OSError:
             pass  # _spawn falls back to DEVNULL if the file cannot be opened
         log_path = str(log_dir / "server.log")
+    proc = None
+    spawn_error = None
     try:
-        _spawn(port, data_root, system_root, log_path)
+        proc = _spawn(port, data_root, system_root, log_path)
     except Exception as exc:
         # A spawn failure may just be a port-bind race with another starter, in
         # which case health polling below will still succeed. But it may also be a
         # real problem (missing uvicorn, permission denied) — log it for diagnostics.
+        spawn_error = exc
         logger.warning("cognee server spawn attempt failed (will still poll /health): %s", exc)
     deadline = time.monotonic() + float(boot_timeout)
     while time.monotonic() < deadline:
         if health_ok(url):
             return url
+        # Our spawn being gone is not itself fatal — losing a port-bind race to a
+        # concurrent starter looks exactly like this, and then the port has an
+        # owner worth waiting for. Dead spawn AND a silent port is fatal.
+        spawn_is_gone = spawn_error is not None or (proc is not None and proc.poll() is not None)
+        if spawn_is_gone and not port_bound(port):
+            cause = (
+                "failed to launch (%s)" % spawn_error
+                if spawn_error is not None
+                else "exited with code %s" % proc.returncode
+            )
+            raise RuntimeError(
+                "cognee local server %s and nothing is listening on port %s. "
+                "See %s for the server output." % (cause, port, log_path)
+            )
         time.sleep(1.0)
     raise RuntimeError(
-        "cognee local server did not become healthy at %s within %ss" % (url, boot_timeout)
+        "cognee local server did not become healthy at %s within %ss. "
+        "See %s for the server output." % (url, boot_timeout, log_path)
     )

--- a/integrations/hermes-agent/plugin.yaml
+++ b/integrations/hermes-agent/plugin.yaml
@@ -1,6 +1,6 @@
 name: cognee
 kind: exclusive
-version: 0.1.0
+version: 0.2.0
 description: "Cognee memory provider for Hermes Agent: session-aware graph memory, recall, forget, and session-end improvement."
 pip_dependencies:
   - cognee>=1.0.0,<2.0.0

--- a/integrations/hermes-agent/plugin.yaml
+++ b/integrations/hermes-agent/plugin.yaml
@@ -3,7 +3,12 @@ kind: exclusive
 version: 0.2.0
 description: "Cognee memory provider for Hermes Agent: session-aware graph memory, recall, forget, and session-end improvement."
 pip_dependencies:
-  - cognee>=1.0.0,<2.0.0
+  # Floor 1.2.1: the HTTP wire contract this plugin depends on
+  # (/api/v1/remember/entry, improve(session_ids)) first shipped there.
+  # Cap 1.4.0: the newest version verified against the test suite and a live
+  # server boot. Repo policy (scripts/check_version_pins.py) requires a bounded
+  # range rather than an exact pin; the lockfile resolves to 1.4.0.
+  - cognee>=1.2.1,<=1.4.0
 hooks:
   - on_session_end
   - on_memory_write

--- a/integrations/hermes-agent/plugin.yaml
+++ b/integrations/hermes-agent/plugin.yaml
@@ -1,6 +1,6 @@
 name: cognee
 kind: exclusive
-version: 0.2.0
+version: 1.0.0
 description: "Cognee memory provider for Hermes Agent: session-aware graph memory, recall, forget, and session-end improvement."
 pip_dependencies:
   # Floor 1.2.1: the HTTP wire contract this plugin depends on

--- a/integrations/hermes-agent/pyproject.toml
+++ b/integrations/hermes-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cognee-integration-hermes-agent"
-version = "0.1.0"
+version = "0.2.0"
 description = "Standalone Cognee memory provider plugin for Hermes Agent."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/hermes-agent/pyproject.toml
+++ b/integrations/hermes-agent/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cognee-integration-hermes-agent"
-version = "0.2.0"
+version = "1.0.0"
 description = "Standalone Cognee memory provider plugin for Hermes Agent."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/hermes-agent/pyproject.toml
+++ b/integrations/hermes-agent/pyproject.toml
@@ -18,9 +18,20 @@ dependencies = [
 [project.entry-points."hermes_agent.plugins"]
 cognee = "cognee_integration_hermes"
 
+[project.scripts]
+# Hermes discovers plugins by directory scan, not entry points — this copies
+# the installed package into $HERMES_HOME/plugins/cognee. See installer.py.
+cognee-hermes-install = "cognee_integration_hermes.installer:main"
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["cognee_integration_hermes*"]
+
+[tool.setuptools.package-data]
+# The plugin-root files (plugin.yaml, cli.py shim, after-install.md) that the
+# installer lays down next to the package. Kept byte-identical to the repo-root
+# canonical copies by tests/test_installer.py.
+cognee_integration_hermes = ["_plugin_root/*"]
 
 [dependency-groups]
 dev = [

--- a/integrations/hermes-agent/pyproject.toml
+++ b/integrations/hermes-agent/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     {name = "Cognee team"}
 ]
 dependencies = [
-    "cognee>=1.0.0,<2.0.0",
+    "cognee>=1.2.1,<=1.4.0",
 ]
 
 [project.entry-points."hermes_agent.plugins"]

--- a/integrations/hermes-agent/tests/_char_helpers.py
+++ b/integrations/hermes-agent/tests/_char_helpers.py
@@ -101,6 +101,10 @@ class FakeCognee:
             "disconnect": None,
         }
         self.errors = {}
+        # ``gates[name] = threading.Event()`` holds that operation inside the call
+        # until the test sets the event — the only way to deterministically
+        # observe a provider worker that is mid-flight.
+        self.gates = {}
         self.config = _FakeCogneeConfig(self)
         self._lock = threading.Lock()
         self._events = {}
@@ -112,6 +116,9 @@ class FakeCognee:
             self.calls.append((name, kwargs))
             event = self._events.setdefault(name, threading.Event())
         event.set()
+        gate = self.gates.get(name)
+        if gate is not None:
+            gate.wait(timeout=5.0)
         error = self.errors.get(name)
         if error is not None:
             raise error

--- a/integrations/hermes-agent/tests/_char_helpers.py
+++ b/integrations/hermes-agent/tests/_char_helpers.py
@@ -6,21 +6,19 @@ builds, the session-id derivation, and the lifecycle-hook semantics that exist
 only in Hermes (``agent_context`` write gating, the prefetch two-phase protocol,
 ``on_memory_write``, ``on_delegation``).
 
-**One seam.** Every cognee-touching call the provider makes goes through a
-call-time ``import cognee``, so this module fakes the ``cognee`` module itself
-rather than patching provider internals. That has two useful properties:
+**Two fakes, one per layer.**
 
-1. The recorded kwargs are exactly what the provider asks cognee to do — which
-   is the contract the HTTP payloads must reproduce field for field.
-2. When the backend protocol lands, **this file is the only one that should need
-   to change.** The assertions live in the test modules and are written against
-   provider inputs and outputs, never against cognee.
+* :func:`fake_backend` records the provider's calls to the transport protocol.
+  Provider-level tests use this and never mention cognee — which is what lets the
+  transport change underneath them.
+* :func:`fake_cognee` installs a fake ``cognee`` package in ``sys.modules``. Only
+  the transport's own tests (``test_sdk_backend.py``) use it, to assert wire
+  format.
 
 None of these tests need the real cognee installed, and none of them touch the
-network or the filesystem outside ``tmp_path``.
+network or the filesystem outside a temporary directory.
 """
 
-import asyncio
 import contextlib
 import sys
 import threading
@@ -32,6 +30,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from cognee_integration_hermes import provider as provider_mod  # noqa: E402
+from cognee_integration_hermes.backend import MemoryBackend  # noqa: E402
 
 # Module paths the fake has to occupy for ``from cognee.x.y import z`` to
 # resolve. Keep in sync with the call-time imports in provider.py.
@@ -168,19 +167,14 @@ class FakeCognee:
         return self.record("disconnect", kwargs)
 
 
-class _SyncBridge:
-    """Runs the provider's coroutines inline — no event-loop thread in tests."""
-
-    def run(self, coro, timeout=None):
-        return asyncio.run(coro)
-
-    def shutdown(self):
-        pass
-
-
 @contextlib.contextmanager
 def fake_cognee():
-    """Install a :class:`FakeCognee` as the ``cognee`` package for the duration."""
+    """Install a :class:`FakeCognee` as the ``cognee`` package for the duration.
+
+    Used by ``test_sdk_backend.py`` to assert the SDK transport's wire format.
+    Provider-level tests use :func:`fake_backend` instead — they should not know
+    that cognee exists.
+    """
     recorder = FakeCognee()
 
     modules = {}
@@ -214,8 +208,124 @@ def fake_cognee():
                 sys.modules[path] = original
 
 
+class FakeBackend(MemoryBackend):
+    """Records the protocol calls the provider makes, and what it hands back.
+
+    This is the seam the contract tests assert against: provider behaviour on one
+    side, transport on the other. Each transport then has its own small test that
+    it faithfully turns these protocol args into wire format
+    (``test_sdk_backend.py``, and later an HTTP equivalent).
+
+    Shares ``FakeCognee``'s recorder API — ``results``, ``errors``, ``gates``,
+    ``wait``, ``kwargs_for``, ``only_call`` — so retargeting a test is a one-line
+    change of which recorder it reads.
+    """
+
+    def __init__(self):
+        self._recorder = FakeCognee()
+        self._recorder.results = {
+            "recall": [],
+            "remember_session": None,
+            "remember_permanent": RememberResultStub(),
+            "forget": {"deleted": True},
+            "improve": {},
+            "connect": None,
+            "resolve_identity": "USER",
+        }
+        self.empty_recall_hint_value = None
+
+    # Recorder passthrough ------------------------------------------------
+
+    @property
+    def results(self):
+        return self._recorder.results
+
+    @property
+    def errors(self):
+        return self._recorder.errors
+
+    @property
+    def gates(self):
+        return self._recorder.gates
+
+    @property
+    def calls(self):
+        return self._recorder.calls
+
+    def wait(self, name, timeout=2.0):
+        return self._recorder.wait(name, timeout=timeout)
+
+    def names(self):
+        return self._recorder.names()
+
+    def kwargs_for(self, name):
+        return self._recorder.kwargs_for(name)
+
+    def only_call(self, name):
+        return self._recorder.only_call(name)
+
+    # MemoryBackend -------------------------------------------------------
+
+    def configure_models(self, **kwargs):
+        self._recorder.record("configure_models", kwargs)
+
+    def configure_local_roots(self, **kwargs):
+        self._recorder.record("configure_local_roots", kwargs)
+
+    def connect(self, **kwargs):
+        return self._recorder.record("connect", kwargs)
+
+    def resolve_identity(self, **kwargs):
+        return self._recorder.record("resolve_identity", kwargs)
+
+    def close(self, **kwargs):
+        self._recorder.record("close", kwargs)
+
+    def recall(self, **kwargs):
+        return self._recorder.record("recall", kwargs)
+
+    def remember_session(self, **kwargs):
+        return self._recorder.record("remember_session", kwargs)
+
+    def remember_permanent(self, **kwargs):
+        return self._recorder.record("remember_permanent", kwargs)
+
+    def forget(self, **kwargs):
+        return self._recorder.record("forget", kwargs)
+
+    def improve(self, **kwargs):
+        return self._recorder.record("improve", kwargs)
+
+    def empty_recall_hint(self, **kwargs):
+        self._recorder.record("empty_recall_hint", kwargs)
+        return self.empty_recall_hint_value
+
+
+_CURRENT_FAKE_BACKEND = None
+
+
+@contextlib.contextmanager
+def fake_backend():
+    """Yield a :class:`FakeBackend` and make it the default for ``make_provider``.
+
+    Ambient on purpose, mirroring how ``fake_cognee`` installs itself into
+    ``sys.modules``: a test says ``with fake_backend() as fake`` and every
+    provider built inside the block records to it, with no plumbing at the call
+    sites.
+    """
+    global _CURRENT_FAKE_BACKEND
+    previous = _CURRENT_FAKE_BACKEND
+    backend = FakeBackend()
+    _CURRENT_FAKE_BACKEND = backend
+    try:
+        yield backend
+    finally:
+        _CURRENT_FAKE_BACKEND = previous
+
+
 def make_provider(
     *,
+    backend=None,
     dataset="hermes",
     top_k=5,
     session_id="s-1",
@@ -226,14 +336,14 @@ def make_provider(
     improve_on_end=True,
     config=None,
 ):
-    """A provider wired for inline execution, with post-``initialize()`` state set.
+    """A provider with post-``initialize()`` state set and a fake transport.
 
-    ``remote_mode`` defaults to True so the embedded-only dimension-mismatch
-    probe short-circuits — ``test_dim_mismatch.py`` already covers that gate, and
-    it disappears with the SDK.
+    Uses the ambient backend from an enclosing ``fake_backend()`` block, or a
+    throwaway one when there is none.
     """
-    provider = provider_mod.CogneeMemoryProvider()
-    provider._bridge = _SyncBridge()
+    provider = provider_mod.CogneeMemoryProvider(
+        backend=backend or _CURRENT_FAKE_BACKEND or FakeBackend()
+    )
     provider._initialized = True
     provider._remote_mode = remote_mode
     provider._writes_enabled = writes_enabled

--- a/integrations/hermes-agent/tests/_char_helpers.py
+++ b/integrations/hermes-agent/tests/_char_helpers.py
@@ -278,6 +278,9 @@ class FakeBackend(MemoryBackend):
     def resolve_identity(self, **kwargs):
         return self._recorder.record("resolve_identity", kwargs)
 
+    def ensure_dataset(self, **kwargs):
+        return self._recorder.record("ensure_dataset", kwargs)
+
     def close(self, **kwargs):
         self._recorder.record("close", kwargs)
 

--- a/integrations/hermes-agent/tests/_char_helpers.py
+++ b/integrations/hermes-agent/tests/_char_helpers.py
@@ -1,0 +1,246 @@
+"""Shared stubbing for the characterization suite.
+
+The characterization tests pin the behaviour the HTTP refactor must preserve:
+the JSON envelopes Hermes hands to the model, the request payloads the provider
+builds, the session-id derivation, and the lifecycle-hook semantics that exist
+only in Hermes (``agent_context`` write gating, the prefetch two-phase protocol,
+``on_memory_write``, ``on_delegation``).
+
+**One seam.** Every cognee-touching call the provider makes goes through a
+call-time ``import cognee``, so this module fakes the ``cognee`` module itself
+rather than patching provider internals. That has two useful properties:
+
+1. The recorded kwargs are exactly what the provider asks cognee to do — which
+   is the contract the HTTP payloads must reproduce field for field.
+2. When the backend protocol lands, **this file is the only one that should need
+   to change.** The assertions live in the test modules and are written against
+   provider inputs and outputs, never against cognee.
+
+None of these tests need the real cognee installed, and none of them touch the
+network or the filesystem outside ``tmp_path``.
+"""
+
+import asyncio
+import contextlib
+import sys
+import threading
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from cognee_integration_hermes import provider as provider_mod  # noqa: E402
+
+# Module paths the fake has to occupy for ``from cognee.x.y import z`` to
+# resolve. Keep in sync with the call-time imports in provider.py.
+_FAKE_MODULE_PATHS = (
+    "cognee",
+    "cognee.modules",
+    "cognee.modules.search",
+    "cognee.modules.search.types",
+)
+
+
+class RememberResultStub:
+    """Stands in for cognee's ``RememberResult`` (an object with ``.status``)."""
+
+    def __init__(self, status="completed"):
+        self.status = status
+
+
+class _SearchType:
+    """Enough of cognee's ``SearchType`` for ``_resolve_search_type`` to work.
+
+    Attribute lookup returns the name as a plain string so recorded
+    ``query_type`` values stay readable in assertions.
+    """
+
+    GRAPH_COMPLETION = "GRAPH_COMPLETION"
+    RAG_COMPLETION = "RAG_COMPLETION"
+    CHUNKS = "CHUNKS"
+    CHUNKS_LEXICAL = "CHUNKS_LEXICAL"
+    TEMPORAL = "TEMPORAL"
+    FEELING_LUCKY = "FEELING_LUCKY"
+
+
+class _FakeCogneeConfig:
+    def __init__(self, recorder):
+        self._recorder = recorder
+
+    def set_llm_api_key(self, value):
+        self._recorder.record("config.set_llm_api_key", {"value": value})
+
+    def set_llm_model(self, value):
+        self._recorder.record("config.set_llm_model", {"value": value})
+
+    def data_root_directory(self, value):
+        self._recorder.record("config.data_root_directory", {"value": value})
+
+    def system_root_directory(self, value):
+        self._recorder.record("config.system_root_directory", {"value": value})
+
+
+class FakeCognee:
+    """Records what the provider asks cognee to do, and what it hands back.
+
+    ``results[name]`` sets the return value for an operation; ``errors[name]``
+    makes it raise. Threaded provider paths (``sync_turn``, ``on_memory_write``,
+    ``queue_prefetch``) are awaited with :meth:`wait`.
+    """
+
+    def __init__(self):
+        self.calls = []
+        self.results = {
+            "recall": [],
+            "remember": RememberResultStub(),
+            "improve": {},
+            "forget": {"deleted": True},
+            "serve": None,
+            "disconnect": None,
+        }
+        self.errors = {}
+        self.config = _FakeCogneeConfig(self)
+        self._lock = threading.Lock()
+        self._events = {}
+
+    # -- recording ---------------------------------------------------------
+
+    def record(self, name, kwargs):
+        with self._lock:
+            self.calls.append((name, kwargs))
+            event = self._events.setdefault(name, threading.Event())
+        event.set()
+        error = self.errors.get(name)
+        if error is not None:
+            raise error
+        return self.results.get(name)
+
+    def _event(self, name):
+        with self._lock:
+            return self._events.setdefault(name, threading.Event())
+
+    def wait(self, name, timeout=2.0):
+        """Block until *name* has been called at least once. Returns True on success."""
+        return self._event(name).wait(timeout)
+
+    # -- inspection --------------------------------------------------------
+
+    def names(self):
+        return [name for name, _ in self.calls]
+
+    def kwargs_for(self, name):
+        return [kwargs for called, kwargs in self.calls if called == name]
+
+    def only_call(self, name):
+        """The kwargs of the single call to *name*; fails loudly if not exactly one."""
+        matches = self.kwargs_for(name)
+        if len(matches) != 1:
+            raise AssertionError(f"expected exactly 1 {name!r} call, got {len(matches)}")
+        return matches[0]
+
+    # -- the async surface provider.py awaits ------------------------------
+
+    async def recall(self, **kwargs):
+        return self.record("recall", kwargs)
+
+    async def remember(self, **kwargs):
+        return self.record("remember", kwargs)
+
+    async def improve(self, **kwargs):
+        return self.record("improve", kwargs)
+
+    async def forget(self, **kwargs):
+        return self.record("forget", kwargs)
+
+    async def serve(self, **kwargs):
+        return self.record("serve", kwargs)
+
+    async def disconnect(self, **kwargs):
+        return self.record("disconnect", kwargs)
+
+
+class _SyncBridge:
+    """Runs the provider's coroutines inline — no event-loop thread in tests."""
+
+    def run(self, coro, timeout=None):
+        return asyncio.run(coro)
+
+    def shutdown(self):
+        pass
+
+
+@contextlib.contextmanager
+def fake_cognee():
+    """Install a :class:`FakeCognee` as the ``cognee`` package for the duration."""
+    recorder = FakeCognee()
+
+    modules = {}
+    root = types.ModuleType("cognee")
+    root.recall = recorder.recall
+    root.remember = recorder.remember
+    root.improve = recorder.improve
+    root.forget = recorder.forget
+    root.serve = recorder.serve
+    root.disconnect = recorder.disconnect
+    root.config = recorder.config
+    modules["cognee"] = root
+
+    for path in _FAKE_MODULE_PATHS[1:]:
+        modules[path] = types.ModuleType(path)
+    modules["cognee.modules.search.types"].SearchType = _SearchType
+    # Parent-attribute wiring, so both ``import a.b`` and ``from a.b import c`` work.
+    modules["cognee"].modules = modules["cognee.modules"]
+    modules["cognee.modules"].search = modules["cognee.modules.search"]
+    modules["cognee.modules.search"].types = modules["cognee.modules.search.types"]
+
+    saved = {path: sys.modules.get(path) for path in _FAKE_MODULE_PATHS}
+    sys.modules.update(modules)
+    try:
+        yield recorder
+    finally:
+        for path, original in saved.items():
+            if original is None:
+                sys.modules.pop(path, None)
+            else:
+                sys.modules[path] = original
+
+
+def make_provider(
+    *,
+    dataset="hermes",
+    top_k=5,
+    session_id="s-1",
+    session_cognee_id=None,
+    remote_mode=True,
+    writes_enabled=True,
+    auto_route=True,
+    improve_on_end=True,
+    config=None,
+):
+    """A provider wired for inline execution, with post-``initialize()`` state set.
+
+    ``remote_mode`` defaults to True so the embedded-only dimension-mismatch
+    probe short-circuits — ``test_dim_mismatch.py`` already covers that gate, and
+    it disappears with the SDK.
+    """
+    provider = provider_mod.CogneeMemoryProvider()
+    provider._bridge = _SyncBridge()
+    provider._initialized = True
+    provider._remote_mode = remote_mode
+    provider._writes_enabled = writes_enabled
+    provider._dataset = dataset
+    provider._top_k = top_k
+    provider._auto_route = auto_route
+    provider._improve_on_end = improve_on_end
+    provider._session_id = session_id
+    provider._session_cognee_id = session_cognee_id or f"hermes_{session_id}"
+    provider._config = {
+        "recall_timeout": 5,
+        "write_timeout": 5,
+        "improve_timeout": 5,
+        "improve_background": "",
+        **(config or {}),
+    }
+    return provider

--- a/integrations/hermes-agent/tests/test_config_contract.py
+++ b/integrations/hermes-agent/tests/test_config_contract.py
@@ -130,7 +130,7 @@ class TestDefaults(unittest.TestCase):
         cfg = _load()
         self.assertEqual(cfg["dataset"], "hermes")
         self.assertEqual(cfg["top_k"], 5)
-        self.assertEqual(cfg["local_port"], 8000)
+        self.assertEqual(cfg["local_port"], 8011)
         self.assertEqual(cfg["server_boot_timeout"], 30)
         self.assertEqual(cfg["session_prefix"], "hermes")
         self.assertEqual(cfg["recall_timeout"], 120)
@@ -196,7 +196,7 @@ class TestEmptyEnvVarQuirks(unittest.TestCase):
     def test_blank_numeric_vars_fall_back_to_defaults(self):
         cfg = _load(env={"COGNEE_TOP_K": "", "COGNEE_LOCAL_PORT": ""})
         self.assertEqual(cfg["top_k"], 5)
-        self.assertEqual(cfg["local_port"], 8000)
+        self.assertEqual(cfg["local_port"], 8011)
 
     def test_blank_boolean_vars_fall_back_to_defaults(self):
         cfg = _load(env={"COGNEE_AUTO_ROUTE": "", "COGNEE_EMBEDDED": ""})

--- a/integrations/hermes-agent/tests/test_config_contract.py
+++ b/integrations/hermes-agent/tests/test_config_contract.py
@@ -143,7 +143,7 @@ class TestDefaults(unittest.TestCase):
         self.assertEqual(cfg["dataset"], "agent_sessions")
         self.assertEqual(cfg["top_k"], 5)
         self.assertEqual(cfg["local_port"], 8011)
-        self.assertEqual(cfg["server_boot_timeout"], 30)
+        self.assertEqual(cfg["server_boot_timeout"], 600)
         self.assertEqual(cfg["session_prefix"], "hermes")
         self.assertEqual(cfg["recall_timeout"], 120)
         self.assertEqual(cfg["write_timeout"], 120)

--- a/integrations/hermes-agent/tests/test_config_contract.py
+++ b/integrations/hermes-agent/tests/test_config_contract.py
@@ -1,0 +1,341 @@
+"""Characterization: config resolution, coercion, and the files we write.
+
+The subtle one is precedence: ``cognee.json`` is applied *over* the environment,
+so a saved config wins. Inverting that on rewrite would silently break every
+documented env var for anyone who has run the setup wizard.
+
+Run standalone with ``python3 tests/test_config_contract.py``.
+"""
+
+import contextlib
+import json
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from _char_helpers import make_provider  # noqa: E402
+from cognee_integration_hermes import config as config_mod  # noqa: E402
+
+# Every env var load_config reads. Removed (not blanked) before each test:
+# some keys distinguish "absent" from "empty" — see TestEmptyEnvVarQuirks.
+_MANAGED_KEYS = (
+    "COGNEE_BASE_URL",
+    "COGNEE_SERVICE_URL",
+    "COGNEE_API_KEY",
+    "COGNEE_EMBEDDED",
+    "COGNEE_DATASET",
+    "COGNEE_TOP_K",
+    "COGNEE_LOCAL_PORT",
+    "COGNEE_SERVER_BOOT_TIMEOUT",
+    "COGNEE_AUTO_ROUTE",
+    "COGNEE_IMPROVE_ON_END",
+    "COGNEE_IMPROVE_BACKGROUND",
+    "COGNEE_SESSION_PREFIX",
+    "COGNEE_DATA_ROOT",
+    "COGNEE_SYSTEM_ROOT",
+    "COGNEE_RECALL_TIMEOUT",
+    "COGNEE_WRITE_TIMEOUT",
+    "COGNEE_IMPROVE_TIMEOUT",
+    "COGNEE_HERMES_USER_EMAIL",
+    "COGNEE_HERMES_USER_PASSWORD",
+    "LLM_API_KEY",
+    "LLM_MODEL",
+)
+
+
+@contextlib.contextmanager
+def _clean_env(overrides=None):
+    """Run with every managed key *removed*, then apply *overrides*."""
+    env = {key: value for key, value in os.environ.items() if key not in _MANAGED_KEYS}
+    env.update(overrides or {})
+    with mock.patch.dict(os.environ, env, clear=True):
+        yield
+
+
+class _TmpHome:
+    """A temporary HERMES_HOME with an optional pre-written cognee.json."""
+
+    def __init__(self, file_config=None):
+        self._file_config = file_config
+        self._tmp = None
+
+    def __enter__(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        home = Path(self._tmp.name)
+        if self._file_config is not None:
+            (home / "cognee.json").write_text(json.dumps(self._file_config), encoding="utf-8")
+        return home
+
+    def __exit__(self, *exc):
+        self._tmp.cleanup()
+        return False
+
+
+def _load(env=None, file_config=None):
+    with _TmpHome(file_config) as home:
+        with _clean_env(env):
+            return config_mod.load_config(home)
+
+
+# --------------------------------------------------------------------------
+# Precedence
+# --------------------------------------------------------------------------
+
+
+class TestPrecedence(unittest.TestCase):
+    def test_file_config_overrides_the_environment(self):
+        cfg = _load(
+            env={"COGNEE_DATASET": "from_env"},
+            file_config={"dataset": "from_file"},
+        )
+        self.assertEqual(cfg["dataset"], "from_file")
+
+    def test_environment_is_used_when_the_file_omits_the_key(self):
+        cfg = _load(env={"COGNEE_DATASET": "from_env"}, file_config={"top_k": 3})
+        self.assertEqual(cfg["dataset"], "from_env")
+
+    def test_null_file_values_do_not_override(self):
+        cfg = _load(env={"COGNEE_DATASET": "from_env"}, file_config={"dataset": None})
+        self.assertEqual(cfg["dataset"], "from_env")
+
+    def test_unreadable_file_is_ignored_rather_than_fatal(self):
+        with _TmpHome() as home:
+            (home / "cognee.json").write_text("{not json", encoding="utf-8")
+            with _clean_env():
+                cfg = config_mod.load_config(home)
+        self.assertEqual(cfg["dataset"], config_mod.DEFAULT_DATASET)
+
+    def test_base_url_wins_over_the_deprecated_alias(self):
+        cfg = _load(
+            env={"COGNEE_BASE_URL": "https://canonical", "COGNEE_SERVICE_URL": "https://legacy"}
+        )
+        self.assertEqual(cfg["service_url"], "https://canonical")
+
+
+# --------------------------------------------------------------------------
+# Defaults and coercion
+# --------------------------------------------------------------------------
+
+
+class TestDefaults(unittest.TestCase):
+    def test_documented_defaults(self):
+        cfg = _load()
+        self.assertEqual(cfg["dataset"], "hermes")
+        self.assertEqual(cfg["top_k"], 5)
+        self.assertEqual(cfg["local_port"], 8000)
+        self.assertEqual(cfg["server_boot_timeout"], 30)
+        self.assertEqual(cfg["session_prefix"], "hermes")
+        self.assertEqual(cfg["recall_timeout"], 120)
+        self.assertEqual(cfg["write_timeout"], 120)
+        self.assertEqual(cfg["improve_timeout"], 300)
+        self.assertIs(cfg["auto_route"], True)
+        self.assertIs(cfg["improve_on_end"], True)
+        self.assertIs(cfg["embedded"], False)
+
+    def test_improve_background_is_an_empty_tristate_by_default(self):
+        # "" means auto (background in server/remote, synchronous in embedded).
+        self.assertEqual(_load()["improve_background"], "")
+
+    def test_improve_background_can_be_forced(self):
+        self.assertEqual(
+            _load(env={"COGNEE_IMPROVE_BACKGROUND": "false"})["improve_background"], "false"
+        )
+
+
+class TestCoercion(unittest.TestCase):
+    def test_top_k_floor_is_one(self):
+        self.assertEqual(_load(file_config={"top_k": 0})["top_k"], 1)
+        self.assertEqual(_load(file_config={"top_k": -5})["top_k"], 1)
+
+    def test_non_numeric_top_k_falls_back_to_the_default(self):
+        self.assertEqual(_load(file_config={"top_k": "abc"})["top_k"], 5)
+
+    def test_local_port_clamped_to_the_valid_range(self):
+        self.assertEqual(_load(env={"COGNEE_LOCAL_PORT": "999999"})["local_port"], 65535)
+        self.assertEqual(_load(env={"COGNEE_LOCAL_PORT": "0"})["local_port"], 1)
+
+    def test_timeout_floors_are_one(self):
+        cfg = _load(file_config={"recall_timeout": 0, "write_timeout": -1, "improve_timeout": 0})
+        self.assertEqual(cfg["recall_timeout"], 1)
+        self.assertEqual(cfg["write_timeout"], 1)
+        self.assertEqual(cfg["improve_timeout"], 1)
+
+    def test_server_boot_timeout_floor_is_one(self):
+        self.assertEqual(_load(file_config={"server_boot_timeout": 0})["server_boot_timeout"], 1)
+
+    def test_string_booleans_from_the_config_file_are_coerced(self):
+        cfg = _load(file_config={"auto_route": "no", "improve_on_end": "0", "embedded": "yes"})
+        self.assertIs(cfg["auto_route"], False)
+        self.assertIs(cfg["improve_on_end"], False)
+        self.assertIs(cfg["embedded"], True)
+
+
+class TestEmptyEnvVarQuirks(unittest.TestCase):
+    """An empty env var is not the same as an absent one — and not uniformly so.
+
+    Plain ``os.environ.get(key, DEFAULT)`` reads take the empty string as a real
+    value, while the ``str_to_int`` / ``str_to_bool`` reads fall back to their
+    default. Pinned because it is exactly the kind of asymmetry a rewrite tidies
+    up by accident, changing behaviour for anyone who exports a blank var.
+    """
+
+    def test_blank_dataset_is_honoured_as_empty(self):
+        self.assertEqual(_load(env={"COGNEE_DATASET": ""})["dataset"], "")
+
+    def test_blank_session_prefix_is_honoured_as_empty(self):
+        self.assertEqual(_load(env={"COGNEE_SESSION_PREFIX": ""})["session_prefix"], "")
+
+    def test_blank_numeric_vars_fall_back_to_defaults(self):
+        cfg = _load(env={"COGNEE_TOP_K": "", "COGNEE_LOCAL_PORT": ""})
+        self.assertEqual(cfg["top_k"], 5)
+        self.assertEqual(cfg["local_port"], 8000)
+
+    def test_blank_boolean_vars_fall_back_to_defaults(self):
+        cfg = _load(env={"COGNEE_AUTO_ROUTE": "", "COGNEE_EMBEDDED": ""})
+        self.assertIs(cfg["auto_route"], True)
+        self.assertIs(cfg["embedded"], False)
+
+    def test_the_provider_re_defaults_a_blank_dataset_at_use_time(self):
+        # provider.initialize does `config.get("dataset") or DEFAULT_DATASET`, so a
+        # blank dataset never reaches cognee — the recovery lives there, not in
+        # load_config. Both halves have to survive together.
+        provider = make_provider()
+        self.assertEqual(
+            str(_load(env={"COGNEE_DATASET": ""}).get("dataset") or "hermes"),
+            provider._dataset,
+        )
+
+
+class TestStrToBool(unittest.TestCase):
+    def test_truthy_spellings(self):
+        for value in ("1", "true", "TRUE", "yes", "y", "on", " True "):
+            self.assertTrue(config_mod.str_to_bool(value, False), value)
+
+    def test_falsy_spellings(self):
+        for value in ("0", "false", "no", "n", "off", " Off "):
+            self.assertFalse(config_mod.str_to_bool(value, True), value)
+
+    def test_unrecognized_and_none_use_the_default(self):
+        self.assertTrue(config_mod.str_to_bool("maybe", True))
+        self.assertFalse(config_mod.str_to_bool("maybe", False))
+        self.assertTrue(config_mod.str_to_bool(None, True))
+
+    def test_actual_booleans_pass_through(self):
+        self.assertTrue(config_mod.str_to_bool(True, False))
+        self.assertFalse(config_mod.str_to_bool(False, True))
+
+
+# --------------------------------------------------------------------------
+# Files we write
+# --------------------------------------------------------------------------
+
+
+class TestWriteEnvVars(unittest.TestCase):
+    def test_creates_the_file_with_owner_only_permissions(self):
+        with _TmpHome() as home:
+            env_path = home / ".env"
+            config_mod.write_env_vars(env_path, {"COGNEE_API_KEY": "secret"})
+            mode = stat.S_IMODE(env_path.stat().st_mode)
+        self.assertEqual(mode, 0o600)
+
+    def test_updates_an_existing_key_in_place(self):
+        with _TmpHome() as home:
+            env_path = home / ".env"
+            env_path.write_text("COGNEE_API_KEY=old\n", encoding="utf-8")
+            config_mod.write_env_vars(env_path, {"COGNEE_API_KEY": "new"})
+            lines = env_path.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(lines, ["COGNEE_API_KEY=new"])
+
+    def test_preserves_unrelated_lines_and_comments(self):
+        with _TmpHome() as home:
+            env_path = home / ".env"
+            env_path.write_text(
+                "# a comment\nOTHER_TOOL=keepme\nCOGNEE_API_KEY=old\n", encoding="utf-8"
+            )
+            config_mod.write_env_vars(env_path, {"COGNEE_API_KEY": "new"})
+            content = env_path.read_text(encoding="utf-8")
+        self.assertIn("# a comment", content)
+        self.assertIn("OTHER_TOOL=keepme", content)
+        self.assertIn("COGNEE_API_KEY=new", content)
+        self.assertNotIn("COGNEE_API_KEY=old", content)
+
+    def test_appends_keys_that_are_not_present(self):
+        with _TmpHome() as home:
+            env_path = home / ".env"
+            env_path.write_text("EXISTING=1\n", encoding="utf-8")
+            config_mod.write_env_vars(env_path, {"NEW_KEY": "2"})
+            lines = env_path.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(lines, ["EXISTING=1", "NEW_KEY=2"])
+
+    def test_empty_value_clears_a_key(self):
+        # This is how post_setup retires the deprecated COGNEE_SERVICE_URL alias.
+        with _TmpHome() as home:
+            env_path = home / ".env"
+            env_path.write_text("COGNEE_SERVICE_URL=https://legacy\n", encoding="utf-8")
+            config_mod.write_env_vars(env_path, {"COGNEE_SERVICE_URL": ""})
+            lines = env_path.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(lines, ["COGNEE_SERVICE_URL="])
+
+    def test_no_values_writes_no_file(self):
+        with _TmpHome() as home:
+            env_path = home / ".env"
+            config_mod.write_env_vars(env_path, {})
+            self.assertFalse(env_path.exists())
+
+
+class TestSaveConfig(unittest.TestCase):
+    def test_merges_into_an_existing_file(self):
+        with _TmpHome(file_config={"dataset": "old", "top_k": 3}) as home:
+            config_mod.save_config({"dataset": "new"}, home)
+            written = json.loads((home / "cognee.json").read_text(encoding="utf-8"))
+        self.assertEqual(written["dataset"], "new")
+        self.assertEqual(written["top_k"], 3)
+
+    def test_skips_none_values(self):
+        with _TmpHome(file_config={"dataset": "keep"}) as home:
+            config_mod.save_config({"dataset": None, "top_k": 4}, home)
+            written = json.loads((home / "cognee.json").read_text(encoding="utf-8"))
+        self.assertEqual(written["dataset"], "keep")
+        self.assertEqual(written["top_k"], 4)
+
+    def test_provider_save_config_never_writes_secrets(self):
+        provider = make_provider()
+        with _TmpHome() as home:
+            provider.save_config(
+                {
+                    "dataset": "hermes",
+                    "api_key": "ck_secret",
+                    "llm_api_key": "sk_secret",
+                },
+                str(home),
+            )
+            written = json.loads((home / "cognee.json").read_text(encoding="utf-8"))
+        self.assertEqual(written, {"dataset": "hermes"})
+
+    def test_provider_save_config_writes_nothing_when_only_secrets_are_given(self):
+        provider = make_provider()
+        with _TmpHome() as home:
+            provider.save_config({"api_key": "ck", "llm_api_key": "sk"}, str(home))
+            self.assertFalse((home / "cognee.json").exists())
+
+
+class TestConfigPath(unittest.TestCase):
+    def test_resolves_under_the_given_hermes_home(self):
+        with _TmpHome() as home:
+            self.assertEqual(config_mod.config_path(home), home / "cognee.json")
+
+    def test_is_none_when_hermes_home_cannot_be_resolved(self):
+        # hermes_constants is not importable outside a Hermes install.
+        self.assertIsNone(config_mod.config_path(None))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/integrations/hermes-agent/tests/test_config_contract.py
+++ b/integrations/hermes-agent/tests/test_config_contract.py
@@ -23,6 +23,7 @@ if str(ROOT) not in sys.path:
 
 from _char_helpers import make_provider  # noqa: E402
 from cognee_integration_hermes import config as config_mod  # noqa: E402
+from cognee_integration_hermes import provider as provider_mod  # noqa: E402
 
 # Every env var load_config reads. Removed (not blanked) before each test:
 # some keys distinguish "absent" from "empty" — see TestEmptyEnvVarQuirks.
@@ -325,6 +326,69 @@ class TestSaveConfig(unittest.TestCase):
         with _TmpHome() as home:
             provider.save_config({"api_key": "ck", "llm_api_key": "sk"}, str(home))
             self.assertFalse((home / "cognee.json").exists())
+
+
+class TestResolveLocalRoots(unittest.TestCase):
+    """Where cognee stores things — profile-scoped unless told otherwise."""
+
+    def test_scoped_under_hermes_home_by_default(self):
+        with _TmpHome() as home:
+            data, system = config_mod.resolve_local_roots({}, home)
+        self.assertTrue(data.endswith(str(Path("cognee") / "data")))
+        self.assertTrue(system.endswith(str(Path("cognee") / "system")))
+        self.assertTrue(data.startswith(str(home)))
+
+    def test_explicit_config_wins(self):
+        with _TmpHome() as home:
+            data, system = config_mod.resolve_local_roots(
+                {"data_root": "/mnt/graph", "system_root": "/mnt/sys"}, home
+            )
+        self.assertEqual(data, "/mnt/graph")
+        self.assertEqual(system, "/mnt/sys")
+
+    def test_a_single_override_leaves_the_other_scoped(self):
+        with _TmpHome() as home:
+            data, system = config_mod.resolve_local_roots({"data_root": "/mnt/graph"}, home)
+        self.assertEqual(data, "/mnt/graph")
+        self.assertTrue(system.startswith(str(home)))
+
+    def test_empty_when_there_is_nothing_to_say(self):
+        # No explicit config and no resolvable home: leave cognee's own defaults.
+        with _clean_env():
+            self.assertEqual(config_mod.resolve_local_roots({}, None), ("", ""))
+
+
+class TestBackupPaths(unittest.TestCase):
+    """``hermes backup`` walks HERMES_HOME itself; declare only what is outside it."""
+
+    def test_profile_scoped_roots_need_no_declaring(self):
+        with _TmpHome() as home:
+            with _clean_env():
+                provider = make_provider()
+                with mock.patch.object(config_mod, "resolve_hermes_home", return_value=home):
+                    with mock.patch.object(provider_mod, "resolve_hermes_home", return_value=home):
+                        self.assertEqual(provider.backup_paths(), [])
+
+    def test_externally_configured_roots_are_declared(self):
+        with _TmpHome() as home:
+            with _clean_env({"COGNEE_DATA_ROOT": "/mnt/graph", "COGNEE_SYSTEM_ROOT": "/mnt/sys"}):
+                provider = make_provider()
+                with mock.patch.object(provider_mod, "resolve_hermes_home", return_value=home):
+                    paths = provider.backup_paths()
+        self.assertEqual(sorted(paths), ["/mnt/graph", "/mnt/sys"])
+
+    def test_no_paths_when_roots_fall_back_to_cognee_defaults(self):
+        # Reporting those would mean importing cognee; this must stay cheap.
+        with _clean_env():
+            provider = make_provider()
+            with mock.patch.object(provider_mod, "resolve_hermes_home", return_value=None):
+                self.assertEqual(provider.backup_paths(), [])
+
+    def test_callable_without_initialize(self):
+        # Upstream requires this: backup runs on providers that were never started.
+        with _clean_env():
+            provider = provider_mod.CogneeMemoryProvider()
+            self.assertIsInstance(provider.backup_paths(), list)
 
 
 class TestConfigPath(unittest.TestCase):

--- a/integrations/hermes-agent/tests/test_config_contract.py
+++ b/integrations/hermes-agent/tests/test_config_contract.py
@@ -32,6 +32,7 @@ _MANAGED_KEYS = (
     "COGNEE_SERVICE_URL",
     "COGNEE_API_KEY",
     "COGNEE_EMBEDDED",
+    "COGNEE_PLUGIN_DATASET",
     "COGNEE_DATASET",
     "COGNEE_TOP_K",
     "COGNEE_LOCAL_PORT",
@@ -120,6 +121,15 @@ class TestPrecedence(unittest.TestCase):
         )
         self.assertEqual(cfg["service_url"], "https://canonical")
 
+    def test_plugin_dataset_wins_over_the_hermes_alias(self):
+        # COGNEE_PLUGIN_DATASET is what the other cognee plugins read; the
+        # 0.1.x-era COGNEE_DATASET stays as a lower-precedence alias.
+        cfg = _load(env={"COGNEE_PLUGIN_DATASET": "shared", "COGNEE_DATASET": "legacy"})
+        self.assertEqual(cfg["dataset"], "shared")
+
+    def test_the_hermes_dataset_alias_still_works(self):
+        self.assertEqual(_load(env={"COGNEE_DATASET": "legacy"})["dataset"], "legacy")
+
 
 # --------------------------------------------------------------------------
 # Defaults and coercion
@@ -129,7 +139,8 @@ class TestPrecedence(unittest.TestCase):
 class TestDefaults(unittest.TestCase):
     def test_documented_defaults(self):
         cfg = _load()
-        self.assertEqual(cfg["dataset"], "hermes")
+        # The dataset is shared with the other cognee agent plugins on purpose.
+        self.assertEqual(cfg["dataset"], "agent_sessions")
         self.assertEqual(cfg["top_k"], 5)
         self.assertEqual(cfg["local_port"], 8011)
         self.assertEqual(cfg["server_boot_timeout"], 30)
@@ -208,9 +219,9 @@ class TestEmptyEnvVarQuirks(unittest.TestCase):
         # provider.initialize does `config.get("dataset") or DEFAULT_DATASET`, so a
         # blank dataset never reaches cognee — the recovery lives there, not in
         # load_config. Both halves have to survive together.
-        provider = make_provider()
+        provider = make_provider(dataset=config_mod.DEFAULT_DATASET)
         self.assertEqual(
-            str(_load(env={"COGNEE_DATASET": ""}).get("dataset") or "hermes"),
+            str(_load(env={"COGNEE_DATASET": ""}).get("dataset") or config_mod.DEFAULT_DATASET),
             provider._dataset,
         )
 
@@ -329,45 +340,50 @@ class TestSaveConfig(unittest.TestCase):
 
 
 class TestResolveLocalRoots(unittest.TestCase):
-    """Where cognee stores things — profile-scoped unless told otherwise."""
+    """Where cognee stores things — the shared ~/.cognee unless told otherwise."""
 
-    def test_scoped_under_hermes_home_by_default(self):
-        with _TmpHome() as home:
-            data, system = config_mod.resolve_local_roots({}, home)
-        self.assertTrue(data.endswith(str(Path("cognee") / "data")))
-        self.assertTrue(system.endswith(str(Path("cognee") / "system")))
-        self.assertTrue(data.startswith(str(home)))
+    def test_the_shared_cognee_home_by_default(self):
+        data, system = config_mod.resolve_local_roots({})
+        self.assertEqual(data, str(config_mod.SHARED_COGNEE_HOME / "data"))
+        self.assertEqual(system, str(config_mod.SHARED_COGNEE_HOME / "system"))
+
+    def test_the_shared_home_matches_the_other_plugins(self):
+        # claude-code/codex/openclaw pin ~/.cognee/{data,system}; the point of
+        # the default is that any plugin's server serves the same store.
+        self.assertEqual(config_mod.SHARED_COGNEE_HOME, Path.home() / ".cognee")
+        self.assertEqual(config_mod.SHARED_PLUGIN_STATE_DIR, Path.home() / ".cognee-plugin")
 
     def test_explicit_config_wins(self):
-        with _TmpHome() as home:
-            data, system = config_mod.resolve_local_roots(
-                {"data_root": "/mnt/graph", "system_root": "/mnt/sys"}, home
-            )
+        data, system = config_mod.resolve_local_roots(
+            {"data_root": "/mnt/graph", "system_root": "/mnt/sys"}
+        )
         self.assertEqual(data, "/mnt/graph")
         self.assertEqual(system, "/mnt/sys")
 
-    def test_a_single_override_leaves_the_other_scoped(self):
-        with _TmpHome() as home:
-            data, system = config_mod.resolve_local_roots({"data_root": "/mnt/graph"}, home)
+    def test_a_single_override_leaves_the_other_shared(self):
+        data, system = config_mod.resolve_local_roots({"data_root": "/mnt/graph"})
         self.assertEqual(data, "/mnt/graph")
-        self.assertTrue(system.startswith(str(home)))
-
-    def test_empty_when_there_is_nothing_to_say(self):
-        # No explicit config and no resolvable home: leave cognee's own defaults.
-        with _clean_env():
-            self.assertEqual(config_mod.resolve_local_roots({}, None), ("", ""))
+        self.assertEqual(system, str(config_mod.SHARED_COGNEE_HOME / "system"))
 
 
 class TestBackupPaths(unittest.TestCase):
     """``hermes backup`` walks HERMES_HOME itself; declare only what is outside it."""
 
-    def test_profile_scoped_roots_need_no_declaring(self):
+    def test_the_shared_default_store_is_declared(self):
+        # The default roots live in ~/.cognee, outside any HERMES_HOME — a backup
+        # deliberately includes the machine's shared memory store.
         with _TmpHome() as home:
             with _clean_env():
                 provider = make_provider()
-                with mock.patch.object(config_mod, "resolve_hermes_home", return_value=home):
-                    with mock.patch.object(provider_mod, "resolve_hermes_home", return_value=home):
-                        self.assertEqual(provider.backup_paths(), [])
+                with mock.patch.object(provider_mod, "resolve_hermes_home", return_value=home):
+                    paths = provider.backup_paths()
+        self.assertEqual(
+            paths,
+            [
+                str(config_mod.SHARED_COGNEE_HOME / "data"),
+                str(config_mod.SHARED_COGNEE_HOME / "system"),
+            ],
+        )
 
     def test_externally_configured_roots_are_declared(self):
         with _TmpHome() as home:
@@ -377,12 +393,16 @@ class TestBackupPaths(unittest.TestCase):
                     paths = provider.backup_paths()
         self.assertEqual(sorted(paths), ["/mnt/graph", "/mnt/sys"])
 
-    def test_no_paths_when_roots_fall_back_to_cognee_defaults(self):
-        # Reporting those would mean importing cognee; this must stay cheap.
-        with _clean_env():
-            provider = make_provider()
-            with mock.patch.object(provider_mod, "resolve_hermes_home", return_value=None):
-                self.assertEqual(provider.backup_paths(), [])
+    def test_roots_inside_hermes_home_need_no_declaring(self):
+        with _TmpHome() as home:
+            env = {
+                "COGNEE_DATA_ROOT": str(home / "cognee" / "data"),
+                "COGNEE_SYSTEM_ROOT": str(home / "cognee" / "system"),
+            }
+            with _clean_env(env):
+                provider = make_provider()
+                with mock.patch.object(provider_mod, "resolve_hermes_home", return_value=home):
+                    self.assertEqual(provider.backup_paths(), [])
 
     def test_callable_without_initialize(self):
         # Upstream requires this: backup runs on providers that were never started.

--- a/integrations/hermes-agent/tests/test_dim_mismatch.py
+++ b/integrations/hermes-agent/tests/test_dim_mismatch.py
@@ -1,6 +1,10 @@
-"""Tests for the embedding-dimension probe in the Hermes provider.
+"""Tests for the embedding-dimension probe in the SDK transport.
 
-``_dimension_mismatch_hint`` returns a one-line actionable diagnostic naming both
+The probe lives with ``SdkBackend`` because it introspects the in-process vector
+engine — see ``backend.py``. The provider only asks for a hint when a recall comes
+back empty; the transport decides whether it can answer.
+
+``dimension_mismatch_hint`` returns a one-line actionable diagnostic naming both
 dims and the active model on a confirmed mismatch, and None in every other case
 (matching dims, no data, or any error) so recall keeps its normal empty-result
 behavior. A fake vector engine is injected so cognee is not required.
@@ -17,7 +21,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from cognee_integration_hermes import provider as provider_mod  # noqa: E402
+from cognee_integration_hermes import backend as backend_mod  # noqa: E402
 
 
 class _FakeEmbed:
@@ -83,7 +87,7 @@ class _FakeErrorEngine:
 
 
 def _hint(engine):
-    return asyncio.run(provider_mod._dimension_mismatch_hint(engine))
+    return asyncio.run(backend_mod.dimension_mismatch_hint(engine))
 
 
 class TestDimensionMismatchHint(unittest.TestCase):
@@ -122,26 +126,26 @@ class TestDimensionMismatchHint(unittest.TestCase):
         self.assertIsNone(_hint(_Broken()))
 
 
-class TestProviderGate(unittest.TestCase):
-    def test_remote_mode_skips_check(self):
-        provider = provider_mod.CogneeMemoryProvider()
-        provider._remote_mode = True
-        self.assertIsNone(provider._embedding_dimension_mismatch_hint())
+class TestBackendGate(unittest.TestCase):
+    def test_served_mode_skips_the_check(self):
+        backend = backend_mod.SdkBackend()
+        backend.served = True
+        self.assertIsNone(backend.empty_recall_hint())
 
-    def test_embedded_mode_runs_check_via_bridge(self):
-        provider = provider_mod.CogneeMemoryProvider()
-        provider._remote_mode = False
+    def test_in_process_mode_runs_the_check(self):
+        backend = backend_mod.SdkBackend()
+        backend.served = False
 
         async def _fake_hint():
             return "DIM MISMATCH"
 
-        original = provider_mod._dimension_mismatch_hint
-        provider_mod._dimension_mismatch_hint = _fake_hint
+        original = backend_mod.dimension_mismatch_hint
+        backend_mod.dimension_mismatch_hint = _fake_hint
         try:
-            self.assertEqual(provider._embedding_dimension_mismatch_hint(), "DIM MISMATCH")
+            self.assertEqual(backend.empty_recall_hint(), "DIM MISMATCH")
         finally:
-            provider_mod._dimension_mismatch_hint = original
-            provider._bridge.shutdown()
+            backend_mod.dimension_mismatch_hint = original
+            backend.close()
 
 
 if __name__ == "__main__":

--- a/integrations/hermes-agent/tests/test_exit_watcher.py
+++ b/integrations/hermes-agent/tests/test_exit_watcher.py
@@ -1,0 +1,261 @@
+"""Tests for the crash-safe session close (the detached exit watcher).
+
+The unit half exercises the state-file API and the fire logic against an
+in-process HTTP server. The live half spawns the real watcher process against a
+real dummy parent and kills the parent — the only way to prove the whole
+detached chain (spawn, poll, fire, disarm) actually works.
+
+Runs under pytest or standalone (``python3 tests/test_exit_watcher.py``); needs
+neither cognee nor the network (servers are local, on ephemeral ports).
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from cognee_integration_hermes import exit_watcher as ew  # noqa: E402
+
+
+class _RecordingServer:
+    """A local HTTP server that records every request and answers 200."""
+
+    def __init__(self):
+        self.requests = []
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length") or 0)
+                body = self.rfile.read(length) if length else b""
+                outer.requests.append(
+                    {
+                        "path": self.path,
+                        "body": json.loads(body) if body else None,
+                        "api_key": self.headers.get("X-Api-Key"),
+                    }
+                )
+                payload = b'{"ok": true}'
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def log_message(self, *args):  # keep test output quiet
+                pass
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.url = "http://127.0.0.1:%d" % self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def wait_for(self, count, timeout=15.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if len(self.requests) >= count:
+                return True
+            time.sleep(0.05)
+        return False
+
+    def close(self):
+        self._server.shutdown()
+        self._server.server_close()
+
+
+def _state(tmp, **overrides):
+    state = {
+        "parent_pid": os.getpid(),
+        "url": "http://127.0.0.1:1",
+        "agent_session_name": "hermes",
+        "dataset": "agent_sessions",
+        "session_id": "hermes_s1",
+        "improve": True,
+        "improve_timeout": 5.0,
+        "poll_interval": 0.05,
+    }
+    state.update(overrides)
+    path = Path(tmp) / "watcher.json"
+    ew.write_state(path, state)
+    return path
+
+
+class TestStateFileApi(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.tmp = tmp.name
+
+    def test_arm_writes_state_and_spawns_detached(self):
+        state_path = Path(self.tmp) / "w.json"
+        with mock.patch.object(ew.subprocess, "Popen") as popen:
+            ew.arm(
+                state_path=state_path,
+                log_path=Path(self.tmp) / "w.log",
+                parent_pid=123,
+                url="http://127.0.0.1:8011",
+                api_key="secret-key",
+                agent_session_name="hermes",
+                dataset="agent_sessions",
+                session_id="hermes_s1",
+                improve=True,
+                improve_timeout=300,
+            )
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertEqual(state["parent_pid"], 123)
+        self.assertEqual(state["session_id"], "hermes_s1")
+        # The key travels via the child env, never via the state file or argv.
+        self.assertNotIn("api_key", state)
+        args, kwargs = popen.call_args
+        self.assertEqual(args[0][0], sys.executable)
+        self.assertIn("--state", args[0])
+        self.assertNotIn("secret-key", " ".join(args[0]))
+        self.assertEqual(kwargs["env"]["COGNEE_API_KEY"], "secret-key")
+        self.assertTrue(kwargs["start_new_session"])
+
+    def test_update_merges_fields_and_preserves_the_rest(self):
+        path = _state(self.tmp, session_id="hermes_old")
+        ew.update(path, session_id="hermes_new", improve=False)
+        state = ew.read_state(path)
+        self.assertEqual(state["session_id"], "hermes_new")
+        self.assertIs(state["improve"], False)
+        self.assertEqual(state["dataset"], "agent_sessions")
+
+    def test_update_and_disarm_are_noops_without_a_state_file(self):
+        missing = Path(self.tmp) / "missing.json"
+        ew.update(missing, session_id="x")  # must not raise or create
+        self.assertFalse(missing.exists())
+        ew.disarm(missing)  # must not raise
+
+    def test_pid_alive(self):
+        self.assertTrue(ew.pid_alive(os.getpid()))
+        proc = subprocess.Popen([sys.executable, "-c", "pass"])
+        proc.wait()
+        self.assertFalse(ew.pid_alive(proc.pid))
+
+
+class TestFire(unittest.TestCase):
+    def setUp(self):
+        self.server = _RecordingServer()
+        self.addCleanup(self.server.close)
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.tmp = tmp.name
+
+    def _fire(self, **overrides):
+        state = ew.read_state(_state(self.tmp, url=self.server.url, **overrides))
+        with mock.patch.dict(os.environ, {"COGNEE_API_KEY": "k-env"}, clear=False):
+            ew.fire(state)
+        return self.server.requests
+
+    def test_improves_then_unregisters_in_that_order(self):
+        requests = self._fire()
+        self.assertEqual(
+            [r["path"] for r in requests],
+            ["/api/v1/improve", "/api/v1/agents/unregister"],
+        )
+        improve = requests[0]["body"]
+        self.assertEqual(improve["session_ids"], ["hermes_s1"])
+        self.assertEqual(improve["dataset_name"], "agent_sessions")
+        self.assertIs(improve["run_in_background"], False)
+        self.assertEqual(requests[0]["api_key"], "k-env")
+
+    def test_improve_is_skipped_when_disabled_but_unregister_still_runs(self):
+        requests = self._fire(improve=False)
+        self.assertEqual([r["path"] for r in requests], ["/api/v1/agents/unregister"])
+
+    def test_a_failed_improve_does_not_block_the_unregister(self):
+        state = ew.read_state(_state(self.tmp, url=self.server.url))
+        real_post = ew._post
+
+        def flaky(url, path, payload, **kwargs):
+            if path == "/api/v1/improve":
+                raise OSError("boom")
+            return real_post(url, path, payload, **kwargs)
+
+        with mock.patch.object(ew, "_post", side_effect=flaky):
+            ew.fire(state)
+        self.assertEqual([r["path"] for r in self.server.requests], ["/api/v1/agents/unregister"])
+
+
+class TestLiveWatcher(unittest.TestCase):
+    """The real detached chain: spawn the watcher, kill the parent, observe."""
+
+    def setUp(self):
+        self.server = _RecordingServer()
+        self.addCleanup(self.server.close)
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.tmp = tmp.name
+
+    def _arm(self, parent_pid, **overrides):
+        state_path = Path(self.tmp) / "watcher.json"
+        params = {
+            "state_path": state_path,
+            "log_path": Path(self.tmp) / "watcher.log",
+            "parent_pid": parent_pid,
+            "url": self.server.url,
+            "api_key": "k-live",
+            "agent_session_name": "hermes",
+            "dataset": "agent_sessions",
+            "session_id": "hermes_live",
+            "improve": True,
+            "improve_timeout": 10.0,
+            "poll_interval": 0.1,
+        }
+        params.update(overrides)
+        ew.arm(**params)
+        return state_path
+
+    def test_an_unclean_death_improves_and_unregisters(self):
+        parent = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(300)"])
+        self.addCleanup(parent.kill)
+        state_path = self._arm(parent.pid)
+
+        parent.kill()
+        parent.wait()
+
+        self.assertTrue(
+            self.server.wait_for(2),
+            f"watcher never fired; log:\n{(Path(self.tmp) / 'watcher.log').read_text()}",
+        )
+        self.assertEqual(
+            [r["path"] for r in self.server.requests],
+            ["/api/v1/improve", "/api/v1/agents/unregister"],
+        )
+        self.assertEqual(self.server.requests[0]["body"]["session_ids"], ["hermes_live"])
+        self.assertEqual(self.server.requests[0]["api_key"], "k-live")
+        # The watcher cleans up after itself once it has acted.
+        deadline = time.monotonic() + 5.0
+        while state_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        self.assertFalse(state_path.exists())
+
+    def test_a_clean_disarm_means_the_watcher_never_acts(self):
+        # The parent (this test process) stays alive; disarming must be enough.
+        state_path = self._arm(os.getpid())
+        # Give the watcher time to start and claim the state file.
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            state = ew.read_state(state_path)
+            if state and state.get("watcher_pid"):
+                break
+            time.sleep(0.05)
+        ew.disarm(state_path)
+        time.sleep(0.6)  # several poll intervals
+        self.assertEqual(self.server.requests, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/integrations/hermes-agent/tests/test_exit_watcher.py
+++ b/integrations/hermes-agent/tests/test_exit_watcher.py
@@ -144,6 +144,25 @@ class TestStateFileApi(unittest.TestCase):
         proc.wait()
         self.assertFalse(ew.pid_alive(proc.pid))
 
+    def test_pid_alive_rejects_group_and_garbage_pids(self):
+        # POSIX gives pid<=0 group/broadcast semantics — os.kill(-1, 0) would
+        # "succeed" and read as alive forever. Never wait on those.
+        for bogus in (0, -1, None, "not-a-pid"):
+            self.assertFalse(ew.pid_alive(bogus))
+
+    def test_pid_alive_on_windows_never_signals(self):
+        # On Windows os.kill implements non-console signals as TerminateProcess:
+        # "probing" with it would kill the watched Hermes. The Windows path must
+        # route through the process-handle query and never touch os.kill.
+        with (
+            mock.patch.object(ew, "_WINDOWS", True),
+            mock.patch.object(ew, "_pid_alive_windows", return_value=True) as win_probe,
+            mock.patch.object(ew.os, "kill") as kill,
+        ):
+            self.assertTrue(ew.pid_alive(1234))
+        win_probe.assert_called_once_with(1234)
+        kill.assert_not_called()
+
 
 class TestFire(unittest.TestCase):
     def setUp(self):

--- a/integrations/hermes-agent/tests/test_http_backend.py
+++ b/integrations/hermes-agent/tests/test_http_backend.py
@@ -15,6 +15,7 @@ Runs standalone with ``python3 tests/test_http_backend.py``; needs no cognee.
 import io
 import json
 import sys
+import tempfile
 import unittest
 import urllib.error
 from pathlib import Path
@@ -391,6 +392,13 @@ class TestConnect(unittest.TestCase):
 
 
 class TestApiKeyResolution(unittest.TestCase):
+    def setUp(self):
+        # An unset cache_dir means the real shared ~/.cognee-plugin — tests must
+        # never read a developer's actual key or overwrite it with a fake one.
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.cache_dir = tmp.name
+
     def _mint_opener(self):
         return FakeOpener(
             {
@@ -401,17 +409,25 @@ class TestApiKeyResolution(unittest.TestCase):
             }
         )
 
+    def _connect(self, opener, *, api_key="", url=_URL, cache_dir=None):
+        backend = HttpBackend(opener=opener, cache_dir=cache_dir or self.cache_dir)
+        backend.connect(url=url, api_key=api_key, timeout=_TIMEOUT)
+        return backend
+
+    def test_the_default_cache_is_the_shared_plugin_state_dir(self):
+        from cognee_integration_hermes.config import SHARED_PLUGIN_STATE_DIR
+
+        self.assertEqual(HttpBackend()._cache_dir, SHARED_PLUGIN_STATE_DIR)
+
     def test_a_configured_key_is_used_as_is(self):
         opener = self._mint_opener()
-        backend = HttpBackend(opener=opener)
-        backend.connect(url=_URL, api_key="given", timeout=_TIMEOUT)
+        backend = self._connect(opener, api_key="given")
         self.assertEqual(backend.api_key, "given")
         self.assertNotIn("/api/v1/auth/login", opener.paths())
 
     def test_a_key_is_minted_when_none_is_configured(self):
         opener = self._mint_opener()
-        backend = HttpBackend(opener=opener)
-        backend.connect(url=_URL, api_key="", timeout=_TIMEOUT)
+        backend = self._connect(opener)
         self.assertEqual(backend.api_key, "minted-key")
         login = opener.request_for("/api/v1/auth/login")
         self.assertEqual(login["headers"]["content-type"], "application/x-www-form-urlencoded")
@@ -420,37 +436,43 @@ class TestApiKeyResolution(unittest.TestCase):
     def test_minting_reuses_an_existing_key_when_the_server_lists_one(self):
         opener = self._mint_opener()
         opener.responses["/api/v1/auth/api-keys"] = [{"key": "existing-key"}]
-        backend = HttpBackend(opener=opener)
-        backend.connect(url=_URL, api_key="", timeout=_TIMEOUT)
+        backend = self._connect(opener)
         self.assertEqual(backend.api_key, "existing-key")
 
     def test_a_minted_key_is_cached_and_reused(self):
-        import tempfile
+        first = self._mint_opener()
+        self._connect(first)
+        self.assertIn("/api/v1/auth/login", first.paths())
 
-        with tempfile.TemporaryDirectory() as home:
-            first = self._mint_opener()
-            HttpBackend(opener=first, cache_dir=home).connect(
-                url=_URL, api_key="", timeout=_TIMEOUT
-            )
-            self.assertIn("/api/v1/auth/login", first.paths())
+        second = self._mint_opener()
+        backend = self._connect(second)
+        self.assertEqual(backend.api_key, "minted-key")
+        self.assertNotIn("/api/v1/auth/login", second.paths())
 
-            second = self._mint_opener()
-            backend = HttpBackend(opener=second, cache_dir=home)
-            backend.connect(url=_URL, api_key="", timeout=_TIMEOUT)
-            self.assertEqual(backend.api_key, "minted-key")
-            self.assertNotIn("/api/v1/auth/login", second.paths())
+    def test_the_cache_file_is_the_shared_plugin_format(self):
+        # The cache is shared with claude-code/codex/openclaw — same filename,
+        # same fields — so whichever plugin mints first, the rest reuse.
+        self._connect(self._mint_opener())
+        data = json.loads((Path(self.cache_dir) / "api_key.json").read_text(encoding="utf-8"))
+        self.assertEqual(data["api_key"], "minted-key")
+        self.assertEqual(data["base_url"], _URL)
+        self.assertIn("updated_at", data)
+
+    def test_a_key_cached_by_another_plugin_is_reused(self):
+        (Path(self.cache_dir) / "api_key.json").write_text(
+            json.dumps({"base_url": _URL, "api_key": "claude-minted", "updated_at": "x"}),
+            encoding="utf-8",
+        )
+        opener = self._mint_opener()
+        backend = self._connect(opener)
+        self.assertEqual(backend.api_key, "claude-minted")
+        self.assertNotIn("/api/v1/auth/login", opener.paths())
 
     def test_a_cached_key_for_a_different_url_is_ignored(self):
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as home:
-            HttpBackend(opener=self._mint_opener(), cache_dir=home).connect(
-                url=_URL, api_key="", timeout=_TIMEOUT
-            )
-            other = self._mint_opener()
-            backend = HttpBackend(opener=other, cache_dir=home)
-            backend.connect(url="http://127.0.0.1:9999", api_key="", timeout=_TIMEOUT)
-            self.assertIn("/api/v1/auth/login", other.paths())
+        self._connect(self._mint_opener())
+        other = self._mint_opener()
+        self._connect(other, url="http://127.0.0.1:9999")
+        self.assertIn("/api/v1/auth/login", other.paths())
 
     def test_failed_minting_proceeds_without_a_key(self):
         # A server with authentication disabled needs no key at all.
@@ -458,8 +480,7 @@ class TestApiKeyResolution(unittest.TestCase):
         opener.responses["/api/v1/auth/login"] = urllib.error.HTTPError(
             _URL, 404, "no auth", {}, None
         )
-        backend = HttpBackend(opener=opener)
-        backend.connect(url=_URL, api_key="", timeout=_TIMEOUT)
+        backend = self._connect(opener)
         self.assertEqual(backend.api_key, "")
 
 

--- a/integrations/hermes-agent/tests/test_http_backend.py
+++ b/integrations/hermes-agent/tests/test_http_backend.py
@@ -1,0 +1,573 @@
+"""Wire-level tests for ``HttpBackend``: protocol args in, HTTP requests out.
+
+The mirror of ``test_sdk_backend.py`` for the direct-HTTP transport. The provider
+tests already pin Hermes behaviour against the protocol; this file pins that the
+protocol becomes the request bodies cognee's routers actually accept (verified
+against cognee 1.2.1's DTOs).
+
+The headline assertion is :meth:`TestImproveWireFormat.test_session_ids_reach_the_wire`
+— the whole reason this transport exists.
+
+A fake opener stands in for ``urlopen``, so nothing here touches the network.
+Runs standalone with ``python3 tests/test_http_backend.py``; needs no cognee.
+"""
+
+import io
+import json
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from _char_helpers import make_provider  # noqa: E402
+from cognee_integration_hermes.http_backend import (  # noqa: E402
+    CogneeHttpError,
+    CogneeUnreachable,
+    HttpBackend,
+)
+
+_TIMEOUT = 5.0
+_URL = "http://127.0.0.1:8000"
+
+
+class _Response(io.BytesIO):
+    def __init__(self, payload, status=200):
+        body = payload if isinstance(payload, (bytes, str)) else json.dumps(payload)
+        super().__init__(body.encode("utf-8") if isinstance(body, str) else body)
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class FakeOpener:
+    """Records requests and replies from a per-path script."""
+
+    def __init__(self, responses=None):
+        self.requests = []
+        self.responses = responses or {}
+        self.default = {}
+
+    def __call__(self, request, timeout=None):
+        path = request.selector if hasattr(request, "selector") else request.full_url
+        body = request.data
+        self.requests.append(
+            {
+                "method": request.get_method(),
+                "path": path,
+                "url": request.full_url,
+                "headers": {k.lower(): v for k, v in request.header_items()},
+                "body": body,
+                "timeout": timeout,
+            }
+        )
+        outcome = self.responses.get(self._key(path), self.default)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return _Response(outcome)
+
+    @staticmethod
+    def _key(path):
+        return path.split("?")[0]
+
+    # -- inspection --------------------------------------------------------
+
+    def paths(self):
+        return [r["path"] for r in self.requests]
+
+    def request_for(self, path):
+        matches = [r for r in self.requests if r["path"] == path]
+        if len(matches) != 1:
+            raise AssertionError(f"expected exactly 1 request to {path}, got {len(matches)}")
+        return matches[0]
+
+    def json_body(self, path):
+        return json.loads(self.request_for(path)["body"].decode("utf-8"))
+
+    def multipart_fields(self, path):
+        """Parse a multipart body into ``{name: value}`` (text parts only)."""
+        raw = self.request_for(path)["body"].decode("utf-8", errors="replace")
+        fields = {}
+        for chunk in raw.split("--")[1:]:
+            if 'name="' not in chunk:
+                continue
+            name = chunk.split('name="', 1)[1].split('"', 1)[0]
+            if "\r\n\r\n" not in chunk:
+                continue
+            value = chunk.split("\r\n\r\n", 1)[1]
+            fields[name] = value.rsplit("\r\n", 1)[0]
+        return fields
+
+
+def _backend(opener, *, api_key="k", url=_URL, cache_dir=None):
+    backend = HttpBackend(opener=opener, cache_dir=cache_dir)
+    backend.url = url
+    backend.api_key = api_key
+    return backend
+
+
+class TestRecallWireFormat(unittest.TestCase):
+    def _recall(self, **overrides):
+        params = {
+            "query": "q",
+            "session_id": "hermes_s1",
+            "datasets": ["hermes"],
+            "top_k": 5,
+            "auto_route": True,
+            "query_type": None,
+            "timeout": _TIMEOUT,
+        }
+        params.update(overrides)
+        opener = FakeOpener({"/api/v1/recall": [{"text": "hit"}]})
+        results = _backend(opener).recall(**params)
+        return opener, results
+
+    def test_posts_to_the_recall_endpoint(self):
+        opener, _ = self._recall()
+        self.assertEqual(opener.request_for("/api/v1/recall")["method"], "POST")
+
+    def test_query_is_named_query_not_query_text(self):
+        # The endpoint's DTO field is ``query``; only the SDK calls it query_text.
+        opener, _ = self._recall(query="hello")
+        body = opener.json_body("/api/v1/recall")
+        self.assertEqual(body["query"], "hello")
+        self.assertNotIn("query_text", body)
+
+    def test_session_and_datasets_are_sent_when_targeted(self):
+        opener, _ = self._recall()
+        body = opener.json_body("/api/v1/recall")
+        self.assertEqual(body["session_id"], "hermes_s1")
+        self.assertEqual(body["datasets"], ["hermes"])
+        self.assertEqual(body["top_k"], 5)
+
+    def test_none_targets_are_omitted(self):
+        opener, _ = self._recall(datasets=None)
+        self.assertNotIn("datasets", opener.json_body("/api/v1/recall"))
+
+        opener, _ = self._recall(session_id=None)
+        self.assertNotIn("session_id", opener.json_body("/api/v1/recall"))
+
+    def test_query_type_is_sent_as_search_type_uppercased(self):
+        opener, _ = self._recall(query_type="chunks")
+        body = opener.json_body("/api/v1/recall")
+        self.assertEqual(body["search_type"], "CHUNKS")
+        self.assertNotIn("query_type", body)
+
+    def test_absent_query_type_is_omitted(self):
+        self.assertNotIn("search_type", self._recall()[0].json_body("/api/v1/recall"))
+
+    def test_api_key_header_is_sent(self):
+        opener, _ = self._recall()
+        self.assertEqual(opener.request_for("/api/v1/recall")["headers"]["x-api-key"], "k")
+
+    def test_results_are_returned_as_a_list(self):
+        _, results = self._recall()
+        self.assertEqual(results, [{"text": "hit"}])
+
+    def test_a_single_object_response_is_wrapped(self):
+        opener = FakeOpener({"/api/v1/recall": {"text": "one"}})
+        results = _backend(opener).recall(
+            query="q",
+            session_id=None,
+            datasets=None,
+            top_k=1,
+            auto_route=True,
+            query_type=None,
+            timeout=_TIMEOUT,
+        )
+        self.assertEqual(results, [{"text": "one"}])
+
+    def test_auto_route_false_warns_but_does_not_fail(self):
+        # /api/v1/recall has no auto_route field, so the setting cannot be honoured.
+        with self.assertLogs("cognee_integration_hermes.http_backend", level="WARNING") as logs:
+            opener, results = self._recall(auto_route=False)
+        self.assertIn("auto_route", "\n".join(logs.output))
+        self.assertNotIn("auto_route", opener.json_body("/api/v1/recall"))
+        self.assertEqual(results, [{"text": "hit"}])
+
+
+class TestRememberWireFormat(unittest.TestCase):
+    def test_session_write_carries_the_session_id(self):
+        opener = FakeOpener({"/api/v1/remember": {"status": "session_stored"}})
+        result = _backend(opener).remember_session(
+            text="a turn", session_id="hermes_s1", dataset="hermes", timeout=_TIMEOUT
+        )
+        fields = opener.multipart_fields("/api/v1/remember")
+        self.assertEqual(fields["datasetName"], "hermes")
+        self.assertEqual(fields["session_id"], "hermes_s1")
+        self.assertEqual(fields["data"], "a turn")
+        self.assertEqual(result.status, "session_stored")
+
+    def test_permanent_write_omits_the_session_id(self):
+        # No session_id makes the server do a direct add + cognify.
+        opener = FakeOpener({"/api/v1/remember": {"status": "completed"}})
+        _backend(opener).remember_permanent(
+            text="a fact", dataset="hermes", session_ids=[], timeout=_TIMEOUT
+        )
+        fields = opener.multipart_fields("/api/v1/remember")
+        self.assertNotIn("session_id", fields)
+        self.assertEqual(fields["data"], "a fact")
+
+    def test_permanent_write_warns_that_session_ids_cannot_be_sent(self):
+        opener = FakeOpener({"/api/v1/remember": {"status": "completed"}})
+        with self.assertLogs("cognee_integration_hermes.http_backend", level="WARNING") as logs:
+            _backend(opener).remember_permanent(
+                text="a fact", dataset="hermes", session_ids=["hermes_s1"], timeout=_TIMEOUT
+            )
+        self.assertIn("session_ids", "\n".join(logs.output))
+        self.assertNotIn("session_ids", opener.multipart_fields("/api/v1/remember"))
+
+    def test_content_type_is_multipart(self):
+        opener = FakeOpener({"/api/v1/remember": {}})
+        _backend(opener).remember_session(text="t", session_id="s", dataset="d", timeout=_TIMEOUT)
+        content_type = opener.request_for("/api/v1/remember")["headers"]["content-type"]
+        self.assertTrue(content_type.startswith("multipart/form-data; boundary="))
+
+    def test_result_exposes_status_as_an_attribute(self):
+        # The provider reads getattr(result, "status", "completed"); a bare dict
+        # would silently report "completed" for every write.
+        opener = FakeOpener({"/api/v1/remember": {"status": "running"}})
+        result = _backend(opener).remember_permanent(
+            text="t", dataset="d", session_ids=[], timeout=_TIMEOUT
+        )
+        self.assertEqual(result.status, "running")
+
+    def test_missing_status_defaults_to_completed(self):
+        opener = FakeOpener({"/api/v1/remember": {}})
+        result = _backend(opener).remember_permanent(
+            text="t", dataset="d", session_ids=[], timeout=_TIMEOUT
+        )
+        self.assertEqual(result.status, "completed")
+
+
+class TestImproveWireFormat(unittest.TestCase):
+    def test_session_ids_reach_the_wire(self):
+        """The regression this transport exists to fix.
+
+        ``cognee.improve(session_ids=[...])`` through the SDK's CloudClient never
+        sends them (improve.py:128 forwards only node_name/**kwargs), so the
+        session-to-graph bridge silently became a dataset-wide improve.
+        """
+        opener = FakeOpener({"/api/v1/improve": {"status": "started"}})
+        _backend(opener).improve(
+            dataset="hermes", session_ids=["hermes_s1"], background=True, timeout=_TIMEOUT
+        )
+        body = opener.json_body("/api/v1/improve")
+        self.assertEqual(body["session_ids"], ["hermes_s1"])
+        self.assertEqual(body["dataset_name"], "hermes")
+        self.assertIs(body["run_in_background"], True)
+
+    def test_background_false_is_sent_explicitly(self):
+        opener = FakeOpener({"/api/v1/improve": {}})
+        _backend(opener).improve(
+            dataset="hermes", session_ids=["s"], background=False, timeout=_TIMEOUT
+        )
+        self.assertIs(opener.json_body("/api/v1/improve")["run_in_background"], False)
+
+    def test_empty_session_ids_are_omitted(self):
+        opener = FakeOpener({"/api/v1/improve": {}})
+        _backend(opener).improve(
+            dataset="hermes", session_ids=[], background=True, timeout=_TIMEOUT
+        )
+        self.assertNotIn("session_ids", opener.json_body("/api/v1/improve"))
+
+
+class TestForgetWireFormat(unittest.TestCase):
+    def _forget(self, **overrides):
+        params = {
+            "dataset": "hermes",
+            "everything": False,
+            "memory_only": False,
+            "timeout": _TIMEOUT,
+        }
+        params.update(overrides)
+        opener = FakeOpener({"/api/v1/forget": {"deleted": True}})
+        _backend(opener).forget(**params)
+        return opener.json_body("/api/v1/forget")
+
+    def test_dataset_scoped_delete(self):
+        body = self._forget()
+        self.assertEqual(body["dataset"], "hermes")
+        self.assertIs(body["everything"], False)
+        self.assertIs(body["memory_only"], False)
+
+    def test_everything_drops_the_dataset(self):
+        body = self._forget(everything=True)
+        self.assertIs(body["everything"], True)
+        self.assertNotIn("dataset", body)
+
+    def test_memory_only_passes_through(self):
+        self.assertIs(self._forget(memory_only=True)["memory_only"], True)
+
+
+class TestConnect(unittest.TestCase):
+    def _opener(self, **overrides):
+        responses = {
+            "/health": {"status": "ok"},
+            "/api/v1/agents/register": {"id": "conn-1"},
+        }
+        responses.update(overrides)
+        return FakeOpener(responses)
+
+    def test_health_check_then_register(self):
+        opener = self._opener()
+        backend = HttpBackend(opener=opener)
+        backend.connect(url=_URL, api_key="k", timeout=_TIMEOUT)
+        self.assertEqual(opener.paths()[0], "/health")
+        self.assertIn("/api/v1/agents/register", opener.paths())
+        self.assertTrue(backend.registered)
+
+    def test_unreachable_server_raises(self):
+        # cognee.serve() only logged a warning here and handed back a client, so a
+        # bad COGNEE_BASE_URL looked like success until the first real call.
+        opener = self._opener(**{"/health": urllib.error.URLError("refused")})
+        backend = HttpBackend(opener=opener)
+        with self.assertRaises(CogneeUnreachable):
+            backend.connect(url=_URL, api_key="k", timeout=_TIMEOUT)
+
+    def test_unhealthy_server_raises(self):
+        opener = self._opener(**{"/health": urllib.error.HTTPError(_URL, 503, "down", {}, None)})
+        backend = HttpBackend(opener=opener)
+        with self.assertRaises(CogneeHttpError):
+            backend.connect(url=_URL, api_key="k", timeout=_TIMEOUT)
+
+    def test_registration_failure_is_not_fatal(self):
+        # Registration only drives the server's idle-shutdown watchdog.
+        opener = self._opener(
+            **{"/api/v1/agents/register": urllib.error.HTTPError(_URL, 404, "nope", {}, None)}
+        )
+        backend = HttpBackend(opener=opener)
+        backend.connect(url=_URL, api_key="k", timeout=_TIMEOUT)
+        self.assertFalse(backend.registered)
+
+    def test_trailing_slash_is_normalized(self):
+        opener = self._opener()
+        backend = HttpBackend(opener=opener)
+        backend.connect(url=_URL + "/", api_key="k", timeout=_TIMEOUT)
+        self.assertEqual(backend.url, _URL)
+
+    def test_close_unregisters_only_when_registered(self):
+        opener = self._opener(**{"/api/v1/agents/unregister": {"active_agents": 0}})
+        backend = HttpBackend(opener=opener)
+        backend.connect(url=_URL, api_key="k", timeout=_TIMEOUT)
+        backend.close(timeout=_TIMEOUT)
+        self.assertIn("/api/v1/agents/unregister", opener.paths())
+        self.assertFalse(backend.registered)
+
+        fresh = FakeOpener()
+        HttpBackend(opener=fresh).close(timeout=_TIMEOUT)
+        self.assertEqual(fresh.paths(), [])
+
+
+class TestApiKeyResolution(unittest.TestCase):
+    def _mint_opener(self):
+        return FakeOpener(
+            {
+                "/health": {"status": "ok"},
+                "/api/v1/auth/login": {"access_token": "jwt-1"},
+                "/api/v1/auth/api-keys": {"key": "minted-key"},
+                "/api/v1/agents/register": {},
+            }
+        )
+
+    def test_a_configured_key_is_used_as_is(self):
+        opener = self._mint_opener()
+        backend = HttpBackend(opener=opener)
+        backend.connect(url=_URL, api_key="given", timeout=_TIMEOUT)
+        self.assertEqual(backend.api_key, "given")
+        self.assertNotIn("/api/v1/auth/login", opener.paths())
+
+    def test_a_key_is_minted_when_none_is_configured(self):
+        opener = self._mint_opener()
+        backend = HttpBackend(opener=opener)
+        backend.connect(url=_URL, api_key="", timeout=_TIMEOUT)
+        self.assertEqual(backend.api_key, "minted-key")
+        login = opener.request_for("/api/v1/auth/login")
+        self.assertEqual(login["headers"]["content-type"], "application/x-www-form-urlencoded")
+        self.assertIn(b"username=", login["body"])
+
+    def test_minting_reuses_an_existing_key_when_the_server_lists_one(self):
+        opener = self._mint_opener()
+        opener.responses["/api/v1/auth/api-keys"] = [{"key": "existing-key"}]
+        backend = HttpBackend(opener=opener)
+        backend.connect(url=_URL, api_key="", timeout=_TIMEOUT)
+        self.assertEqual(backend.api_key, "existing-key")
+
+    def test_a_minted_key_is_cached_and_reused(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as home:
+            first = self._mint_opener()
+            HttpBackend(opener=first, cache_dir=home).connect(
+                url=_URL, api_key="", timeout=_TIMEOUT
+            )
+            self.assertIn("/api/v1/auth/login", first.paths())
+
+            second = self._mint_opener()
+            backend = HttpBackend(opener=second, cache_dir=home)
+            backend.connect(url=_URL, api_key="", timeout=_TIMEOUT)
+            self.assertEqual(backend.api_key, "minted-key")
+            self.assertNotIn("/api/v1/auth/login", second.paths())
+
+    def test_a_cached_key_for_a_different_url_is_ignored(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as home:
+            HttpBackend(opener=self._mint_opener(), cache_dir=home).connect(
+                url=_URL, api_key="", timeout=_TIMEOUT
+            )
+            other = self._mint_opener()
+            backend = HttpBackend(opener=other, cache_dir=home)
+            backend.connect(url="http://127.0.0.1:9999", api_key="", timeout=_TIMEOUT)
+            self.assertIn("/api/v1/auth/login", other.paths())
+
+    def test_failed_minting_proceeds_without_a_key(self):
+        # A server with authentication disabled needs no key at all.
+        opener = self._mint_opener()
+        opener.responses["/api/v1/auth/login"] = urllib.error.HTTPError(
+            _URL, 404, "no auth", {}, None
+        )
+        backend = HttpBackend(opener=opener)
+        backend.connect(url=_URL, api_key="", timeout=_TIMEOUT)
+        self.assertEqual(backend.api_key, "")
+
+
+class TestErrorMapping(unittest.TestCase):
+    def test_http_error_carries_the_status(self):
+        opener = FakeOpener({"/api/v1/recall": urllib.error.HTTPError(_URL, 401, "nope", {}, None)})
+        with self.assertRaises(CogneeHttpError) as caught:
+            _backend(opener).recall(
+                query="q",
+                session_id=None,
+                datasets=None,
+                top_k=1,
+                auto_route=True,
+                query_type=None,
+                timeout=_TIMEOUT,
+            )
+        self.assertEqual(caught.exception.status, 401)
+
+    def test_transport_failure_is_unreachable(self):
+        opener = FakeOpener({"/api/v1/recall": urllib.error.URLError("refused")})
+        with self.assertRaises(CogneeUnreachable):
+            _backend(opener).recall(
+                query="q",
+                session_id=None,
+                datasets=None,
+                top_k=1,
+                auto_route=True,
+                query_type=None,
+                timeout=_TIMEOUT,
+            )
+
+    def test_an_error_shaped_2xx_body_is_an_error(self):
+        opener = FakeOpener({"/api/v1/recall": {"error": "prerequisites not met"}})
+        with self.assertRaises(CogneeHttpError):
+            _backend(opener).recall(
+                query="q",
+                session_id=None,
+                datasets=None,
+                top_k=1,
+                auto_route=True,
+                query_type=None,
+                timeout=_TIMEOUT,
+            )
+
+    def test_malformed_json_is_a_server_error_not_unreachability(self):
+        opener = FakeOpener({"/api/v1/forget": "{not json"})
+        with self.assertRaises(CogneeHttpError):
+            _backend(opener).forget(
+                dataset="d", everything=False, memory_only=False, timeout=_TIMEOUT
+            )
+
+
+class TestEmptyRecallHint(unittest.TestCase):
+    def test_there_is_no_hint_over_http(self):
+        # The server owns the vector store; the probe is in-process only.
+        self.assertIsNone(HttpBackend(opener=FakeOpener()).empty_recall_hint())
+
+
+class TestProviderOverHttp(unittest.TestCase):
+    """The full stack: real provider, real HttpBackend, fake socket.
+
+    The provider tests pin behaviour against the protocol and the tests above pin
+    the protocol against the wire. This class is the join — the first place the two
+    layers run together, and the cheapest way to catch a mismatch that both halves
+    consider correct in isolation.
+    """
+
+    def _provider(self, opener, **kwargs):
+        return make_provider(backend=_backend(opener), **kwargs)
+
+    def test_recall_produces_the_model_visible_envelope(self):
+        opener = FakeOpener({"/api/v1/recall": [{"text": "alpha"}, {"text": "beta"}]})
+        provider = self._provider(opener)
+        out = json.loads(provider.handle_tool_call("cognee_recall", {"query": "q"}))
+        self.assertEqual(out["count"], 2)
+        self.assertEqual([item["text"] for item in out["results"]], ["alpha", "beta"])
+
+    def test_recall_miss_produces_the_miss_envelope(self):
+        opener = FakeOpener({"/api/v1/recall": []})
+        out = json.loads(self._provider(opener).handle_tool_call("cognee_recall", {"query": "q"}))
+        self.assertEqual(out, {"result": "No relevant Cognee memory found.", "count": 0})
+
+    def test_scope_routing_survives_the_whole_stack(self):
+        opener = FakeOpener({"/api/v1/recall": []})
+        provider = self._provider(opener, session_cognee_id="hermes_sX")
+        provider.handle_tool_call("cognee_recall", {"query": "q", "scope": "graph"})
+        body = opener.json_body("/api/v1/recall")
+        self.assertEqual(body["datasets"], ["hermes"])
+        self.assertNotIn("session_id", body)
+
+    def test_remember_reports_the_server_status(self):
+        # The trap: an HTTP dict has no .status attribute, so a bare dict here
+        # would make every write report "completed".
+        opener = FakeOpener({"/api/v1/remember": {"status": "running"}})
+        out = json.loads(
+            self._provider(opener).handle_tool_call("cognee_remember", {"content": "fact"})
+        )
+        self.assertEqual(out, {"result": "Content stored in Cognee.", "status": "running"})
+
+    def test_a_turn_goes_to_the_session_cache(self):
+        opener = FakeOpener({"/api/v1/remember": {"status": "session_stored"}})
+        provider = self._provider(opener, session_cognee_id="hermes_sY")
+        provider.sync_turn("hello", "hi there")
+        provider._sync_thread.join(timeout=2.0)
+        fields = opener.multipart_fields("/api/v1/remember")
+        self.assertEqual(fields["session_id"], "hermes_sY")
+        self.assertEqual(fields["data"], "User: hello\nAssistant: hi there")
+
+    def test_session_end_bridges_the_session_into_the_graph(self):
+        """End-to-end proof that finding #2 is fixed."""
+        opener = FakeOpener({"/api/v1/improve": {"status": "started"}})
+        provider = self._provider(opener, session_cognee_id="hermes_sZ")
+        provider.on_session_end([])
+        body = opener.json_body("/api/v1/improve")
+        self.assertEqual(body["session_ids"], ["hermes_sZ"])
+        self.assertEqual(body["dataset_name"], "hermes")
+
+    def test_a_backend_failure_becomes_the_error_envelope_and_trips_the_breaker(self):
+        opener = FakeOpener({"/api/v1/recall": urllib.error.URLError("refused")})
+        provider = self._provider(opener)
+        for _ in range(5):
+            out = json.loads(provider.handle_tool_call("cognee_recall", {"query": "q"}))
+            self.assertTrue(out["error"].startswith("Cognee recall failed:"))
+        self.assertTrue(provider._is_breaker_open())
+
+    def test_forget_reaches_the_endpoint_and_reports_details(self):
+        opener = FakeOpener({"/api/v1/forget": {"deleted": 2}})
+        out = json.loads(
+            self._provider(opener).handle_tool_call("cognee_forget", {"dataset": "hermes"})
+        )
+        self.assertEqual(out, {"result": "Cognee memory deleted.", "details": {"deleted": 2}})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/integrations/hermes-agent/tests/test_http_backend.py
+++ b/integrations/hermes-agent/tests/test_http_backend.py
@@ -512,6 +512,18 @@ class TestApiKeyResolution(unittest.TestCase):
         self.assertEqual(backend.api_key, "cached-cloud")
 
 
+class TestConnectionInfo(unittest.TestCase):
+    def test_none_before_connect(self):
+        self.assertIsNone(HttpBackend().connection_info())
+
+    def test_reports_the_server_details_after_connect(self):
+        backend = _backend(FakeOpener(), api_key="k")
+        self.assertEqual(
+            backend.connection_info(),
+            {"url": _URL, "api_key": "k", "agent_session_name": "hermes"},
+        )
+
+
 class TestErrorMapping(unittest.TestCase):
     def test_http_error_carries_the_status(self):
         opener = FakeOpener({"/api/v1/recall": urllib.error.HTTPError(_URL, 401, "nope", {}, None)})

--- a/integrations/hermes-agent/tests/test_http_backend.py
+++ b/integrations/hermes-agent/tests/test_http_backend.py
@@ -184,13 +184,24 @@ class TestRecallWireFormat(unittest.TestCase):
         )
         self.assertEqual(results, [{"text": "one"}])
 
-    def test_auto_route_false_warns_but_does_not_fail(self):
-        # /api/v1/recall has no auto_route field, so the setting cannot be honoured.
-        with self.assertLogs("cognee_integration_hermes.http_backend", level="WARNING") as logs:
-            opener, results = self._recall(auto_route=False)
-        self.assertIn("auto_route", "\n".join(logs.output))
-        self.assertNotIn("auto_route", opener.json_body("/api/v1/recall"))
+    def test_auto_route_false_becomes_an_explicit_graph_completion(self):
+        # There is no auto_route field, but the setting is expressible: server-side
+        # auto_route=False with no type means "skip the classifier, use
+        # GRAPH_COMPLETION", and naming that type bypasses the classifier too.
+        opener, results = self._recall(auto_route=False)
+        body = opener.json_body("/api/v1/recall")
+        self.assertEqual(body["search_type"], "GRAPH_COMPLETION")
+        self.assertNotIn("auto_route", body)
         self.assertEqual(results, [{"text": "hit"}])
+
+    def test_auto_route_false_does_not_override_an_explicit_search_type(self):
+        body = self._recall(auto_route=False, query_type="CHUNKS")[0].json_body("/api/v1/recall")
+        self.assertEqual(body["search_type"], "CHUNKS")
+
+    def test_auto_route_true_leaves_the_classifier_to_the_server(self):
+        self.assertNotIn(
+            "search_type", self._recall(auto_route=True)[0].json_body("/api/v1/recall")
+        )
 
 
 class TestRememberWireFormat(unittest.TestCase):

--- a/integrations/hermes-agent/tests/test_http_backend.py
+++ b/integrations/hermes-agent/tests/test_http_backend.py
@@ -512,6 +512,40 @@ class TestApiKeyResolution(unittest.TestCase):
         self.assertEqual(backend.api_key, "cached-cloud")
 
 
+class TestEnsureDatasetWireFormat(unittest.TestCase):
+    def test_posts_the_dataset_name(self):
+        opener = FakeOpener({"/api/v1/datasets": {"id": "d1"}})
+        _backend(opener).ensure_dataset(dataset="agent_sessions", timeout=_TIMEOUT)
+        request = opener.request_for("/api/v1/datasets")
+        self.assertEqual(request["method"], "POST")
+        self.assertEqual(opener.json_body("/api/v1/datasets"), {"name": "agent_sessions"})
+        self.assertEqual(request["headers"]["x-api-key"], "k")
+
+    def test_a_blank_dataset_sends_nothing(self):
+        opener = FakeOpener()
+        _backend(opener).ensure_dataset(dataset="", timeout=_TIMEOUT)
+        self.assertEqual(opener.paths(), [])
+
+    def test_a_redirecting_deployment_is_retried_at_the_slashed_path(self):
+        # Some deployments route the collection at /datasets/ and answer the
+        # non-slash POST with a 307, which urllib will not follow for a body.
+        opener = FakeOpener(
+            {
+                "/api/v1/datasets": urllib.error.HTTPError(_URL, 307, "moved", {}, None),
+                "/api/v1/datasets/": {"id": "d1"},
+            }
+        )
+        _backend(opener).ensure_dataset(dataset="agent_sessions", timeout=_TIMEOUT)
+        self.assertEqual(opener.json_body("/api/v1/datasets/"), {"name": "agent_sessions"})
+
+    def test_a_genuine_error_raises(self):
+        opener = FakeOpener(
+            {"/api/v1/datasets": urllib.error.HTTPError(_URL, 500, "boom", {}, None)}
+        )
+        with self.assertRaises(CogneeHttpError):
+            _backend(opener).ensure_dataset(dataset="agent_sessions", timeout=_TIMEOUT)
+
+
 class TestConnectionInfo(unittest.TestCase):
     def test_none_before_connect(self):
         self.assertIsNone(HttpBackend().connection_info())

--- a/integrations/hermes-agent/tests/test_http_backend.py
+++ b/integrations/hermes-agent/tests/test_http_backend.py
@@ -19,6 +19,7 @@ import tempfile
 import unittest
 import urllib.error
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -33,6 +34,7 @@ from cognee_integration_hermes.http_backend import (  # noqa: E402
 
 _TIMEOUT = 5.0
 _URL = "http://127.0.0.1:8000"
+_REMOTE_URL = "https://cloud.example"
 
 
 class _Response(io.BytesIO):
@@ -475,13 +477,39 @@ class TestApiKeyResolution(unittest.TestCase):
         self.assertIn("/api/v1/auth/login", other.paths())
 
     def test_failed_minting_proceeds_without_a_key(self):
-        # A server with authentication disabled needs no key at all.
+        # A LOCAL server with authentication disabled needs no key at all.
         opener = self._mint_opener()
         opener.responses["/api/v1/auth/login"] = urllib.error.HTTPError(
             _URL, 404, "no auth", {}, None
         )
         backend = self._connect(opener)
         self.assertEqual(backend.api_key, "")
+
+    def test_a_remote_target_without_a_key_fails_at_connect(self):
+        # Cognee Cloud exposes no login route to mint from; continuing without a
+        # key would smear one clear startup error into a 401 on every call.
+        opener = self._mint_opener()
+        with mock.patch.dict("os.environ", {"COGNEE_API_KEY": ""}, clear=False):
+            with self.assertRaisesRegex(RuntimeError, "COGNEE_API_KEY"):
+                self._connect(opener, url=_REMOTE_URL)
+        # And it never tried the default-user login against a remote host.
+        self.assertNotIn("/api/v1/auth/login", opener.paths())
+
+    def test_a_remote_target_with_an_env_key_connects(self):
+        opener = self._mint_opener()
+        with mock.patch.dict("os.environ", {"COGNEE_API_KEY": "cloud-key"}, clear=False):
+            backend = self._connect(opener, url=_REMOTE_URL)
+        self.assertEqual(backend.api_key, "cloud-key")
+        self.assertNotIn("/api/v1/auth/login", opener.paths())
+
+    def test_a_remote_target_with_a_cached_key_connects(self):
+        (Path(self.cache_dir) / "api_key.json").write_text(
+            json.dumps({"base_url": _REMOTE_URL, "api_key": "cached-cloud"}),
+            encoding="utf-8",
+        )
+        with mock.patch.dict("os.environ", {"COGNEE_API_KEY": ""}, clear=False):
+            backend = self._connect(self._mint_opener(), url=_REMOTE_URL)
+        self.assertEqual(backend.api_key, "cached-cloud")
 
 
 class TestErrorMapping(unittest.TestCase):

--- a/integrations/hermes-agent/tests/test_http_backend.py
+++ b/integrations/hermes-agent/tests/test_http_backend.py
@@ -205,16 +205,29 @@ class TestRecallWireFormat(unittest.TestCase):
 
 
 class TestRememberWireFormat(unittest.TestCase):
-    def test_session_write_carries_the_session_id(self):
-        opener = FakeOpener({"/api/v1/remember": {"status": "session_stored"}})
+    def test_a_turn_is_a_typed_qa_entry_not_a_document_upload(self):
+        # Live-diagnosed: /api/v1/remember takes its payload as a multipart file,
+        # which the server coerces to "[UploadFile]" and then *skips* for the
+        # session cache — reporting status "session_stored" while storing nothing.
+        # Turns must go through the typed-entry endpoint.
+        opener = FakeOpener({"/api/v1/remember/entry": {"status": "session_stored"}})
         result = _backend(opener).remember_session(
-            text="a turn", session_id="hermes_s1", dataset="hermes", timeout=_TIMEOUT
+            text="User: hi\nAssistant: hello",
+            session_id="hermes_s1",
+            dataset="hermes",
+            timeout=_TIMEOUT,
         )
-        fields = opener.multipart_fields("/api/v1/remember")
-        self.assertEqual(fields["datasetName"], "hermes")
-        self.assertEqual(fields["session_id"], "hermes_s1")
-        self.assertEqual(fields["data"], "a turn")
+        body = opener.json_body("/api/v1/remember/entry")
+        self.assertEqual(body["dataset_name"], "hermes")
+        self.assertEqual(body["session_id"], "hermes_s1")
+        self.assertEqual(body["entry"]["type"], "qa")
+        self.assertEqual(body["entry"]["answer"], "User: hi\nAssistant: hello")
         self.assertEqual(result.status, "session_stored")
+
+    def test_a_turn_does_not_touch_the_document_endpoint(self):
+        opener = FakeOpener({"/api/v1/remember/entry": {}})
+        _backend(opener).remember_session(text="t", session_id="s", dataset="d", timeout=_TIMEOUT)
+        self.assertEqual(opener.paths(), ["/api/v1/remember/entry"])
 
     def test_permanent_write_omits_the_session_id(self):
         # No session_id makes the server do a direct add + cognify.
@@ -235,9 +248,9 @@ class TestRememberWireFormat(unittest.TestCase):
         self.assertIn("session_ids", "\n".join(logs.output))
         self.assertNotIn("session_ids", opener.multipart_fields("/api/v1/remember"))
 
-    def test_content_type_is_multipart(self):
+    def test_a_permanent_write_is_multipart(self):
         opener = FakeOpener({"/api/v1/remember": {}})
-        _backend(opener).remember_session(text="t", session_id="s", dataset="d", timeout=_TIMEOUT)
+        _backend(opener).remember_permanent(text="t", dataset="d", session_ids=[], timeout=_TIMEOUT)
         content_type = opener.request_for("/api/v1/remember")["headers"]["content-type"]
         self.assertTrue(content_type.startswith("multipart/form-data; boundary="))
 
@@ -547,13 +560,13 @@ class TestProviderOverHttp(unittest.TestCase):
         self.assertEqual(out, {"result": "Content stored in Cognee.", "status": "running"})
 
     def test_a_turn_goes_to_the_session_cache(self):
-        opener = FakeOpener({"/api/v1/remember": {"status": "session_stored"}})
+        opener = FakeOpener({"/api/v1/remember/entry": {"status": "session_stored"}})
         provider = self._provider(opener, session_cognee_id="hermes_sY")
         provider.sync_turn("hello", "hi there")
         provider._sync_thread.join(timeout=2.0)
-        fields = opener.multipart_fields("/api/v1/remember")
-        self.assertEqual(fields["session_id"], "hermes_sY")
-        self.assertEqual(fields["data"], "User: hello\nAssistant: hi there")
+        body = opener.json_body("/api/v1/remember/entry")
+        self.assertEqual(body["session_id"], "hermes_sY")
+        self.assertEqual(body["entry"]["answer"], "User: hello\nAssistant: hi there")
 
     def test_session_end_bridges_the_session_into_the_graph(self):
         """End-to-end proof that finding #2 is fixed."""

--- a/integrations/hermes-agent/tests/test_installer.py
+++ b/integrations/hermes-agent/tests/test_installer.py
@@ -1,0 +1,110 @@
+"""Tests for the pip-install bridge (``cognee-hermes-install``).
+
+Hermes discovers plugins by directory scan, so the installer must materialize
+the exact plugin shape from the wheel: the root files at the plugin root and
+the package beside them. The drift tests are the load-bearing ones — the wheel
+ships *copies* of the repo-root plugin files, and a stale copy would publish a
+plugin.yaml that disagrees with the repository.
+
+Runs under pytest or standalone (``python3 tests/test_installer.py``); touches
+nothing outside temporary directories.
+"""
+
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from cognee_integration_hermes import installer  # noqa: E402
+
+_PACKAGE = ROOT / "cognee_integration_hermes"
+
+
+class TestPackagedCopiesMatchTheRepo(unittest.TestCase):
+    """The wheel's _plugin_root/* must be byte-identical to the repo root files."""
+
+    def _assert_same(self, name):
+        packaged = (_PACKAGE / "_plugin_root" / name).read_bytes()
+        canonical = (ROOT / name).read_bytes()
+        self.assertEqual(
+            packaged,
+            canonical,
+            f"{name}: the packaged copy under _plugin_root/ has drifted from the "
+            f"repo-root canonical file — re-copy it before publishing",
+        )
+
+    def test_plugin_yaml(self):
+        self._assert_same("plugin.yaml")
+
+    def test_cli_shim(self):
+        self._assert_same("cli.py")
+
+    def test_after_install(self):
+        self._assert_same("after-install.md")
+
+    def test_plugin_yaml_version_matches_pyproject(self):
+        # The CHANGELOG contract: one version across plugin.yaml and pyproject.
+        manifest = (ROOT / "plugin.yaml").read_text(encoding="utf-8")
+        manifest_version = next(
+            line.split(":", 1)[1].strip()
+            for line in manifest.splitlines()
+            if line.startswith("version:")
+        )
+        pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        self.assertIn(f'version = "{manifest_version}"', pyproject)
+
+
+class TestInstall(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.home = Path(tmp.name)
+
+    def test_lays_down_the_plugin_shape_hermes_scans_for(self):
+        target = installer.install(self.home)
+        self.assertEqual(target, self.home / "plugins" / "cognee")
+        for name in ("plugin.yaml", "cli.py", "after-install.md"):
+            self.assertTrue((target / name).is_file(), f"missing root file {name}")
+        # The package itself, importable next to the root files.
+        self.assertTrue((target / "cognee_integration_hermes" / "provider.py").is_file())
+        self.assertTrue((target / "cognee_integration_hermes" / "exit_watcher.py").is_file())
+
+    def test_bytecode_caches_are_not_shipped(self):
+        target = installer.install(self.home)
+        leftovers = list(target.rglob("__pycache__")) + list(target.rglob("*.pyc"))
+        self.assertEqual(leftovers, [])
+
+    def test_reinstall_replaces_the_package_wholesale(self):
+        target = installer.install(self.home)
+        stale = target / "cognee_integration_hermes" / "removed_in_next_version.py"
+        stale.write_text("# stale module from an older release\n", encoding="utf-8")
+        installer.install(self.home)
+        self.assertFalse(
+            stale.exists(),
+            "reinstall must replace the package dir, not merge into it — "
+            "stale modules from older releases would otherwise linger",
+        )
+
+    def test_missing_packaged_files_fail_loudly(self):
+        with mock.patch.object(installer, "_ROOT_FILES", ("no-such-file.txt",)):
+            with self.assertRaisesRegex(RuntimeError, "packaged plugin files missing"):
+                installer.install(self.home)
+
+    def test_main_honours_home_and_prints_next_steps(self):
+        out = io.StringIO()
+        with redirect_stdout(out):
+            code = installer.main(["--home", str(self.home)])
+        self.assertEqual(code, 0)
+        self.assertTrue((self.home / "plugins" / "cognee" / "plugin.yaml").is_file())
+        self.assertIn("hermes memory setup", out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/integrations/hermes-agent/tests/test_integration_concurrency.py
+++ b/integrations/hermes-agent/tests/test_integration_concurrency.py
@@ -13,11 +13,15 @@ Run locally (needs cognee installed + LLM creds for the write path):
 
 import importlib.util
 import os
+import signal
 import socket
+import subprocess
 import sys
+import tempfile
 import unittest
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -34,6 +38,40 @@ def _free_port() -> int:
         return s.getsockname()[1]
 
 
+def _kill_server_on(port: int) -> None:
+    """Stop the test-spawned server. ensure_local_server detaches it on purpose
+    (it must outlive Hermes in production), so tests have to reap it by port or
+    it lingers after the run, contending for whatever store it was pointed at."""
+    try:
+        found = subprocess.run(
+            ["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        for pid in found.stdout.split():
+            os.kill(int(pid), signal.SIGKILL)
+    except Exception:
+        pass
+
+
+def _isolated_env(tmp: str, port: int) -> dict:
+    """Point the spawned server and the provider at test-owned storage.
+
+    Without this the server would land on the shared ~/.cognee — the store a
+    developer's real cognee plugins are using — and two servers on one
+    single-writer store is exactly the contention these tests exist to rule out.
+    """
+    return {
+        "COGNEE_LOCAL_PORT": str(port),
+        "COGNEE_DATA_ROOT": str(Path(tmp) / "data"),
+        "COGNEE_SYSTEM_ROOT": str(Path(tmp) / "system"),
+        "COGNEE_BASE_URL": "",
+        "COGNEE_SERVICE_URL": "",
+        "COGNEE_EMBEDDED": "",
+    }
+
+
 def _looks_like_lock_error(exc: BaseException) -> bool:
     text = str(exc).lower()
     return "database is locked" in text or "database table is locked" in text
@@ -45,7 +83,16 @@ class TestRealServerSpawn(unittest.TestCase):
         from cognee_integration_hermes import server_bootstrap as sb
 
         port = _free_port()
-        url = sb.ensure_local_server(port, boot_timeout=90.0)
+        tmp = tempfile.TemporaryDirectory()
+        # LIFO: kill the server first, then remove the store it was using.
+        self.addCleanup(tmp.cleanup)
+        self.addCleanup(_kill_server_on, port)
+        url = sb.ensure_local_server(
+            port,
+            data_root=str(Path(tmp.name) / "data"),
+            system_root=str(Path(tmp.name) / "system"),
+            boot_timeout=90.0,
+        )
         self.assertEqual(url, f"http://127.0.0.1:{port}")
         self.assertTrue(sb.health_ok(url), "server should answer /health after spawn")
 
@@ -55,9 +102,15 @@ class TestConcurrentNoLocking(unittest.TestCase):
     def test_concurrent_remember_recall_no_database_locked(self):
         from cognee_integration_hermes import CogneeMemoryProvider
 
-        os.environ.setdefault("COGNEE_LOCAL_PORT", str(_free_port()))
+        port = _free_port()
+        tmp = tempfile.TemporaryDirectory()
+        # LIFO: shutdown (unregister) -> kill the server -> remove its store.
+        self.addCleanup(tmp.cleanup)
+        self.addCleanup(_kill_server_on, port)
         provider = CogneeMemoryProvider()
-        provider.initialize("integration-concurrency")
+        with mock.patch.dict("os.environ", _isolated_env(tmp.name, port), clear=False):
+            provider.initialize("integration-concurrency")
+        self.addCleanup(provider.shutdown)
 
         errors: list[BaseException] = []
 

--- a/integrations/hermes-agent/tests/test_integration_roundtrip.py
+++ b/integrations/hermes-agent/tests/test_integration_roundtrip.py
@@ -88,6 +88,7 @@ class TestHttpRoundTrip(unittest.TestCase):
         self.dataset = f"hermes_it_{_unique_suffix()}_{self._testMethodName[5:25]}"
 
     def _provider(self):
+        from cognee_integration_hermes import http_backend as http_backend_mod
         from cognee_integration_hermes.http_backend import HttpBackend
         from cognee_integration_hermes.provider import CogneeMemoryProvider
 
@@ -105,7 +106,12 @@ class TestHttpRoundTrip(unittest.TestCase):
             "COGNEE_RECALL_TIMEOUT": "120",
         }
         provider = CogneeMemoryProvider()
-        with mock.patch.dict("os.environ", env, clear=False):
+        with (
+            mock.patch.dict("os.environ", env, clear=False),
+            # The key cache defaults to the real shared ~/.cognee-plugin; a test
+            # server on a random port must not overwrite the machine's actual key.
+            mock.patch.object(http_backend_mod, "SHARED_PLUGIN_STATE_DIR", Path(self.home.name)),
+        ):
             provider.initialize(f"rt-{self._testMethodName}", hermes_home=self.home.name)
         self.assertIsInstance(
             provider._backend, HttpBackend, "the HTTP transport should be the default"
@@ -229,8 +235,8 @@ class TestHttpConnectAgainstRealServer(unittest.TestCase):
                 # resolved it must have been written through for the next session.
                 if backend.api_key:
                     self.assertTrue(
-                        (Path(home) / "cognee-api-key.json").exists(),
-                        "a resolved key should be cached under HERMES_HOME",
+                        (Path(home) / "api_key.json").exists(),
+                        "a resolved key should be cached in the shared-format file",
                     )
             finally:
                 backend.close(timeout=15.0)

--- a/integrations/hermes-agent/tests/test_integration_roundtrip.py
+++ b/integrations/hermes-agent/tests/test_integration_roundtrip.py
@@ -22,7 +22,9 @@ each other or a developer's real memory.
 import importlib.util
 import logging
 import os
+import signal
 import socket
+import subprocess
 import sys
 import tempfile
 import time
@@ -59,6 +61,23 @@ def _unique_suffix() -> str:
     return f"{os.getpid()}_{int(time.time())}"
 
 
+def _kill_server_on(port: int) -> None:
+    """Stop the test-spawned server. ensure_local_server detaches it on purpose
+    (it must outlive Hermes in production), so tests have to reap it by port or
+    it lingers after the run, contending for whatever store it was pointed at."""
+    try:
+        found = subprocess.run(
+            ["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        for pid in found.stdout.split():
+            os.kill(int(pid), signal.SIGKILL)
+    except Exception:
+        pass
+
+
 @unittest.skipUnless(_RUN and _HAS_COGNEE and _HAS_LLM, _REASON)
 class TestHttpRoundTrip(unittest.TestCase):
     """remember -> recall -> session turn -> session end -> recall from the graph."""
@@ -79,6 +98,7 @@ class TestHttpRoundTrip(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        _kill_server_on(cls.port)
         cls.home.cleanup()
 
     def setUp(self):
@@ -218,6 +238,7 @@ class TestHttpConnectAgainstRealServer(unittest.TestCase):
         from cognee_integration_hermes.server_bootstrap import ensure_local_server
 
         port = _free_port()
+        self.addCleanup(_kill_server_on, port)
         with tempfile.TemporaryDirectory() as home:
             url = ensure_local_server(
                 port,

--- a/integrations/hermes-agent/tests/test_integration_roundtrip.py
+++ b/integrations/hermes-agent/tests/test_integration_roundtrip.py
@@ -1,0 +1,261 @@
+"""Live round trip against a real cognee server — the only proof that matters.
+
+Everything else in this suite is mocked at one seam or another, so nothing else
+can catch a wire format the server rejects, or a field it accepts and ignores.
+This is specifically the test for the bug the HTTP transport exists to fix:
+``improve(session_ids=[...])`` bridging a session's cached turns into the
+permanent graph. Through the SDK's ``CloudClient`` those ids are dropped
+(``improve.py:128`` forwards only ``node_name`` and ``**kwargs``), so the bridge
+silently degraded into a dataset-wide improve and session turns never landed in
+the graph.
+
+**Opt-in**: needs a real cognee install *and* LLM credentials (graph extraction
+calls an LLM), so it is skipped unless both are present::
+
+    COGNEE_RUN_INTEGRATION=1 LLM_API_KEY=sk-... \\
+        uv run pytest tests/test_integration_roundtrip.py -v
+
+Each run uses its own dataset and its own port, so repeated runs do not pollute
+each other or a developer's real memory.
+"""
+
+import importlib.util
+import os
+import socket
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_RUN = os.environ.get("COGNEE_RUN_INTEGRATION") == "1"
+_HAS_COGNEE = importlib.util.find_spec("cognee") is not None
+_HAS_LLM = bool(os.environ.get("LLM_API_KEY"))
+_REASON = (
+    "set COGNEE_RUN_INTEGRATION=1, install cognee, and provide LLM_API_KEY "
+    "(graph extraction needs an LLM) to run the live round trip"
+)
+
+# Graph building is LLM-bound; these are deliberately patient.
+_BOOT_TIMEOUT = 120.0
+_WRITE_TIMEOUT = 600.0
+_IMPROVE_TIMEOUT = 900.0
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _unique_suffix() -> str:
+    # Unique per run so reruns neither collide nor accumulate.
+    return f"{os.getpid()}_{int(time.time())}"
+
+
+@unittest.skipUnless(_RUN and _HAS_COGNEE and _HAS_LLM, _REASON)
+class TestHttpRoundTrip(unittest.TestCase):
+    """remember -> recall -> session turn -> session end -> recall from the graph."""
+
+    @classmethod
+    def setUpClass(cls):
+        from cognee_integration_hermes.server_bootstrap import ensure_local_server
+
+        cls.port = _free_port()
+        cls.home = tempfile.TemporaryDirectory()
+        cls.dataset = f"hermes_it_{_unique_suffix()}"
+        # Own the server's storage too, so the run leaves nothing behind.
+        cls.url = ensure_local_server(
+            cls.port,
+            data_root=str(Path(cls.home.name) / "cognee" / "data"),
+            system_root=str(Path(cls.home.name) / "cognee" / "system"),
+            boot_timeout=_BOOT_TIMEOUT,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.home.cleanup()
+
+    def _provider(self):
+        from cognee_integration_hermes.http_backend import HttpBackend
+        from cognee_integration_hermes.provider import CogneeMemoryProvider
+
+        env = {
+            "COGNEE_BASE_URL": "",
+            "COGNEE_SERVICE_URL": "",
+            "COGNEE_EMBEDDED": "",
+            "COGNEE_LOCAL_PORT": str(self.port),
+            "COGNEE_DATASET": self.dataset,
+            # Synchronous improve: on_session_end backgrounds it by default in
+            # server mode, and a backgrounded bridge cannot be asserted on.
+            "COGNEE_IMPROVE_BACKGROUND": "false",
+            "COGNEE_WRITE_TIMEOUT": str(int(_WRITE_TIMEOUT)),
+            "COGNEE_IMPROVE_TIMEOUT": str(int(_IMPROVE_TIMEOUT)),
+            "COGNEE_RECALL_TIMEOUT": "120",
+        }
+        provider = CogneeMemoryProvider()
+        with mock.patch.dict("os.environ", env, clear=False):
+            provider.initialize("roundtrip-1", hermes_home=self.home.name)
+        self.assertIsInstance(
+            provider._backend, HttpBackend, "the HTTP transport should be the default"
+        )
+        self.assertTrue(provider._initialized)
+        return provider
+
+    def test_explicit_remember_is_recallable(self):
+        import json
+
+        provider = self._provider()
+        try:
+            fact = "The Meditech Solutions contract is worth 1.2 million pounds."
+            stored = json.loads(provider.handle_tool_call("cognee_remember", {"content": fact}))
+            self.assertNotIn("error", stored, stored)
+
+            found = json.loads(
+                provider.handle_tool_call(
+                    "cognee_recall",
+                    {"query": "What is the Meditech Solutions contract worth?"},
+                )
+            )
+            self.assertNotIn("error", found, found)
+            self.assertGreater(found.get("count", 0), 0, f"nothing recalled: {found}")
+        finally:
+            provider.shutdown()
+
+    def test_session_turns_reach_the_graph_after_session_end(self):
+        """The regression test for the dropped ``session_ids``.
+
+        A turn goes into the session cache, which does no graph extraction. Only
+        ``improve(session_ids=[...])`` promotes it. If those ids do not reach the
+        server the bridge becomes a dataset-wide improve and the turn stays
+        invisible to a graph-scoped recall.
+        """
+        import json
+
+        provider = self._provider()
+        try:
+            provider.sync_turn(
+                "Remember that Ada Lovelace wrote the first algorithm.",
+                "Noted — Ada Lovelace wrote the first algorithm.",
+            )
+            if provider._sync_thread is not None:
+                provider._sync_thread.join(timeout=_WRITE_TIMEOUT)
+
+            # Before the bridge runs, the graph should not have it yet.
+            provider.on_session_end([])
+
+            found = json.loads(
+                provider.handle_tool_call(
+                    "cognee_recall",
+                    {"query": "Who wrote the first algorithm?", "scope": "graph"},
+                )
+            )
+            self.assertNotIn("error", found, found)
+            self.assertGreater(
+                found.get("count", 0),
+                0,
+                "the session turn never reached the graph — improve() probably did "
+                f"not carry session_ids: {found}",
+            )
+        finally:
+            provider.shutdown()
+
+    def test_forget_clears_the_dataset(self):
+        import json
+
+        provider = self._provider()
+        try:
+            provider.handle_tool_call("cognee_remember", {"content": "Disposable fact."})
+            result = json.loads(
+                provider.handle_tool_call("cognee_forget", {"dataset": self.dataset})
+            )
+            self.assertNotIn("error", result, result)
+        finally:
+            provider.shutdown()
+
+
+@unittest.skipUnless(
+    _RUN and _HAS_COGNEE,
+    "set COGNEE_RUN_INTEGRATION=1 and install cognee to run the live connect check",
+)
+class TestHttpConnectAgainstRealServer(unittest.TestCase):
+    """Boot a real server and exercise ``connect()`` — no LLM required.
+
+    Covers the parts that only a real server can confirm: that ``/health`` answers,
+    that an API key can actually be minted through
+    ``/api/v1/auth/login`` -> ``/api/v1/auth/api-keys``, and that the agent
+    connection registers and unregisters. Writes and recalls need an LLM, so they
+    live in :class:`TestHttpRoundTrip`; this class is the credential-free half and
+    is the one to run first when something looks wrong.
+    """
+
+    def test_connect_mints_a_key_registers_and_caches(self):
+        from cognee_integration_hermes.http_backend import HttpBackend
+        from cognee_integration_hermes.server_bootstrap import ensure_local_server
+
+        port = _free_port()
+        with tempfile.TemporaryDirectory() as home:
+            url = ensure_local_server(
+                port,
+                data_root=str(Path(home) / "data"),
+                system_root=str(Path(home) / "system"),
+                boot_timeout=_BOOT_TIMEOUT,
+            )
+            backend = HttpBackend(cache_dir=home)
+            try:
+                backend.connect(url=url, api_key="", timeout=60.0)
+                self.assertEqual(backend.url, url)
+                self.assertTrue(backend.registered, "agent connection should register")
+                # A server with auth enabled hands back a key, which we cache; one
+                # with auth disabled needs none. Either is fine — but if a key was
+                # resolved it must have been written through for the next session.
+                if backend.api_key:
+                    self.assertTrue(
+                        (Path(home) / "cognee-api-key.json").exists(),
+                        "a resolved key should be cached under HERMES_HOME",
+                    )
+            finally:
+                backend.close(timeout=15.0)
+            self.assertFalse(backend.registered, "close() should unregister")
+
+
+@unittest.skipUnless(_RUN, "set COGNEE_RUN_INTEGRATION=1 to run against real sockets")
+class TestHttpConnectFailsLoudly(unittest.TestCase):
+    """An unreachable target must raise, not look like success.
+
+    ``cognee.serve()`` logged a warning and returned a client anyway, so a wrong
+    ``COGNEE_BASE_URL`` only surfaced on the first real call. This needs neither
+    cognee nor an LLM — just a real socket refusing a connection — so it is the
+    cheapest live check in the suite. Its mocked twin lives in
+    ``test_http_backend.py::TestConnect``.
+    """
+
+    def test_unreachable_base_url_raises(self):
+        from cognee_integration_hermes.provider import CogneeMemoryProvider
+
+        env = {
+            # A port nothing is listening on.
+            "COGNEE_BASE_URL": f"http://127.0.0.1:{_free_port()}",
+            "COGNEE_SERVICE_URL": "",
+            "COGNEE_EMBEDDED": "",
+        }
+        provider = CogneeMemoryProvider()
+        with mock.patch.dict("os.environ", env, clear=False):
+            with self.assertRaises(RuntimeError):
+                provider.initialize("unreachable-1")
+        self.assertFalse(provider._initialized)
+
+        # And having failed, it must refuse to work rather than degrade.
+        import json
+
+        out = json.loads(provider.handle_tool_call("cognee_recall", {"query": "q"}))
+        self.assertIn("unavailable", out["error"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/integrations/hermes-agent/tests/test_integration_roundtrip.py
+++ b/integrations/hermes-agent/tests/test_integration_roundtrip.py
@@ -20,6 +20,7 @@ each other or a developer's real memory.
 """
 
 import importlib.util
+import logging
 import os
 import socket
 import sys
@@ -68,7 +69,6 @@ class TestHttpRoundTrip(unittest.TestCase):
 
         cls.port = _free_port()
         cls.home = tempfile.TemporaryDirectory()
-        cls.dataset = f"hermes_it_{_unique_suffix()}"
         # Own the server's storage too, so the run leaves nothing behind.
         cls.url = ensure_local_server(
             cls.port,
@@ -80,6 +80,12 @@ class TestHttpRoundTrip(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.home.cleanup()
+
+    def setUp(self):
+        # One dataset and one session per test. Sharing them let the forget test
+        # (alphabetically earlier) delete the state the bridge test needs, which
+        # surfaced as a misleading "Recall prerequisites not met" from the server.
+        self.dataset = f"hermes_it_{_unique_suffix()}_{self._testMethodName[5:25]}"
 
     def _provider(self):
         from cognee_integration_hermes.http_backend import HttpBackend
@@ -100,7 +106,7 @@ class TestHttpRoundTrip(unittest.TestCase):
         }
         provider = CogneeMemoryProvider()
         with mock.patch.dict("os.environ", env, clear=False):
-            provider.initialize("roundtrip-1", hermes_home=self.home.name)
+            provider.initialize(f"rt-{self._testMethodName}", hermes_home=self.home.name)
         self.assertIsInstance(
             provider._backend, HttpBackend, "the HTTP transport should be the default"
         )
@@ -146,8 +152,15 @@ class TestHttpRoundTrip(unittest.TestCase):
             if provider._sync_thread is not None:
                 provider._sync_thread.join(timeout=_WRITE_TIMEOUT)
 
-            # Before the bridge runs, the graph should not have it yet.
-            provider.on_session_end([])
+            # on_session_end logs improve failures and carries on, so watch the
+            # log rather than trusting silence.
+            with self.assertLogs("cognee_integration_hermes.provider", level="WARNING") as logs:
+                provider.on_session_end([])
+                logging.getLogger("cognee_integration_hermes.provider").warning(
+                    "sentinel: assertLogs requires at least one record"
+                )
+            improve_failures = [line for line in logs.output if "improve failed" in line]
+            self.assertEqual(improve_failures, [], f"improve() failed: {improve_failures}")
 
             found = json.loads(
                 provider.handle_tool_call(

--- a/integrations/hermes-agent/tests/test_lifecycle_contract.py
+++ b/integrations/hermes-agent/tests/test_lifecycle_contract.py
@@ -1,0 +1,478 @@
+"""Characterization: the Hermes-only lifecycle semantics.
+
+None of this exists in the claude-code / codex / openclaw plugins, so there is
+nothing to copy it from — it can only be preserved deliberately. Covered here:
+
+* ``agent_context`` write gating (subagents must not write)
+* the ``queue_prefetch`` → ``prefetch`` two-phase protocol and its formatting
+* ``sync_turn`` turn framing and session-cache routing
+* ``on_memory_write`` mirroring, ``on_delegation``, ``on_session_switch``
+* session-id derivation and the in-memory circuit breaker
+
+Run standalone with ``python3 tests/test_lifecycle_contract.py``.
+"""
+
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from _char_helpers import _SyncBridge, fake_cognee, make_provider  # noqa: E402
+from cognee_integration_hermes import provider as provider_mod  # noqa: E402
+
+_NO_URL = {"COGNEE_BASE_URL": "", "COGNEE_SERVICE_URL": ""}
+
+
+def _settle_prefetch(provider, timeout=2.0):
+    """Wait for a queued prefetch to finish *writing its result*.
+
+    ``fake.wait("recall")`` only proves the backend was called; the worker stores
+    the formatted result after that call returns. Joining the worker is the
+    deterministic barrier.
+    """
+    thread = provider._prefetch_thread
+    if thread is not None:
+        thread.join(timeout=timeout)
+
+
+def _initialize(**init_kwargs):
+    """Run the real ``initialize()`` in embedded mode against the fake cognee.
+
+    Embedded mode is the only path that needs neither a server nor the network:
+    identity resolution fails closed to None (the fake has no
+    ``cognee.modules.users.methods``) and the local-root configuration is a
+    no-op without ``hermes_home``.
+    """
+    provider = provider_mod.CogneeMemoryProvider()
+    provider._bridge = _SyncBridge()
+    env = {**_NO_URL, "COGNEE_EMBEDDED": "true"}
+    with mock.patch.dict("os.environ", env, clear=False):
+        provider.initialize("sess-1", **init_kwargs)
+    return provider
+
+
+# --------------------------------------------------------------------------
+# Write gating — subagents must not write to memory
+# --------------------------------------------------------------------------
+
+
+class TestAgentContextWriteGating(unittest.TestCase):
+    def test_absent_agent_context_enables_writes(self):
+        with fake_cognee():
+            self.assertTrue(_initialize()._writes_enabled)
+
+    def test_primary_empty_and_none_enable_writes(self):
+        with fake_cognee():
+            for value in ("primary", "", None):
+                self.assertTrue(
+                    _initialize(agent_context=value)._writes_enabled,
+                    f"agent_context={value!r} should allow writes",
+                )
+
+    def test_subagent_context_disables_writes(self):
+        with fake_cognee():
+            self.assertFalse(_initialize(agent_context="subagent")._writes_enabled)
+
+    def test_disabled_writes_suppress_sync_turn(self):
+        with fake_cognee() as fake:
+            provider = make_provider(writes_enabled=False)
+            provider.sync_turn("u", "a")
+        self.assertEqual(fake.kwargs_for("remember"), [])
+
+    def test_disabled_writes_suppress_session_end_improve(self):
+        with fake_cognee() as fake:
+            provider = make_provider(writes_enabled=False)
+            provider.on_session_end([])
+        self.assertEqual(fake.kwargs_for("improve"), [])
+
+    def test_memory_write_mirror_is_not_gated_on_writes_enabled(self):
+        # Deliberate pin of current behaviour: on_memory_write checks only the
+        # breaker, not _writes_enabled — so a subagent's built-in memory write
+        # still mirrors to the graph, unlike sync_turn. Preserve or change on
+        # purpose; do not let the refactor decide it silently.
+        with fake_cognee() as fake:
+            provider = make_provider(writes_enabled=False)
+            provider.on_memory_write("add", "project", "note")
+            self.assertTrue(fake.wait("remember"))
+        self.assertEqual(len(fake.kwargs_for("remember")), 1)
+
+
+# --------------------------------------------------------------------------
+# sync_turn
+# --------------------------------------------------------------------------
+
+
+class TestSyncTurn(unittest.TestCase):
+    def test_turn_framing_and_session_cache_routing(self):
+        with fake_cognee() as fake:
+            provider = make_provider(session_cognee_id="hermes_s1")
+            provider.sync_turn("what is up", "not much")
+            self.assertTrue(fake.wait("remember"))
+            kwargs = fake.only_call("remember")
+        self.assertEqual(kwargs["data"], "User: what is up\nAssistant: not much")
+        self.assertEqual(kwargs["session_id"], "hermes_s1")
+        self.assertEqual(kwargs["dataset_name"], "hermes")
+        self.assertIs(kwargs["self_improvement"], False)
+        self.assertNotIn("session_ids", kwargs)
+
+    def test_open_breaker_suppresses_the_write(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            provider._is_breaker_open = lambda: True
+            provider.sync_turn("u", "a")
+        self.assertEqual(fake.kwargs_for("remember"), [])
+
+    def test_per_call_session_id_overrides_the_initialized_session(self):
+        with fake_cognee() as fake:
+            provider = make_provider(session_id="s-1", session_cognee_id="hermes_s-1")
+            provider.sync_turn("u", "a", session_id="s-2")
+            self.assertTrue(fake.wait("remember"))
+            self.assertEqual(fake.only_call("remember")["session_id"], "hermes_s-2")
+
+    def test_matching_session_id_uses_the_cached_derived_id(self):
+        with fake_cognee() as fake:
+            provider = make_provider(session_id="s-1", session_cognee_id="custom_id")
+            provider.sync_turn("u", "a", session_id="s-1")
+            self.assertTrue(fake.wait("remember"))
+            self.assertEqual(fake.only_call("remember")["session_id"], "custom_id")
+
+
+# --------------------------------------------------------------------------
+# prefetch / queue_prefetch two-phase protocol
+# --------------------------------------------------------------------------
+
+
+class TestPrefetchProtocol(unittest.TestCase):
+    def test_queued_result_is_returned_with_the_cognee_memory_header(self):
+        with fake_cognee() as fake:
+            fake.results["recall"] = [{"text": "remembered thing", "source": "graph"}]
+            provider = make_provider()
+            provider.queue_prefetch("q")
+            out = provider.prefetch("q")
+        self.assertEqual(out, "## Cognee Memory\n- [graph] remembered thing")
+
+    def test_prefetch_without_a_queued_result_is_empty(self):
+        with fake_cognee():
+            provider = make_provider()
+            self.assertEqual(provider.prefetch("q"), "")
+
+    def test_prefetch_consumes_the_cached_result(self):
+        with fake_cognee() as fake:
+            fake.results["recall"] = [{"text": "once"}]
+            provider = make_provider()
+            provider.queue_prefetch("q")
+            self.assertNotEqual(provider.prefetch("q"), "")
+            self.assertEqual(provider.prefetch("q"), "")
+
+    def test_empty_recall_leaves_nothing_cached(self):
+        with fake_cognee() as fake:
+            fake.results["recall"] = []
+            provider = make_provider()
+            provider.queue_prefetch("q")
+            self.assertEqual(provider.prefetch("q"), "")
+
+    def test_blank_query_is_not_queued(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            provider.queue_prefetch("")
+        self.assertEqual(fake.kwargs_for("recall"), [])
+
+    def test_open_breaker_is_not_queued(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            provider._is_breaker_open = lambda: True
+            provider.queue_prefetch("q")
+        self.assertEqual(fake.kwargs_for("recall"), [])
+
+    def test_prefetch_uses_a_smaller_budget_than_explicit_recall(self):
+        with fake_cognee() as fake:
+            provider = make_provider(top_k=12)
+            provider.queue_prefetch("q")
+            self.assertTrue(fake.wait("recall"))
+            kwargs = fake.only_call("recall")
+        self.assertEqual(kwargs["top_k"], 5)
+        self.assertIn("session_id", kwargs)
+        self.assertIn("datasets", kwargs)
+        self.assertNotIn("query_type", kwargs)
+
+    def test_prefetch_budget_respects_a_lower_configured_top_k(self):
+        with fake_cognee() as fake:
+            provider = make_provider(top_k=2)
+            provider.queue_prefetch("q")
+            self.assertTrue(fake.wait("recall"))
+            self.assertEqual(fake.only_call("recall")["top_k"], 2)
+
+    def test_at_most_five_lines_are_injected(self):
+        with fake_cognee() as fake:
+            fake.results["recall"] = [{"text": f"item {i}"} for i in range(8)]
+            provider = make_provider()
+            provider.queue_prefetch("q")
+            out = provider.prefetch("q")
+        self.assertEqual(len(out.splitlines()), 6)  # header + 5 items
+
+    def test_long_text_is_truncated_to_500_chars(self):
+        with fake_cognee() as fake:
+            fake.results["recall"] = [{"text": "x" * 900}]
+            provider = make_provider()
+            provider.queue_prefetch("q")
+            out = provider.prefetch("q")
+        self.assertEqual(out.count("x"), 500)
+
+    def test_blank_text_results_are_skipped(self):
+        with fake_cognee() as fake:
+            fake.results["recall"] = [{"text": "   "}, {"text": "kept"}]
+            provider = make_provider()
+            provider.queue_prefetch("q")
+            out = provider.prefetch("q")
+        self.assertEqual(out, "## Cognee Memory\n- [cognee] kept")
+
+    def test_recall_failure_leaves_prefetch_empty_and_does_not_raise(self):
+        with fake_cognee() as fake:
+            fake.errors["recall"] = RuntimeError("down")
+            provider = make_provider()
+            provider.queue_prefetch("q")
+            self.assertEqual(provider.prefetch("q"), "")
+
+
+# --------------------------------------------------------------------------
+# on_session_end / on_memory_write / on_delegation / on_session_switch
+# --------------------------------------------------------------------------
+
+
+class TestSessionEnd(unittest.TestCase):
+    def test_improve_targets_the_dataset_and_the_session(self):
+        with fake_cognee() as fake:
+            provider = make_provider(session_cognee_id="hermes_sX")
+            provider.on_session_end([])
+            kwargs = fake.only_call("improve")
+        self.assertEqual(kwargs["dataset"], "hermes")
+        self.assertEqual(kwargs["session_ids"], ["hermes_sX"])
+        self.assertIn("run_in_background", kwargs)
+
+    def test_improve_on_end_disabled_skips_it(self):
+        with fake_cognee() as fake:
+            provider = make_provider(improve_on_end=False)
+            provider.on_session_end([])
+        self.assertEqual(fake.kwargs_for("improve"), [])
+
+    def test_open_breaker_skips_it(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            provider._is_breaker_open = lambda: True
+            provider.on_session_end([])
+        self.assertEqual(fake.kwargs_for("improve"), [])
+
+
+class TestMemoryWriteMirror(unittest.TestCase):
+    def _mirror(self, *args, **kwargs):
+        with fake_cognee() as fake:
+            provider = make_provider(session_cognee_id="hermes_sM")
+            provider.on_memory_write(*args, **kwargs)
+            if not fake.wait("remember", timeout=2.0):
+                return fake, None
+            return fake, fake.only_call("remember")
+
+    def test_payload_format_with_the_default_origin(self):
+        _, kwargs = self._mirror("add", "project", "prefers tabs")
+        self.assertEqual(
+            kwargs["data"],
+            "Hermes project memory (add, hermes_memory_tool): prefers tabs",
+        )
+
+    def test_write_origin_metadata_replaces_the_default_origin(self):
+        _, kwargs = self._mirror("replace", "user", "likes dark mode", {"write_origin": "user_md"})
+        self.assertEqual(
+            kwargs["data"],
+            "Hermes user memory (replace, user_md): likes dark mode",
+        )
+
+    def test_mirror_targets_the_permanent_graph(self):
+        _, kwargs = self._mirror("add", "project", "note")
+        self.assertIs(kwargs["self_improvement"], True)
+        self.assertEqual(kwargs["session_ids"], ["hermes_sM"])
+        self.assertEqual(kwargs["dataset_name"], "hermes")
+
+    def test_only_add_and_replace_are_mirrored(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            for action in ("delete", "remove", "read", ""):
+                provider.on_memory_write(action, "project", "note")
+        self.assertEqual(fake.kwargs_for("remember"), [])
+
+    def test_empty_content_is_not_mirrored(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            provider.on_memory_write("add", "project", "")
+        self.assertEqual(fake.kwargs_for("remember"), [])
+
+    def test_open_breaker_suppresses_the_mirror(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            provider._is_breaker_open = lambda: True
+            provider.on_memory_write("add", "project", "note")
+        self.assertEqual(fake.kwargs_for("remember"), [])
+
+
+class TestDelegation(unittest.TestCase):
+    def test_parent_records_task_and_result_as_a_turn(self):
+        with fake_cognee() as fake:
+            provider = make_provider(session_cognee_id="hermes_parent")
+            provider.on_delegation("do the thing", "did the thing", child_session_id="child-1")
+            self.assertTrue(fake.wait("remember"))
+            kwargs = fake.only_call("remember")
+        self.assertEqual(
+            kwargs["data"],
+            "User: Delegated task: do the thing\nResult: did the thing\nAssistant: ",
+        )
+        self.assertEqual(kwargs["session_id"], "hermes_parent")
+        self.assertIs(kwargs["self_improvement"], False)
+
+    def test_empty_task_and_result_records_nothing(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            provider.on_delegation("", "")
+        self.assertEqual(fake.kwargs_for("remember"), [])
+
+
+class TestSessionSwitch(unittest.TestCase):
+    def test_switch_rederives_the_session_id(self):
+        with fake_cognee():
+            provider = make_provider(session_id="s-1")
+            provider.on_session_switch("s-2")
+        self.assertEqual(provider._session_id, "s-2")
+        self.assertEqual(provider._session_cognee_id, "hermes_s-2")
+
+    def test_reset_clears_a_settled_prefetch(self):
+        with fake_cognee() as fake:
+            fake.results["recall"] = [{"text": "stale"}]
+            provider = make_provider()
+            provider.queue_prefetch("q")
+            _settle_prefetch(provider)
+            provider.on_session_switch("s-2", reset=True)
+            self.assertEqual(provider.prefetch("q"), "")
+
+    def test_non_reset_switch_keeps_a_settled_prefetch(self):
+        with fake_cognee() as fake:
+            fake.results["recall"] = [{"text": "carried over"}]
+            provider = make_provider()
+            provider.queue_prefetch("q")
+            _settle_prefetch(provider)
+            provider.on_session_switch("s-2", parent_session_id="s-1", reset=False)
+            self.assertIn("carried over", provider.prefetch("q"))
+
+    @unittest.expectedFailure
+    def test_reset_should_not_be_defeated_by_a_late_prefetch_write(self):
+        """KNOWN BUG — pinned so the refactor neither hides nor inherits it.
+
+        ``on_session_switch`` joins ``_sync_thread`` but *not*
+        ``_prefetch_thread``, so a prefetch still in flight during ``/reset``
+        writes its result after the clear. Memory recalled for the previous
+        conversation then gets injected into the fresh one — a cross-conversation
+        context leak. Reproduced deterministically here by performing the same
+        late write the prefetch thread does. Flip this to a normal test once
+        ``on_session_switch`` joins or invalidates the in-flight prefetch.
+        """
+        with fake_cognee():
+            provider = make_provider()
+            provider.on_session_switch("s-2", reset=True)
+            provider._prefetch_result = "leaked from the previous conversation"
+            self.assertEqual(provider.prefetch("q"), "")
+
+
+# --------------------------------------------------------------------------
+# Session-id derivation — drift here silently orphans history
+# --------------------------------------------------------------------------
+
+
+class TestSessionIdDerivation(unittest.TestCase):
+    def test_default_prefix(self):
+        provider = make_provider()
+        self.assertEqual(provider._build_cognee_session_id("abc123"), "hermes_abc123")
+
+    def test_configured_prefix(self):
+        provider = make_provider(config={"session_prefix": "hermes-cli"})
+        self.assertEqual(provider._build_cognee_session_id("abc"), "hermes-cli_abc")
+
+    def test_extra_kwargs_are_accepted_but_not_embedded(self):
+        provider = make_provider()
+        derived = provider._build_cognee_session_id("abc", agent_workspace="/tmp/ws", user_id="u-9")
+        self.assertEqual(derived, "hermes_abc")
+
+    def test_allowed_characters_survive(self):
+        self.assertEqual(
+            provider_mod._safe_session_component("Ab9-c_d.e"),
+            "Ab9-c_d.e",
+        )
+
+    def test_disallowed_characters_become_underscores(self):
+        self.assertEqual(provider_mod._safe_session_component("a/b c:d"), "a_b_c_d")
+
+    def test_leading_and_trailing_dots_and_underscores_are_stripped(self):
+        self.assertEqual(provider_mod._safe_session_component("._abc_."), "abc")
+
+    def test_capped_at_120_characters(self):
+        self.assertEqual(len(provider_mod._safe_session_component("x" * 200)), 120)
+
+    def test_empty_input_falls_back_to_session(self):
+        self.assertEqual(provider_mod._safe_session_component(""), "session")
+        self.assertEqual(provider_mod._safe_session_component("..."), "session")
+
+    def test_session_cognee_id_for_blank_returns_the_current_session(self):
+        provider = make_provider(session_id="s-1", session_cognee_id="cached")
+        self.assertEqual(provider._session_cognee_id_for(""), "cached")
+
+    def test_session_cognee_id_for_current_session_returns_the_cached_id(self):
+        provider = make_provider(session_id="s-1", session_cognee_id="cached")
+        self.assertEqual(provider._session_cognee_id_for("s-1"), "cached")
+
+    def test_session_cognee_id_for_another_session_is_derived(self):
+        provider = make_provider(session_id="s-1", session_cognee_id="cached")
+        self.assertEqual(provider._session_cognee_id_for("s-2"), "hermes_s-2")
+
+
+# --------------------------------------------------------------------------
+# Circuit breaker — in-memory on purpose (long-lived provider process)
+# --------------------------------------------------------------------------
+
+
+class TestCircuitBreaker(unittest.TestCase):
+    def test_stays_closed_below_the_threshold(self):
+        provider = make_provider()
+        for _ in range(4):
+            provider._record_failure()
+        self.assertFalse(provider._is_breaker_open())
+
+    def test_opens_at_the_threshold(self):
+        provider = make_provider()
+        for _ in range(5):
+            provider._record_failure()
+        self.assertTrue(provider._is_breaker_open())
+
+    def test_success_resets_the_failure_count(self):
+        provider = make_provider()
+        for _ in range(4):
+            provider._record_failure()
+        provider._record_success()
+        provider._record_failure()
+        self.assertFalse(provider._is_breaker_open())
+
+    def test_closes_again_once_the_cooldown_expires(self):
+        provider = make_provider()
+        for _ in range(5):
+            provider._record_failure()
+        provider._breaker_open_until = time.monotonic() - 1
+        self.assertFalse(provider._is_breaker_open())
+        self.assertEqual(provider._consecutive_failures, 0)
+
+    def test_threshold_and_cooldown_constants(self):
+        self.assertEqual(provider_mod._BREAKER_THRESHOLD, 5)
+        self.assertEqual(provider_mod._BREAKER_COOLDOWN_SECS, 120)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/integrations/hermes-agent/tests/test_lifecycle_contract.py
+++ b/integrations/hermes-agent/tests/test_lifecycle_contract.py
@@ -12,6 +12,7 @@ nothing to copy it from — it can only be preserved deliberately. Covered here:
 Run standalone with ``python3 tests/test_lifecycle_contract.py``.
 """
 
+import json
 import sys
 import threading
 import time
@@ -125,6 +126,77 @@ class TestAgentContextWriteGating(unittest.TestCase):
             provider.on_memory_write("add", "project", "note")
             self.assertTrue(fake.wait("remember_permanent"))
         self.assertEqual(len(fake.kwargs_for("remember_permanent")), 1)
+
+
+# --------------------------------------------------------------------------
+# Fail closed — a provider that never initialized must not touch cognee
+# --------------------------------------------------------------------------
+
+
+class TestFailsClosedWhenUninitialized(unittest.TestCase):
+    """Hermes swallows whatever ``initialize()`` raises and starts anyway.
+
+    ``MemoryManager.initialize_all`` logs the exception and continues, leaving the
+    provider registered with its tool schemas live. Every entry point therefore has
+    to check for itself, or calls would run against an unconnected transport — for
+    the SDK that means silently doing in-process cognee, the exact single-writer DB
+    risk local-server mode exists to prevent.
+    """
+
+    def _uninitialized(self, fake):
+        provider = make_provider(backend=fake)
+        provider._initialized = False  # what a failed initialize() leaves behind
+        return provider
+
+    def test_a_failed_initialize_leaves_the_provider_unusable(self):
+        with fake_backend() as fake:
+            fake.errors["connect"] = RuntimeError("unreachable")
+            provider = provider_mod.CogneeMemoryProvider(backend=fake)
+            env = {**_NO_URL, "COGNEE_BASE_URL": "https://cloud.example"}
+            with mock.patch.dict("os.environ", env, clear=False):
+                with self.assertRaises(RuntimeError):
+                    provider.initialize("sid")
+            self.assertFalse(provider._initialized)
+
+    def test_tool_calls_report_unavailable_instead_of_running(self):
+        with fake_backend() as fake:
+            provider = self._uninitialized(fake)
+            for tool, args in (
+                ("cognee_recall", {"query": "q"}),
+                ("cognee_remember", {"content": "c"}),
+                ("cognee_forget", {"everything": True}),
+            ):
+                out = json.loads(provider.handle_tool_call(tool, args))
+                self.assertIn("unavailable", out["error"])
+            self.assertEqual(fake.calls, [])
+
+    def test_writes_are_suppressed(self):
+        with fake_backend() as fake:
+            provider = self._uninitialized(fake)
+            provider.sync_turn("u", "a")
+            provider.on_memory_write("add", "project", "note")
+            provider.on_delegation("task", "result")
+            provider.on_session_end([])
+            assert_no_call(self, fake, "remember_session")
+            assert_no_call(self, fake, "remember_permanent")
+            self.assertEqual(fake.kwargs_for("improve"), [])
+
+    def test_recall_is_not_queued_or_returned(self):
+        with fake_backend() as fake:
+            provider = self._uninitialized(fake)
+            provider.queue_prefetch("q")
+            assert_no_call(self, fake, "recall")
+            self.assertEqual(provider.prefetch("q"), "")
+
+    def test_memory_is_not_advertised_to_the_model(self):
+        with fake_backend() as fake:
+            self.assertEqual(self._uninitialized(fake).system_prompt_block(), "")
+
+    def test_an_initialized_provider_still_advertises_memory(self):
+        with fake_backend():
+            block = make_provider().system_prompt_block()
+        self.assertIn("Cognee Memory", block)
+        self.assertIn("cognee_recall", block)
 
 
 # --------------------------------------------------------------------------

--- a/integrations/hermes-agent/tests/test_lifecycle_contract.py
+++ b/integrations/hermes-agent/tests/test_lifecycle_contract.py
@@ -13,6 +13,7 @@ Run standalone with ``python3 tests/test_lifecycle_contract.py``.
 """
 
 import sys
+import threading
 import time
 import unittest
 from pathlib import Path
@@ -26,6 +27,27 @@ from _char_helpers import _SyncBridge, fake_cognee, make_provider  # noqa: E402
 from cognee_integration_hermes import provider as provider_mod  # noqa: E402
 
 _NO_URL = {"COGNEE_BASE_URL": "", "COGNEE_SERVICE_URL": ""}
+
+# How long to wait for a call that should never arrive. The write paths spawn
+# daemon workers that reach the (inline) fake in microseconds, so this is ~1000x
+# margin while keeping the suite fast.
+_NO_CALL_GRACE = 0.2
+
+
+def assert_no_call(case, fake, name):
+    """Assert *name* is never called, having waited long enough to mean it.
+
+    Asserting immediately after a suppressed write would pass even if the guard
+    were missing — the worker simply would not have got there yet. Worse, that
+    worker would outlive the ``fake_cognee`` context and import the *real*
+    cognee, racing the next test's fake. Waiting for the call not to arrive
+    fixes both, so this must be called *inside* the ``fake_cognee`` block.
+    """
+    case.assertFalse(
+        fake.wait(name, timeout=_NO_CALL_GRACE),
+        f"expected no {name!r} call, but one was made",
+    )
+    case.assertEqual(fake.kwargs_for(name), [])
 
 
 def _settle_prefetch(provider, timeout=2.0):
@@ -82,7 +104,7 @@ class TestAgentContextWriteGating(unittest.TestCase):
         with fake_cognee() as fake:
             provider = make_provider(writes_enabled=False)
             provider.sync_turn("u", "a")
-        self.assertEqual(fake.kwargs_for("remember"), [])
+            assert_no_call(self, fake, "remember")
 
     def test_disabled_writes_suppress_session_end_improve(self):
         with fake_cognee() as fake:
@@ -90,13 +112,18 @@ class TestAgentContextWriteGating(unittest.TestCase):
             provider.on_session_end([])
         self.assertEqual(fake.kwargs_for("improve"), [])
 
-    def test_memory_write_mirror_is_not_gated_on_writes_enabled(self):
-        # Deliberate pin of current behaviour: on_memory_write checks only the
-        # breaker, not _writes_enabled — so a subagent's built-in memory write
-        # still mirrors to the graph, unlike sync_turn. Preserve or change on
-        # purpose; do not let the refactor decide it silently.
+    def test_disabled_writes_suppress_the_memory_write_mirror(self):
+        # Regression: on_memory_write used to check only the breaker, so a
+        # subagent's built-in memory write reached the graph even though its
+        # conversation turns were suppressed. Write gating is now uniform.
         with fake_cognee() as fake:
             provider = make_provider(writes_enabled=False)
+            provider.on_memory_write("add", "project", "note")
+            assert_no_call(self, fake, "remember")
+
+    def test_enabled_writes_still_mirror(self):
+        with fake_cognee() as fake:
+            provider = make_provider(writes_enabled=True)
             provider.on_memory_write("add", "project", "note")
             self.assertTrue(fake.wait("remember"))
         self.assertEqual(len(fake.kwargs_for("remember")), 1)
@@ -125,7 +152,7 @@ class TestSyncTurn(unittest.TestCase):
             provider = make_provider()
             provider._is_breaker_open = lambda: True
             provider.sync_turn("u", "a")
-        self.assertEqual(fake.kwargs_for("remember"), [])
+            assert_no_call(self, fake, "remember")
 
     def test_per_call_session_id_overrides_the_initialized_session(self):
         with fake_cognee() as fake:
@@ -180,14 +207,14 @@ class TestPrefetchProtocol(unittest.TestCase):
         with fake_cognee() as fake:
             provider = make_provider()
             provider.queue_prefetch("")
-        self.assertEqual(fake.kwargs_for("recall"), [])
+            assert_no_call(self, fake, "recall")
 
     def test_open_breaker_is_not_queued(self):
         with fake_cognee() as fake:
             provider = make_provider()
             provider._is_breaker_open = lambda: True
             provider.queue_prefetch("q")
-        self.assertEqual(fake.kwargs_for("recall"), [])
+            assert_no_call(self, fake, "recall")
 
     def test_prefetch_uses_a_smaller_budget_than_explicit_recall(self):
         with fake_cognee() as fake:
@@ -302,20 +329,20 @@ class TestMemoryWriteMirror(unittest.TestCase):
             provider = make_provider()
             for action in ("delete", "remove", "read", ""):
                 provider.on_memory_write(action, "project", "note")
-        self.assertEqual(fake.kwargs_for("remember"), [])
+            assert_no_call(self, fake, "remember")
 
     def test_empty_content_is_not_mirrored(self):
         with fake_cognee() as fake:
             provider = make_provider()
             provider.on_memory_write("add", "project", "")
-        self.assertEqual(fake.kwargs_for("remember"), [])
+            assert_no_call(self, fake, "remember")
 
     def test_open_breaker_suppresses_the_mirror(self):
         with fake_cognee() as fake:
             provider = make_provider()
             provider._is_breaker_open = lambda: True
             provider.on_memory_write("add", "project", "note")
-        self.assertEqual(fake.kwargs_for("remember"), [])
+            assert_no_call(self, fake, "remember")
 
 
 class TestDelegation(unittest.TestCase):
@@ -336,7 +363,7 @@ class TestDelegation(unittest.TestCase):
         with fake_cognee() as fake:
             provider = make_provider()
             provider.on_delegation("", "")
-        self.assertEqual(fake.kwargs_for("remember"), [])
+            assert_no_call(self, fake, "remember")
 
 
 class TestSessionSwitch(unittest.TestCase):
@@ -365,23 +392,46 @@ class TestSessionSwitch(unittest.TestCase):
             provider.on_session_switch("s-2", parent_session_id="s-1", reset=False)
             self.assertIn("carried over", provider.prefetch("q"))
 
-    @unittest.expectedFailure
-    def test_reset_should_not_be_defeated_by_a_late_prefetch_write(self):
-        """KNOWN BUG — pinned so the refactor neither hides nor inherits it.
+    def test_reset_discards_a_prefetch_that_was_in_flight(self):
+        """Regression: no cross-conversation context leak on ``/reset``.
 
-        ``on_session_switch`` joins ``_sync_thread`` but *not*
-        ``_prefetch_thread``, so a prefetch still in flight during ``/reset``
-        writes its result after the clear. Memory recalled for the previous
-        conversation then gets injected into the fresh one — a cross-conversation
-        context leak. Reproduced deterministically here by performing the same
-        late write the prefetch thread does. Flip this to a normal test once
-        ``on_session_switch`` joins or invalidates the in-flight prefetch.
+        A recall issued for the previous conversation must not land in the fresh
+        one, even when it returns *after* the reset cleared the slot. Held inside
+        the backend call with a gate so the in-flight window is deterministic
+        rather than timing-dependent.
         """
-        with fake_cognee():
+        with fake_cognee() as fake:
+            fake.results["recall"] = [{"text": "belongs to the old conversation"}]
+            gate = threading.Event()
+            fake.gates["recall"] = gate
+
             provider = make_provider()
+            provider.queue_prefetch("q")
+            self.assertTrue(fake.wait("recall"))  # worker is now inside the recall
+
             provider.on_session_switch("s-2", reset=True)
-            provider._prefetch_result = "leaked from the previous conversation"
+            gate.set()  # let the recall return, after the reset
+            _settle_prefetch(provider)
+
             self.assertEqual(provider.prefetch("q"), "")
+
+    def test_non_reset_switch_keeps_a_prefetch_that_was_in_flight(self):
+        """The mirror case: /resume, /branch and compression continue the same
+        logical conversation, so an in-flight prefetch stays valid."""
+        with fake_cognee() as fake:
+            fake.results["recall"] = [{"text": "still relevant"}]
+            gate = threading.Event()
+            fake.gates["recall"] = gate
+
+            provider = make_provider()
+            provider.queue_prefetch("q")
+            self.assertTrue(fake.wait("recall"))
+
+            provider.on_session_switch("s-2", parent_session_id="s-1", reset=False)
+            gate.set()
+            _settle_prefetch(provider)
+
+            self.assertIn("still relevant", provider.prefetch("q"))
 
 
 # --------------------------------------------------------------------------

--- a/integrations/hermes-agent/tests/test_lifecycle_contract.py
+++ b/integrations/hermes-agent/tests/test_lifecycle_contract.py
@@ -592,6 +592,24 @@ class TestCircuitBreaker(unittest.TestCase):
         self.assertEqual(provider_mod._BREAKER_THRESHOLD, 5)
         self.assertEqual(provider_mod._BREAKER_COOLDOWN_SECS, 120)
 
+    def test_concurrent_failures_are_not_lost(self):
+        # The breaker is hit from the main thread and every worker thread; an
+        # unlocked `+= 1` can drop increments under that concurrency, delaying
+        # the trip. Hammer it and require an exact count.
+        provider = make_provider()
+        per_thread = 200
+
+        def fail_repeatedly():
+            for _ in range(per_thread):
+                provider._record_failure()
+
+        threads = [threading.Thread(target=fail_repeatedly) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        self.assertEqual(provider._consecutive_failures, 8 * per_thread)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/integrations/hermes-agent/tests/test_lifecycle_contract.py
+++ b/integrations/hermes-agent/tests/test_lifecycle_contract.py
@@ -23,7 +23,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from _char_helpers import _SyncBridge, fake_cognee, make_provider  # noqa: E402
+from _char_helpers import FakeBackend, fake_backend, make_provider  # noqa: E402
 from cognee_integration_hermes import provider as provider_mod  # noqa: E402
 
 _NO_URL = {"COGNEE_BASE_URL": "", "COGNEE_SERVICE_URL": ""}
@@ -39,9 +39,9 @@ def assert_no_call(case, fake, name):
 
     Asserting immediately after a suppressed write would pass even if the guard
     were missing — the worker simply would not have got there yet. Worse, that
-    worker would outlive the ``fake_cognee`` context and import the *real*
+    worker would outlive the ``fake_backend`` context and import the *real*
     cognee, racing the next test's fake. Waiting for the call not to arrive
-    fixes both, so this must be called *inside* the ``fake_cognee`` block.
+    fixes both, so this must be called *inside* the ``fake_backend`` block.
     """
     case.assertFalse(
         fake.wait(name, timeout=_NO_CALL_GRACE),
@@ -62,16 +62,14 @@ def _settle_prefetch(provider, timeout=2.0):
         thread.join(timeout=timeout)
 
 
-def _initialize(**init_kwargs):
-    """Run the real ``initialize()`` in embedded mode against the fake cognee.
+def _initialize(backend=None, **init_kwargs):
+    """Run the real ``initialize()`` in embedded mode against a fake transport.
 
     Embedded mode is the only path that needs neither a server nor the network:
-    identity resolution fails closed to None (the fake has no
-    ``cognee.modules.users.methods``) and the local-root configuration is a
-    no-op without ``hermes_home``.
+    it configures local roots and resolves an identity, both of which the fake
+    backend records without touching anything.
     """
-    provider = provider_mod.CogneeMemoryProvider()
-    provider._bridge = _SyncBridge()
+    provider = provider_mod.CogneeMemoryProvider(backend=backend or FakeBackend())
     env = {**_NO_URL, "COGNEE_EMBEDDED": "true"}
     with mock.patch.dict("os.environ", env, clear=False):
         provider.initialize("sess-1", **init_kwargs)
@@ -85,11 +83,11 @@ def _initialize(**init_kwargs):
 
 class TestAgentContextWriteGating(unittest.TestCase):
     def test_absent_agent_context_enables_writes(self):
-        with fake_cognee():
+        with fake_backend():
             self.assertTrue(_initialize()._writes_enabled)
 
     def test_primary_empty_and_none_enable_writes(self):
-        with fake_cognee():
+        with fake_backend():
             for value in ("primary", "", None):
                 self.assertTrue(
                     _initialize(agent_context=value)._writes_enabled,
@@ -97,17 +95,17 @@ class TestAgentContextWriteGating(unittest.TestCase):
                 )
 
     def test_subagent_context_disables_writes(self):
-        with fake_cognee():
+        with fake_backend():
             self.assertFalse(_initialize(agent_context="subagent")._writes_enabled)
 
     def test_disabled_writes_suppress_sync_turn(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(writes_enabled=False)
             provider.sync_turn("u", "a")
-            assert_no_call(self, fake, "remember")
+            assert_no_call(self, fake, "remember_permanent")
 
     def test_disabled_writes_suppress_session_end_improve(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(writes_enabled=False)
             provider.on_session_end([])
         self.assertEqual(fake.kwargs_for("improve"), [])
@@ -116,17 +114,17 @@ class TestAgentContextWriteGating(unittest.TestCase):
         # Regression: on_memory_write used to check only the breaker, so a
         # subagent's built-in memory write reached the graph even though its
         # conversation turns were suppressed. Write gating is now uniform.
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(writes_enabled=False)
             provider.on_memory_write("add", "project", "note")
-            assert_no_call(self, fake, "remember")
+            assert_no_call(self, fake, "remember_permanent")
 
     def test_enabled_writes_still_mirror(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(writes_enabled=True)
             provider.on_memory_write("add", "project", "note")
-            self.assertTrue(fake.wait("remember"))
-        self.assertEqual(len(fake.kwargs_for("remember")), 1)
+            self.assertTrue(fake.wait("remember_permanent"))
+        self.assertEqual(len(fake.kwargs_for("remember_permanent")), 1)
 
 
 # --------------------------------------------------------------------------
@@ -136,37 +134,38 @@ class TestAgentContextWriteGating(unittest.TestCase):
 
 class TestSyncTurn(unittest.TestCase):
     def test_turn_framing_and_session_cache_routing(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(session_cognee_id="hermes_s1")
             provider.sync_turn("what is up", "not much")
-            self.assertTrue(fake.wait("remember"))
-            kwargs = fake.only_call("remember")
-        self.assertEqual(kwargs["data"], "User: what is up\nAssistant: not much")
+            self.assertTrue(fake.wait("remember_session"))
+            kwargs = fake.only_call("remember_session")
+        self.assertEqual(kwargs["text"], "User: what is up\nAssistant: not much")
         self.assertEqual(kwargs["session_id"], "hermes_s1")
-        self.assertEqual(kwargs["dataset_name"], "hermes")
-        self.assertIs(kwargs["self_improvement"], False)
-        self.assertNotIn("session_ids", kwargs)
+        self.assertEqual(kwargs["dataset"], "hermes")
+        # Routing to the session cache is expressed by the method chosen, so the
+        # permanent-graph path must not also have fired.
+        self.assertEqual(fake.kwargs_for("remember_permanent"), [])
 
     def test_open_breaker_suppresses_the_write(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             provider._is_breaker_open = lambda: True
             provider.sync_turn("u", "a")
-            assert_no_call(self, fake, "remember")
+            assert_no_call(self, fake, "remember_session")
 
     def test_per_call_session_id_overrides_the_initialized_session(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(session_id="s-1", session_cognee_id="hermes_s-1")
             provider.sync_turn("u", "a", session_id="s-2")
-            self.assertTrue(fake.wait("remember"))
-            self.assertEqual(fake.only_call("remember")["session_id"], "hermes_s-2")
+            self.assertTrue(fake.wait("remember_session"))
+            self.assertEqual(fake.only_call("remember_session")["session_id"], "hermes_s-2")
 
     def test_matching_session_id_uses_the_cached_derived_id(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(session_id="s-1", session_cognee_id="custom_id")
             provider.sync_turn("u", "a", session_id="s-1")
-            self.assertTrue(fake.wait("remember"))
-            self.assertEqual(fake.only_call("remember")["session_id"], "custom_id")
+            self.assertTrue(fake.wait("remember_session"))
+            self.assertEqual(fake.only_call("remember_session")["session_id"], "custom_id")
 
 
 # --------------------------------------------------------------------------
@@ -176,7 +175,7 @@ class TestSyncTurn(unittest.TestCase):
 
 class TestPrefetchProtocol(unittest.TestCase):
     def test_queued_result_is_returned_with_the_cognee_memory_header(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.results["recall"] = [{"text": "remembered thing", "source": "graph"}]
             provider = make_provider()
             provider.queue_prefetch("q")
@@ -184,12 +183,12 @@ class TestPrefetchProtocol(unittest.TestCase):
         self.assertEqual(out, "## Cognee Memory\n- [graph] remembered thing")
 
     def test_prefetch_without_a_queued_result_is_empty(self):
-        with fake_cognee():
+        with fake_backend():
             provider = make_provider()
             self.assertEqual(provider.prefetch("q"), "")
 
     def test_prefetch_consumes_the_cached_result(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.results["recall"] = [{"text": "once"}]
             provider = make_provider()
             provider.queue_prefetch("q")
@@ -197,45 +196,45 @@ class TestPrefetchProtocol(unittest.TestCase):
             self.assertEqual(provider.prefetch("q"), "")
 
     def test_empty_recall_leaves_nothing_cached(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.results["recall"] = []
             provider = make_provider()
             provider.queue_prefetch("q")
             self.assertEqual(provider.prefetch("q"), "")
 
     def test_blank_query_is_not_queued(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             provider.queue_prefetch("")
             assert_no_call(self, fake, "recall")
 
     def test_open_breaker_is_not_queued(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             provider._is_breaker_open = lambda: True
             provider.queue_prefetch("q")
             assert_no_call(self, fake, "recall")
 
     def test_prefetch_uses_a_smaller_budget_than_explicit_recall(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(top_k=12)
             provider.queue_prefetch("q")
             self.assertTrue(fake.wait("recall"))
             kwargs = fake.only_call("recall")
         self.assertEqual(kwargs["top_k"], 5)
-        self.assertIn("session_id", kwargs)
-        self.assertIn("datasets", kwargs)
-        self.assertNotIn("query_type", kwargs)
+        self.assertIsNotNone(kwargs["session_id"])
+        self.assertIsNotNone(kwargs["datasets"])
+        self.assertIsNone(kwargs["query_type"])
 
     def test_prefetch_budget_respects_a_lower_configured_top_k(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(top_k=2)
             provider.queue_prefetch("q")
             self.assertTrue(fake.wait("recall"))
             self.assertEqual(fake.only_call("recall")["top_k"], 2)
 
     def test_at_most_five_lines_are_injected(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.results["recall"] = [{"text": f"item {i}"} for i in range(8)]
             provider = make_provider()
             provider.queue_prefetch("q")
@@ -243,7 +242,7 @@ class TestPrefetchProtocol(unittest.TestCase):
         self.assertEqual(len(out.splitlines()), 6)  # header + 5 items
 
     def test_long_text_is_truncated_to_500_chars(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.results["recall"] = [{"text": "x" * 900}]
             provider = make_provider()
             provider.queue_prefetch("q")
@@ -251,7 +250,7 @@ class TestPrefetchProtocol(unittest.TestCase):
         self.assertEqual(out.count("x"), 500)
 
     def test_blank_text_results_are_skipped(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.results["recall"] = [{"text": "   "}, {"text": "kept"}]
             provider = make_provider()
             provider.queue_prefetch("q")
@@ -259,7 +258,7 @@ class TestPrefetchProtocol(unittest.TestCase):
         self.assertEqual(out, "## Cognee Memory\n- [cognee] kept")
 
     def test_recall_failure_leaves_prefetch_empty_and_does_not_raise(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.errors["recall"] = RuntimeError("down")
             provider = make_provider()
             provider.queue_prefetch("q")
@@ -273,22 +272,22 @@ class TestPrefetchProtocol(unittest.TestCase):
 
 class TestSessionEnd(unittest.TestCase):
     def test_improve_targets_the_dataset_and_the_session(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(session_cognee_id="hermes_sX")
             provider.on_session_end([])
             kwargs = fake.only_call("improve")
         self.assertEqual(kwargs["dataset"], "hermes")
         self.assertEqual(kwargs["session_ids"], ["hermes_sX"])
-        self.assertIn("run_in_background", kwargs)
+        self.assertIn("background", kwargs)
 
     def test_improve_on_end_disabled_skips_it(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(improve_on_end=False)
             provider.on_session_end([])
         self.assertEqual(fake.kwargs_for("improve"), [])
 
     def test_open_breaker_skips_it(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             provider._is_breaker_open = lambda: True
             provider.on_session_end([])
@@ -297,85 +296,83 @@ class TestSessionEnd(unittest.TestCase):
 
 class TestMemoryWriteMirror(unittest.TestCase):
     def _mirror(self, *args, **kwargs):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(session_cognee_id="hermes_sM")
             provider.on_memory_write(*args, **kwargs)
-            if not fake.wait("remember", timeout=2.0):
+            if not fake.wait("remember_permanent", timeout=2.0):
                 return fake, None
-            return fake, fake.only_call("remember")
+            return fake, fake.only_call("remember_permanent")
 
     def test_payload_format_with_the_default_origin(self):
         _, kwargs = self._mirror("add", "project", "prefers tabs")
         self.assertEqual(
-            kwargs["data"],
+            kwargs["text"],
             "Hermes project memory (add, hermes_memory_tool): prefers tabs",
         )
 
     def test_write_origin_metadata_replaces_the_default_origin(self):
         _, kwargs = self._mirror("replace", "user", "likes dark mode", {"write_origin": "user_md"})
         self.assertEqual(
-            kwargs["data"],
+            kwargs["text"],
             "Hermes user memory (replace, user_md): likes dark mode",
         )
 
     def test_mirror_targets_the_permanent_graph(self):
         _, kwargs = self._mirror("add", "project", "note")
-        self.assertIs(kwargs["self_improvement"], True)
         self.assertEqual(kwargs["session_ids"], ["hermes_sM"])
-        self.assertEqual(kwargs["dataset_name"], "hermes")
+        self.assertEqual(kwargs["dataset"], "hermes")
 
     def test_only_add_and_replace_are_mirrored(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             for action in ("delete", "remove", "read", ""):
                 provider.on_memory_write(action, "project", "note")
-            assert_no_call(self, fake, "remember")
+            assert_no_call(self, fake, "remember_permanent")
 
     def test_empty_content_is_not_mirrored(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             provider.on_memory_write("add", "project", "")
-            assert_no_call(self, fake, "remember")
+            assert_no_call(self, fake, "remember_permanent")
 
     def test_open_breaker_suppresses_the_mirror(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             provider._is_breaker_open = lambda: True
             provider.on_memory_write("add", "project", "note")
-            assert_no_call(self, fake, "remember")
+            assert_no_call(self, fake, "remember_permanent")
 
 
 class TestDelegation(unittest.TestCase):
     def test_parent_records_task_and_result_as_a_turn(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(session_cognee_id="hermes_parent")
             provider.on_delegation("do the thing", "did the thing", child_session_id="child-1")
-            self.assertTrue(fake.wait("remember"))
-            kwargs = fake.only_call("remember")
+            self.assertTrue(fake.wait("remember_session"))
+            kwargs = fake.only_call("remember_session")
         self.assertEqual(
-            kwargs["data"],
+            kwargs["text"],
             "User: Delegated task: do the thing\nResult: did the thing\nAssistant: ",
         )
         self.assertEqual(kwargs["session_id"], "hermes_parent")
-        self.assertIs(kwargs["self_improvement"], False)
 
     def test_empty_task_and_result_records_nothing(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             provider.on_delegation("", "")
-            assert_no_call(self, fake, "remember")
+            assert_no_call(self, fake, "remember_session")
 
 
 class TestSessionSwitch(unittest.TestCase):
     def test_switch_rederives_the_session_id(self):
-        with fake_cognee():
+        with fake_backend():
             provider = make_provider(session_id="s-1")
             provider.on_session_switch("s-2")
         self.assertEqual(provider._session_id, "s-2")
         self.assertEqual(provider._session_cognee_id, "hermes_s-2")
 
     def test_reset_clears_a_settled_prefetch(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.results["recall"] = [{"text": "stale"}]
             provider = make_provider()
             provider.queue_prefetch("q")
@@ -384,7 +381,7 @@ class TestSessionSwitch(unittest.TestCase):
             self.assertEqual(provider.prefetch("q"), "")
 
     def test_non_reset_switch_keeps_a_settled_prefetch(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.results["recall"] = [{"text": "carried over"}]
             provider = make_provider()
             provider.queue_prefetch("q")
@@ -400,7 +397,7 @@ class TestSessionSwitch(unittest.TestCase):
         the backend call with a gate so the in-flight window is deterministic
         rather than timing-dependent.
         """
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.results["recall"] = [{"text": "belongs to the old conversation"}]
             gate = threading.Event()
             fake.gates["recall"] = gate
@@ -418,7 +415,7 @@ class TestSessionSwitch(unittest.TestCase):
     def test_non_reset_switch_keeps_a_prefetch_that_was_in_flight(self):
         """The mirror case: /resume, /branch and compression continue the same
         logical conversation, so an in-flight prefetch stays valid."""
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.results["recall"] = [{"text": "still relevant"}]
             gate = threading.Event()
             fake.gates["recall"] = gate

--- a/integrations/hermes-agent/tests/test_sdk_backend.py
+++ b/integrations/hermes-agent/tests/test_sdk_backend.py
@@ -1,0 +1,240 @@
+"""Wire-level tests for ``SdkBackend``: protocol args in, cognee kwargs out.
+
+The provider tests assert on protocol args (``test_tool_contract``,
+``test_lifecycle_contract``); this file asserts that the SDK transport faithfully
+turns those into what cognee expects. That is the whole split: Hermes semantics
+above the seam, wire format below it. An HTTP transport gets an equivalent file.
+
+Two things only exist below the seam and are pinned here: the ``user=`` kwarg
+rule, and the SDK-only fields (``self_improvement``, and dropping ``dataset`` on
+a wipe-everything).
+
+Runs standalone with ``python3 tests/test_sdk_backend.py``; needs no real cognee.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from _char_helpers import fake_cognee  # noqa: E402
+from cognee_integration_hermes.backend import SdkBackend  # noqa: E402
+
+_TIMEOUT = 5.0
+
+
+def _backend(*, served=False, user=None):
+    backend = SdkBackend()
+    backend.served = served
+    backend._user = user
+    # Run coroutines inline instead of on the bridge's loop thread.
+    backend._bridge = _InlineBridge()
+    return backend
+
+
+class _InlineBridge:
+    def run(self, coro, timeout=None):
+        import asyncio
+
+        return asyncio.run(coro)
+
+    def shutdown(self):
+        pass
+
+
+class TestRecallWireFormat(unittest.TestCase):
+    def _recall_kwargs(self, **overrides):
+        params = {
+            "query": "q",
+            "session_id": "hermes_s1",
+            "datasets": ["hermes"],
+            "top_k": 5,
+            "auto_route": True,
+            "query_type": None,
+            "timeout": _TIMEOUT,
+        }
+        params.update(overrides)
+        with fake_cognee() as fake:
+            _backend(served=True).recall(**params)
+            return fake.only_call("recall")
+
+    def test_query_becomes_query_text(self):
+        self.assertEqual(self._recall_kwargs(query="hello")["query_text"], "hello")
+
+    def test_top_k_and_auto_route_pass_through(self):
+        kwargs = self._recall_kwargs(top_k=9, auto_route=False)
+        self.assertEqual(kwargs["top_k"], 9)
+        self.assertIs(kwargs["auto_route"], False)
+
+    def test_none_targets_are_omitted_not_sent_as_none(self):
+        # cognee distinguishes an omitted kwarg from an explicit None, so a
+        # session-only or graph-only recall must leave the other key out.
+        session_only = self._recall_kwargs(datasets=None)
+        self.assertIn("session_id", session_only)
+        self.assertNotIn("datasets", session_only)
+
+        graph_only = self._recall_kwargs(session_id=None)
+        self.assertIn("datasets", graph_only)
+        self.assertNotIn("session_id", graph_only)
+
+    def test_query_type_is_resolved_to_a_search_type(self):
+        self.assertEqual(self._recall_kwargs(query_type="CHUNKS")["query_type"], "CHUNKS")
+
+    def test_query_type_is_uppercased(self):
+        self.assertEqual(self._recall_kwargs(query_type="chunks")["query_type"], "CHUNKS")
+
+    def test_unknown_query_type_falls_back_to_graph_completion(self):
+        kwargs = self._recall_kwargs(query_type="NOT_A_TYPE")
+        self.assertEqual(kwargs["query_type"], "GRAPH_COMPLETION")
+
+    def test_absent_query_type_is_omitted(self):
+        self.assertNotIn("query_type", self._recall_kwargs(query_type=None))
+
+
+class TestRememberWireFormat(unittest.TestCase):
+    def test_session_write_is_a_cheap_cache_write(self):
+        with fake_cognee() as fake:
+            _backend(served=True).remember_session(
+                text="turn", session_id="hermes_s1", dataset="hermes", timeout=_TIMEOUT
+            )
+            kwargs = fake.only_call("remember")
+        self.assertEqual(kwargs["data"], "turn")
+        self.assertEqual(kwargs["dataset_name"], "hermes")
+        self.assertEqual(kwargs["session_id"], "hermes_s1")
+        self.assertIs(kwargs["self_improvement"], False)
+        self.assertNotIn("session_ids", kwargs)
+
+    def test_permanent_write_requests_graph_extraction(self):
+        with fake_cognee() as fake:
+            _backend(served=True).remember_permanent(
+                text="fact", dataset="hermes", session_ids=["hermes_s1"], timeout=_TIMEOUT
+            )
+            kwargs = fake.only_call("remember")
+        self.assertEqual(kwargs["data"], "fact")
+        self.assertEqual(kwargs["dataset_name"], "hermes")
+        self.assertIs(kwargs["self_improvement"], True)
+        self.assertEqual(kwargs["session_ids"], ["hermes_s1"])
+        self.assertNotIn("session_id", kwargs)
+
+
+class TestForgetWireFormat(unittest.TestCase):
+    def _forget_kwargs(self, **overrides):
+        params = {
+            "dataset": "hermes",
+            "everything": False,
+            "memory_only": False,
+            "timeout": _TIMEOUT,
+        }
+        params.update(overrides)
+        with fake_cognee() as fake:
+            _backend(served=True).forget(**params)
+            return fake.only_call("forget")
+
+    def test_dataset_scoped_delete(self):
+        kwargs = self._forget_kwargs()
+        self.assertEqual(kwargs["dataset"], "hermes")
+        self.assertIs(kwargs["everything"], False)
+
+    def test_everything_drops_the_dataset(self):
+        # Sending both would scope a wipe-everything to one dataset.
+        kwargs = self._forget_kwargs(everything=True)
+        self.assertIs(kwargs["everything"], True)
+        self.assertNotIn("dataset", kwargs)
+
+    def test_no_dataset_is_omitted(self):
+        self.assertNotIn("dataset", self._forget_kwargs(dataset=None))
+
+    def test_memory_only_passes_through(self):
+        self.assertIs(self._forget_kwargs(memory_only=True)["memory_only"], True)
+
+
+class TestImproveWireFormat(unittest.TestCase):
+    def test_background_becomes_run_in_background(self):
+        with fake_cognee() as fake:
+            _backend(served=True).improve(
+                dataset="hermes",
+                session_ids=["hermes_s1"],
+                background=True,
+                timeout=_TIMEOUT,
+            )
+            kwargs = fake.only_call("improve")
+        self.assertEqual(kwargs["dataset"], "hermes")
+        self.assertEqual(kwargs["session_ids"], ["hermes_s1"])
+        self.assertIs(kwargs["run_in_background"], True)
+
+    def test_foreground_is_sent_explicitly(self):
+        with fake_cognee() as fake:
+            _backend(served=True).improve(
+                dataset="hermes", session_ids=[], background=False, timeout=_TIMEOUT
+            )
+            self.assertIs(fake.only_call("improve")["run_in_background"], False)
+
+
+class TestUserKwarg(unittest.TestCase):
+    """Identity is the transport's business, and only in-process.
+
+    A served instance owns identity via the api-key principal. Passing
+    ``user=None`` is not the same as omitting it — the SDK may treat an explicit
+    None differently — so it must be left out entirely.
+    """
+
+    def test_omitted_when_served_even_with_a_user_set(self):
+        backend = _backend(served=True, user="USER")
+        kwargs = {}
+        backend._add_user_kwarg(kwargs)
+        self.assertNotIn("user", kwargs)
+
+    def test_included_when_in_process(self):
+        backend = _backend(served=False, user="USER")
+        kwargs = {}
+        backend._add_user_kwarg(kwargs)
+        self.assertEqual(kwargs["user"], "USER")
+
+    def test_omitted_when_there_is_no_user(self):
+        backend = _backend(served=False, user=None)
+        kwargs = {}
+        backend._add_user_kwarg(kwargs)
+        self.assertNotIn("user", kwargs)
+
+    def test_reaches_the_operations_in_process(self):
+        with fake_cognee() as fake:
+            _backend(served=False, user="USER").remember_permanent(
+                text="fact", dataset="hermes", session_ids=[], timeout=_TIMEOUT
+            )
+            self.assertEqual(fake.only_call("remember")["user"], "USER")
+
+
+class TestConnectAndClose(unittest.TestCase):
+    def test_connect_serves_the_url_and_marks_served(self):
+        with fake_cognee() as fake:
+            backend = _backend()
+            backend.connect(url="http://127.0.0.1:8000", api_key="", timeout=_TIMEOUT)
+            self.assertTrue(backend.served)
+            self.assertEqual(fake.only_call("serve"), {"url": "http://127.0.0.1:8000"})
+
+    def test_api_key_is_only_sent_when_present(self):
+        with fake_cognee() as fake:
+            _backend().connect(url="https://cloud.example", api_key="ck_1", timeout=_TIMEOUT)
+            self.assertEqual(fake.only_call("serve")["api_key"], "ck_1")
+
+    def test_close_disconnects_only_when_served(self):
+        with fake_cognee() as fake:
+            _backend(served=True).close(timeout=_TIMEOUT)
+            self.assertEqual(len(fake.kwargs_for("disconnect")), 1)
+
+        with fake_cognee() as fake:
+            _backend(served=False).close(timeout=_TIMEOUT)
+            self.assertEqual(fake.kwargs_for("disconnect"), [])
+
+
+class TestEmptyRecallHint(unittest.TestCase):
+    def test_skipped_when_served(self):
+        # A served instance owns the vector store; the local engine says nothing.
+        self.assertIsNone(_backend(served=True).empty_recall_hint())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/integrations/hermes-agent/tests/test_server_mode.py
+++ b/integrations/hermes-agent/tests/test_server_mode.py
@@ -112,6 +112,14 @@ class TestSpawnEnvironment(unittest.TestCase):
     def test_agent_mode_is_enabled_so_the_server_can_retire(self):
         self.assertEqual(self._spawn_env()["COGNEE_AGENT_MODE"], "true")
 
+    def test_the_env_matches_the_other_plugins_bootstraps(self):
+        # The server must behave identically no matter which cognee plugin booted
+        # it — these mirror claude-code's apply_cognee_env.
+        env = self._spawn_env()
+        self.assertEqual(env["CACHE_ROOT_DIRECTORY"], str(config_mod.SHARED_COGNEE_HOME / "cache"))
+        self.assertEqual(env["LLM_INSTRUCTOR_MODE"], "json_schema_mode")
+        self.assertEqual(env["COGNEE_IMPROVE_SUBMIT_TIMEOUT"], "420")
+
     def test_an_explicit_user_value_wins(self):
         self.assertEqual(self._spawn_env(CACHING="false")["CACHING"], "false")
 
@@ -179,10 +187,13 @@ class TestInitializeModes(unittest.TestCase):
         self.assertFalse(rec["identity_called"])
         self.assertFalse(rec["roots_called"])
 
-    def test_embedded_mode_configures_roots_and_resolves_identity(self):
-        # hermes_home is always injected by MemoryManager.initialize_all, and the
-        # roots are derived from it — without one there is nothing to configure.
-        env = {**_NO_URL, "COGNEE_EMBEDDED": "true"}
+    def test_embedded_mode_configures_shared_roots_and_resolves_identity(self):
+        env = {
+            **_NO_URL,
+            "COGNEE_EMBEDDED": "true",
+            "COGNEE_DATA_ROOT": "",
+            "COGNEE_SYSTEM_ROOT": "",
+        }
         p, rec = _make_provider()
         with tempfile.TemporaryDirectory() as home:
             with mock.patch.dict("os.environ", env, clear=False):
@@ -192,15 +203,22 @@ class TestInitializeModes(unittest.TestCase):
             self.assertTrue(rec["roots_called"])
             self.assertTrue(rec["identity_called"])
             roots = p._backend.only_call("configure_local_roots")
-        self.assertTrue(roots["data_root"].startswith(home))
-        self.assertTrue(roots["system_root"].startswith(home))
+        # The store is the shared ~/.cognee — the same roots the other cognee
+        # plugins pin — not scoped to the Hermes profile.
+        self.assertEqual(roots["data_root"], str(config_mod.SHARED_COGNEE_HOME / "data"))
+        self.assertEqual(roots["system_root"], str(config_mod.SHARED_COGNEE_HOME / "system"))
 
-    def test_embedded_mode_without_hermes_home_configures_no_roots(self):
-        env = {**_NO_URL, "COGNEE_EMBEDDED": "true"}
+    def test_embedded_mode_without_hermes_home_still_configures_roots(self):
+        env = {
+            **_NO_URL,
+            "COGNEE_EMBEDDED": "true",
+            "COGNEE_DATA_ROOT": "",
+            "COGNEE_SYSTEM_ROOT": "",
+        }
         p, rec = _make_provider()
         with mock.patch.dict("os.environ", env, clear=False):
             p.initialize("sid")
-        self.assertFalse(rec["roots_called"])
+        self.assertTrue(rec["roots_called"])
 
     def test_default_mode_ensures_local_server_and_serves_localhost(self):
         env = {**_NO_URL, "COGNEE_EMBEDDED": ""}
@@ -324,8 +342,9 @@ class TestTransportSelection(unittest.TestCase):
             provider.initialize("sid")
         self.assertIs(provider._backend, backend)
 
-    def test_the_http_transport_caches_its_key_under_hermes_home(self):
-        # Profile isolation: a minted key must not leak across Hermes profiles.
+    def test_the_http_transport_caches_its_key_in_the_shared_state_dir(self):
+        # One principal key per machine, shared with the other cognee plugins —
+        # whichever plugin mints first, the rest (including Hermes) reuse it.
         provider = provider_mod.CogneeMemoryProvider()
         with tempfile.TemporaryDirectory() as home:
             with (
@@ -336,7 +355,7 @@ class TestTransportSelection(unittest.TestCase):
                 mock.patch.object(HttpBackend, "connect"),
             ):
                 provider.initialize("sid", hermes_home=home)
-            self.assertEqual(str(provider._backend._cache_dir), home)
+            self.assertEqual(provider._backend._cache_dir, config_mod.SHARED_PLUGIN_STATE_DIR)
 
 
 class TestConfigModes(unittest.TestCase):

--- a/integrations/hermes-agent/tests/test_server_mode.py
+++ b/integrations/hermes-agent/tests/test_server_mode.py
@@ -52,6 +52,20 @@ class TestHealthOk(unittest.TestCase):
             self.assertFalse(sb.health_ok("http://127.0.0.1:8000"))
 
 
+def _live_child():
+    """A spawned process that is still running (poll() -> None)."""
+    proc = mock.MagicMock()
+    proc.poll.return_value = None
+    return proc
+
+
+def _dead_child(returncode=3):
+    proc = mock.MagicMock()
+    proc.poll.return_value = returncode
+    proc.returncode = returncode
+    return proc
+
+
 class TestEnsureLocalServer(unittest.TestCase):
     def test_already_healthy_does_not_spawn(self):
         with (
@@ -66,7 +80,7 @@ class TestEnsureLocalServer(unittest.TestCase):
         # First probe down (-> spawn), second probe up (-> return).
         with (
             mock.patch.object(sb, "health_ok", side_effect=[False, True]),
-            mock.patch.object(sb, "_spawn") as spawn,
+            mock.patch.object(sb, "_spawn", return_value=_live_child()) as spawn,
             mock.patch.object(sb.time, "sleep"),
         ):
             url = sb.ensure_local_server(8123)
@@ -76,11 +90,57 @@ class TestEnsureLocalServer(unittest.TestCase):
     def test_raises_when_never_healthy(self):
         with (
             mock.patch.object(sb, "health_ok", return_value=False),
-            mock.patch.object(sb, "_spawn"),
+            mock.patch.object(sb, "_spawn", return_value=_live_child()),
             mock.patch.object(sb.time, "sleep"),
         ):
             with self.assertRaises(RuntimeError):
                 sb.ensure_local_server(8000, boot_timeout=0.01)
+
+    def test_a_dead_spawn_with_a_silent_port_fails_fast(self):
+        # The 600s deadline exists for slow first boots, not broken installs — a
+        # crashed child with no other owner on the port must not stall the
+        # session start for 10 minutes.
+        with (
+            mock.patch.object(sb, "health_ok", return_value=False),
+            mock.patch.object(sb, "_spawn", return_value=_dead_child(3)),
+            mock.patch.object(sb, "port_bound", return_value=False),
+            mock.patch.object(sb.time, "sleep") as slept,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "exited with code 3"):
+                sb.ensure_local_server(8000, boot_timeout=600.0)
+        slept.assert_not_called()
+
+    def test_a_dead_spawn_that_lost_the_bind_race_keeps_waiting(self):
+        # Our child dying because a concurrent starter won the port is a success
+        # path: the winner owns the port and will become healthy.
+        with (
+            mock.patch.object(sb, "health_ok", side_effect=[False, False, True]),
+            mock.patch.object(sb, "_spawn", return_value=_dead_child(1)),
+            mock.patch.object(sb, "port_bound", return_value=True),
+            mock.patch.object(sb.time, "sleep"),
+        ):
+            url = sb.ensure_local_server(8123, boot_timeout=600.0)
+        self.assertEqual(url, "http://127.0.0.1:8123")
+
+    def test_a_failed_spawn_with_a_silent_port_fails_fast(self):
+        with (
+            mock.patch.object(sb, "health_ok", return_value=False),
+            mock.patch.object(sb, "_spawn", side_effect=OSError("permission denied")),
+            mock.patch.object(sb, "port_bound", return_value=False),
+            mock.patch.object(sb.time, "sleep"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "failed to launch"):
+                sb.ensure_local_server(8000, boot_timeout=600.0)
+
+    def test_the_error_points_at_the_server_log(self):
+        with (
+            mock.patch.object(sb, "health_ok", return_value=False),
+            mock.patch.object(sb, "_spawn", return_value=_dead_child()),
+            mock.patch.object(sb, "port_bound", return_value=False),
+            mock.patch.object(sb.time, "sleep"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "/var/log/cognee.log"):
+                sb.ensure_local_server(8000, boot_timeout=600.0, log_path="/var/log/cognee.log")
 
 
 class TestSpawnEnvironment(unittest.TestCase):
@@ -235,6 +295,9 @@ class TestInitializeModes(unittest.TestCase):
         # 8011 keeps us off cognee's own default of 8000, so we never attach to a
         # server the user is running themselves.
         self.assertEqual(ensure.call_args.args[0], 8011)
+        # The 600s deadline the other plugins use: a cold first boot runs
+        # migrations, and giving up early turns memory off for the whole session.
+        self.assertEqual(ensure.call_args.kwargs["boot_timeout"], 600.0)
         self.assertTrue(p._remote_mode)
         self.assertEqual(rec["served"], ("http://127.0.0.1:8000", ""))
         self.assertFalse(rec["identity_called"])

--- a/integrations/hermes-agent/tests/test_server_mode.py
+++ b/integrations/hermes-agent/tests/test_server_mode.py
@@ -24,6 +24,7 @@ from cognee_integration_hermes import config as config_mod  # noqa: E402
 from cognee_integration_hermes import provider as provider_mod  # noqa: E402
 from cognee_integration_hermes import server_bootstrap as sb  # noqa: E402
 from cognee_integration_hermes.backend import SdkBackend  # noqa: E402
+from cognee_integration_hermes.http_backend import HttpBackend  # noqa: E402
 
 
 class _FakeResp:
@@ -217,32 +218,48 @@ class TestImproveBackgroundDecision(unittest.TestCase):
 
 
 class TestTransportSelection(unittest.TestCase):
-    """``COGNEE_TRANSPORT`` chooses the transport; the SDK stays the default."""
+    """Direct HTTP is the default; the SDK serves embedded mode and opt-out."""
 
     def _transport_for(self, env):
-        # The real transport classes are used so the type assertions mean
-        # something, but SdkBackend's two cognee-importing hooks are stubbed —
-        # otherwise selecting the default would pay a multi-second import.
-        merged = {**_NO_URL, "COGNEE_EMBEDDED": "true", **env}
+        # Real transport classes, so the type assertions mean something — but every
+        # I/O-touching hook is stubbed: SdkBackend's cognee imports would cost
+        # seconds, and connect() would reach for a socket.
+        merged = {**_NO_URL, **env}
         provider = provider_mod.CogneeMemoryProvider()
         with (
             mock.patch.dict("os.environ", merged, clear=False),
+            mock.patch.object(
+                provider_mod, "ensure_local_server", return_value="http://127.0.0.1:8000"
+            ),
             mock.patch.object(SdkBackend, "configure_models"),
             mock.patch.object(SdkBackend, "configure_local_roots"),
             mock.patch.object(SdkBackend, "resolve_identity"),
+            mock.patch.object(SdkBackend, "connect"),
+            mock.patch.object(HttpBackend, "connect"),
         ):
             provider.initialize("sid")
         return type(provider._backend).__name__
 
-    def test_default_is_the_sdk_transport(self):
-        self.assertEqual(self._transport_for({}), "SdkBackend")
+    def test_default_is_the_http_transport(self):
+        self.assertEqual(self._transport_for({}), "HttpBackend")
 
-    def test_http_is_opt_in(self):
-        # Embedded mode never connects, so this exercises selection only.
-        self.assertEqual(self._transport_for({"COGNEE_TRANSPORT": "http"}), "HttpBackend")
+    def test_cloud_mode_also_uses_http(self):
+        self.assertEqual(
+            self._transport_for({"COGNEE_BASE_URL": "https://cloud.example"}), "HttpBackend"
+        )
 
-    def test_explicit_sdk_is_honoured(self):
+    def test_the_sdk_can_be_selected_explicitly(self):
         self.assertEqual(self._transport_for({"COGNEE_TRANSPORT": "sdk"}), "SdkBackend")
+
+    def test_embedded_mode_uses_the_sdk(self):
+        # Embedded means "no server at all", which only the in-process SDK can do.
+        self.assertEqual(self._transport_for({"COGNEE_EMBEDDED": "true"}), "SdkBackend")
+
+    def test_embedded_mode_wins_over_the_http_default(self):
+        self.assertEqual(
+            self._transport_for({"COGNEE_EMBEDDED": "true", "COGNEE_TRANSPORT": "http"}),
+            "SdkBackend",
+        )
 
     def test_an_injected_transport_always_wins(self):
         backend = FakeBackend()
@@ -252,12 +269,17 @@ class TestTransportSelection(unittest.TestCase):
             provider.initialize("sid")
         self.assertIs(provider._backend, backend)
 
-    def test_http_transport_caches_its_key_under_hermes_home(self):
-        # Profile isolation: a minted key must not be shared across profiles.
-        env = {**_NO_URL, "COGNEE_EMBEDDED": "true", "COGNEE_TRANSPORT": "http"}
+    def test_the_http_transport_caches_its_key_under_hermes_home(self):
+        # Profile isolation: a minted key must not leak across Hermes profiles.
         provider = provider_mod.CogneeMemoryProvider()
         with tempfile.TemporaryDirectory() as home:
-            with mock.patch.dict("os.environ", env, clear=False):
+            with (
+                mock.patch.dict("os.environ", _NO_URL, clear=False),
+                mock.patch.object(
+                    provider_mod, "ensure_local_server", return_value="http://127.0.0.1:8000"
+                ),
+                mock.patch.object(HttpBackend, "connect"),
+            ):
                 provider.initialize("sid", hermes_home=home)
             self.assertEqual(str(provider._backend._cache_dir), home)
 

--- a/integrations/hermes-agent/tests/test_server_mode.py
+++ b/integrations/hermes-agent/tests/test_server_mode.py
@@ -162,6 +162,10 @@ class TestInitializeModes(unittest.TestCase):
         ):
             p.initialize("sid")
         ensure.assert_called_once()
+        # The port actually handed to the bootstrap, not just the mocked return:
+        # 8011 keeps us off cognee's own default of 8000, so we never attach to a
+        # server the user is running themselves.
+        self.assertEqual(ensure.call_args.args[0], 8011)
         self.assertTrue(p._remote_mode)
         self.assertEqual(rec["served"], ("http://127.0.0.1:8000", ""))
         self.assertFalse(rec["identity_called"])
@@ -302,7 +306,7 @@ class TestConfigModes(unittest.TestCase):
         with mock.patch.dict("os.environ", env, clear=False):
             cfg = config_mod.load_config()
         self.assertFalse(cfg["embedded"])
-        self.assertEqual(cfg["local_port"], 8000)
+        self.assertEqual(cfg["local_port"], 8011)
 
     def test_local_port_clamped(self):
         env = {**_NO_URL, "COGNEE_LOCAL_PORT": "999999"}

--- a/integrations/hermes-agent/tests/test_server_mode.py
+++ b/integrations/hermes-agent/tests/test_server_mode.py
@@ -9,6 +9,7 @@ How a transport turns protocol calls into wire format lives in
 Runs under pytest or standalone (``python3 tests/test_server_mode.py``).
 """
 
+import os
 import sys
 import tempfile
 import unittest
@@ -419,6 +420,105 @@ class TestTransportSelection(unittest.TestCase):
             ):
                 provider.initialize("sid", hermes_home=home)
             self.assertEqual(provider._backend._cache_dir, config_mod.SHARED_PLUGIN_STATE_DIR)
+
+
+class TestExitWatcherLifecycle(unittest.TestCase):
+    """Crash insurance is armed only when a server outlives the process."""
+
+    def _server_backend(self):
+        backend = FakeBackend()
+        backend.connection_info = lambda: {
+            "url": "http://127.0.0.1:8011",
+            "api_key": "k",
+            "agent_session_name": "hermes",
+        }
+        return backend
+
+    def _initialize(self, backend, arm=None, **init_kwargs):
+        p = provider_mod.CogneeMemoryProvider(backend=backend)
+        with (
+            mock.patch.dict("os.environ", _NO_URL, clear=False),
+            mock.patch.object(
+                provider_mod, "ensure_local_server", return_value="http://127.0.0.1:8000"
+            ),
+            mock.patch.object(provider_mod.exit_watcher, "arm", arm or mock.MagicMock()) as armed,
+        ):
+            p.initialize("sid", **init_kwargs)
+        return p, armed
+
+    def test_no_watcher_without_a_surviving_server(self):
+        # FakeBackend inherits connection_info() -> None (in-process semantics).
+        p, armed = self._initialize(FakeBackend())
+        armed.assert_not_called()
+        self.assertIsNone(p._watcher_state_path)
+
+    def test_armed_in_server_mode_with_the_connection_details(self):
+        p, armed = self._initialize(self._server_backend())
+        kwargs = armed.call_args.kwargs
+        self.assertEqual(kwargs["url"], "http://127.0.0.1:8011")
+        self.assertEqual(kwargs["api_key"], "k")
+        self.assertEqual(kwargs["parent_pid"], os.getpid())
+        self.assertEqual(kwargs["session_id"], p._session_cognee_id)
+        self.assertEqual(kwargs["dataset"], p._dataset)
+        self.assertTrue(kwargs["improve"])
+        self.assertIsNotNone(p._watcher_state_path)
+
+    def test_a_subagent_context_disables_the_improve_half(self):
+        # A subagent must not write; its watcher may still unregister.
+        p, armed = self._initialize(self._server_backend(), agent_context="subagent")
+        self.assertFalse(armed.call_args.kwargs["improve"])
+
+    def test_arm_failure_is_not_fatal(self):
+        arm = mock.MagicMock(side_effect=OSError("no fork for you"))
+        p, _ = self._initialize(self._server_backend(), arm=arm)
+        self.assertTrue(p._initialized)
+        self.assertIsNone(p._watcher_state_path)
+
+    def _armed_provider(self):
+        p, _ = _make_provider()
+        p._initialized = True
+        p._writes_enabled = True
+        p._improve_on_end = True
+        p._remote_mode = True
+        p._config = {"improve_timeout": 300}
+        p._watcher_state_path = Path("/tmp/watcher.json")
+        return p
+
+    def test_session_switch_repoints_the_watcher(self):
+        p = self._armed_provider()
+        with mock.patch.object(provider_mod.exit_watcher, "update") as update:
+            p.on_session_switch("next-session")
+        kwargs = update.call_args.kwargs
+        self.assertEqual(kwargs["session_id"], p._session_cognee_id)
+        self.assertTrue(kwargs["improve"])
+
+    def test_session_end_stands_down_the_improve_half_only(self):
+        p = self._armed_provider()
+        with mock.patch.object(provider_mod.exit_watcher, "update") as update:
+            p.on_session_end([])
+        self.assertIs(update.call_args.kwargs["improve"], False)
+        # Still armed: the unregister half must survive until shutdown.
+        self.assertIsNotNone(p._watcher_state_path)
+
+    def test_a_failed_session_end_improve_keeps_the_insurance(self):
+        p = self._armed_provider()
+        p._backend.errors["improve"] = RuntimeError("server hiccup")
+        with mock.patch.object(provider_mod.exit_watcher, "update") as update:
+            p.on_session_end([])
+        update.assert_not_called()
+
+    def test_shutdown_disarms_before_closing_the_backend(self):
+        p = self._armed_provider()
+        order = []
+        with (
+            mock.patch.object(
+                provider_mod.exit_watcher, "disarm", side_effect=lambda *a: order.append("disarm")
+            ),
+            mock.patch.object(p._backend, "close", side_effect=lambda **k: order.append("close")),
+        ):
+            p.shutdown()
+        self.assertEqual(order, ["disarm", "close"])
+        self.assertIsNone(p._watcher_state_path)
 
 
 class TestConfigModes(unittest.TestCase):

--- a/integrations/hermes-agent/tests/test_server_mode.py
+++ b/integrations/hermes-agent/tests/test_server_mode.py
@@ -303,6 +303,33 @@ class TestInitializeModes(unittest.TestCase):
         self.assertEqual(rec["served"], ("http://127.0.0.1:8000", ""))
         self.assertFalse(rec["identity_called"])
 
+    def test_initialize_ensures_the_dataset(self):
+        env = {**_NO_URL, "COGNEE_EMBEDDED": ""}
+        p, rec = _make_provider()
+        with (
+            mock.patch.dict("os.environ", env, clear=False),
+            mock.patch.object(
+                provider_mod, "ensure_local_server", return_value="http://127.0.0.1:8000"
+            ),
+        ):
+            p.initialize("sid")
+        self.assertEqual(p._backend.only_call("ensure_dataset")["dataset"], p._dataset)
+
+    def test_a_failed_dataset_ensure_is_not_fatal(self):
+        # A write creates the dataset implicitly anyway; failing here only costs
+        # the recall-first case, never the session.
+        env = {**_NO_URL, "COGNEE_EMBEDDED": ""}
+        p, rec = _make_provider()
+        p._backend.errors["ensure_dataset"] = RuntimeError("datasets route down")
+        with (
+            mock.patch.dict("os.environ", env, clear=False),
+            mock.patch.object(
+                provider_mod, "ensure_local_server", return_value="http://127.0.0.1:8000"
+            ),
+        ):
+            p.initialize("sid")
+        self.assertTrue(p._initialized)
+
     def test_local_server_failure_raises_not_silently_embedded(self):
         # Falling back to embedded would reintroduce the DB-lock risk this PR
         # removes, so a server that won't start is a hard error.

--- a/integrations/hermes-agent/tests/test_server_mode.py
+++ b/integrations/hermes-agent/tests/test_server_mode.py
@@ -23,6 +23,7 @@ from _char_helpers import FakeBackend  # noqa: E402
 from cognee_integration_hermes import config as config_mod  # noqa: E402
 from cognee_integration_hermes import provider as provider_mod  # noqa: E402
 from cognee_integration_hermes import server_bootstrap as sb  # noqa: E402
+from cognee_integration_hermes.backend import SdkBackend  # noqa: E402
 
 
 class _FakeResp:
@@ -213,6 +214,52 @@ class TestImproveBackgroundDecision(unittest.TestCase):
 
     def test_env_override_forces_background_in_embedded(self):
         self.assertTrue(self._run_session_end(remote_mode=False, env_override="true"))
+
+
+class TestTransportSelection(unittest.TestCase):
+    """``COGNEE_TRANSPORT`` chooses the transport; the SDK stays the default."""
+
+    def _transport_for(self, env):
+        # The real transport classes are used so the type assertions mean
+        # something, but SdkBackend's two cognee-importing hooks are stubbed —
+        # otherwise selecting the default would pay a multi-second import.
+        merged = {**_NO_URL, "COGNEE_EMBEDDED": "true", **env}
+        provider = provider_mod.CogneeMemoryProvider()
+        with (
+            mock.patch.dict("os.environ", merged, clear=False),
+            mock.patch.object(SdkBackend, "configure_models"),
+            mock.patch.object(SdkBackend, "configure_local_roots"),
+            mock.patch.object(SdkBackend, "resolve_identity"),
+        ):
+            provider.initialize("sid")
+        return type(provider._backend).__name__
+
+    def test_default_is_the_sdk_transport(self):
+        self.assertEqual(self._transport_for({}), "SdkBackend")
+
+    def test_http_is_opt_in(self):
+        # Embedded mode never connects, so this exercises selection only.
+        self.assertEqual(self._transport_for({"COGNEE_TRANSPORT": "http"}), "HttpBackend")
+
+    def test_explicit_sdk_is_honoured(self):
+        self.assertEqual(self._transport_for({"COGNEE_TRANSPORT": "sdk"}), "SdkBackend")
+
+    def test_an_injected_transport_always_wins(self):
+        backend = FakeBackend()
+        provider = provider_mod.CogneeMemoryProvider(backend=backend)
+        env = {**_NO_URL, "COGNEE_EMBEDDED": "true", "COGNEE_TRANSPORT": "http"}
+        with mock.patch.dict("os.environ", env, clear=False):
+            provider.initialize("sid")
+        self.assertIs(provider._backend, backend)
+
+    def test_http_transport_caches_its_key_under_hermes_home(self):
+        # Profile isolation: a minted key must not be shared across profiles.
+        env = {**_NO_URL, "COGNEE_EMBEDDED": "true", "COGNEE_TRANSPORT": "http"}
+        provider = provider_mod.CogneeMemoryProvider()
+        with tempfile.TemporaryDirectory() as home:
+            with mock.patch.dict("os.environ", env, clear=False):
+                provider.initialize("sid", hermes_home=home)
+            self.assertEqual(str(provider._backend._cache_dir), home)
 
 
 class TestConfigModes(unittest.TestCase):

--- a/integrations/hermes-agent/tests/test_server_mode.py
+++ b/integrations/hermes-agent/tests/test_server_mode.py
@@ -83,6 +83,57 @@ class TestEnsureLocalServer(unittest.TestCase):
                 sb.ensure_local_server(8000, boot_timeout=0.01)
 
 
+class TestSpawnEnvironment(unittest.TestCase):
+    """The spawned server's environment — where the session cache lives or dies."""
+
+    def _spawn_env(self, **env_overrides):
+        captured = {}
+
+        def fake_popen(args, env=None, **kwargs):
+            captured.update(env or {})
+            return mock.MagicMock()
+
+        with (
+            mock.patch.dict("os.environ", env_overrides, clear=False),
+            mock.patch.object(sb.subprocess, "Popen", side_effect=fake_popen),
+        ):
+            sb._spawn(9999, "", "", "/dev/null")
+        return captured
+
+    def test_caching_is_enabled_for_the_session_tier(self):
+        # Live-diagnosed: without CACHING, cognee's session manager reports
+        # is_available=False and a session write is dropped while the API still
+        # answers status="session_stored" — so turns silently never reach the graph.
+        self.assertEqual(self._spawn_env()["CACHING"], "true")
+
+    def test_auto_feedback_is_enabled(self):
+        self.assertEqual(self._spawn_env()["AUTO_FEEDBACK"], "true")
+
+    def test_agent_mode_is_enabled_so_the_server_can_retire(self):
+        self.assertEqual(self._spawn_env()["COGNEE_AGENT_MODE"], "true")
+
+    def test_an_explicit_user_value_wins(self):
+        self.assertEqual(self._spawn_env(CACHING="false")["CACHING"], "false")
+
+    def test_data_roots_are_passed_through_when_given(self):
+        captured = {}
+
+        def fake_popen(args, env=None, **kwargs):
+            captured.update(env or {})
+            return mock.MagicMock()
+
+        with mock.patch.object(sb.subprocess, "Popen", side_effect=fake_popen):
+            sb._spawn(9999, "/tmp/data", "/tmp/system", "/dev/null")
+        self.assertEqual(captured["DATA_ROOT_DIRECTORY"], "/tmp/data")
+        self.assertEqual(captured["SYSTEM_ROOT_DIRECTORY"], "/tmp/system")
+
+    def test_roots_are_omitted_when_empty(self):
+        env = self._spawn_env()
+        # Not asserting absence outright: the ambient environment may legitimately
+        # carry them. What matters is we do not invent an empty value.
+        self.assertNotEqual(env.get("DATA_ROOT_DIRECTORY", "unset"), "")
+
+
 class _Recorder(dict):
     """Reads the mode-routing decisions off a fake backend.
 

--- a/integrations/hermes-agent/tests/test_server_mode.py
+++ b/integrations/hermes-agent/tests/test_server_mode.py
@@ -1,11 +1,16 @@
 """Tests for local-server mode: bootstrap helper, init mode routing, config.
 
-Runs under pytest or standalone (``python3 tests/test_server_mode.py``). None of
-these need cognee installed — the provider imports it lazily and we stub the
-serve/identity coroutines, so the tests exercise pure routing logic.
+Mode selection is a Hermes concern and stays in the provider: which transport
+gets built, and whether a local server is spawned first. The transport itself is
+faked, so these exercise pure routing logic and need neither cognee nor a network.
+How a transport turns protocol calls into wire format lives in
+``test_sdk_backend.py``.
+
+Runs under pytest or standalone (``python3 tests/test_server_mode.py``).
 """
 
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -14,6 +19,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from _char_helpers import FakeBackend  # noqa: E402
 from cognee_integration_hermes import config as config_mod  # noqa: E402
 from cognee_integration_hermes import provider as provider_mod  # noqa: E402
 from cognee_integration_hermes import server_bootstrap as sb  # noqa: E402
@@ -75,23 +81,35 @@ class TestEnsureLocalServer(unittest.TestCase):
                 sb.ensure_local_server(8000, boot_timeout=0.01)
 
 
+class _Recorder(dict):
+    """Reads the mode-routing decisions off a fake backend.
+
+    Mode selection stays in the provider — which transport gets built, and
+    whether a local server is spawned first, is a Hermes concern. What the
+    provider then *asks* the transport to do is recorded here.
+    """
+
+    def __init__(self, backend):
+        super().__init__(served=None, identity_called=False, roots_called=False)
+        self._backend = backend
+
+    def _refresh(self):
+        connects = self._backend.kwargs_for("connect")
+        if connects:
+            self["served"] = (connects[0]["url"], connects[0]["api_key"])
+        self["identity_called"] = bool(self._backend.kwargs_for("resolve_identity"))
+        self["roots_called"] = bool(self._backend.kwargs_for("configure_local_roots"))
+
+    def __getitem__(self, key):
+        self._refresh()
+        return super().__getitem__(key)
+
+
 def _make_provider():
-    """A provider with cognee-touching coroutines stubbed; records what ran."""
-    p = provider_mod.CogneeMemoryProvider()
-    rec = {"served": None, "identity_called": False, "roots_called": False}
-
-    async def fake_serve(url, key):
-        rec["served"] = (url, key)
-
-    async def fake_identity():
-        rec["identity_called"] = True
-        return "USER"
-
-    p._do_serve = fake_serve
-    p._ensure_identity = fake_identity
-    p._configure_cognee_models = lambda: None
-    p._configure_cognee_local_roots = lambda: rec.__setitem__("roots_called", True)
-    return p, rec
+    """A provider on a fake transport, plus a recorder of what it was asked to do."""
+    backend = FakeBackend()
+    p = provider_mod.CogneeMemoryProvider(backend=backend)
+    return p, _Recorder(backend)
 
 
 _NO_URL = {"COGNEE_BASE_URL": "", "COGNEE_SERVICE_URL": ""}
@@ -105,20 +123,31 @@ class TestInitializeModes(unittest.TestCase):
             p.initialize("sid")
         self.assertTrue(p._remote_mode)
         self.assertEqual(rec["served"], ("https://cloud.example/api", "k"))
-        self.assertIsNone(p._user)
         self.assertFalse(rec["identity_called"])
         self.assertFalse(rec["roots_called"])
 
     def test_embedded_mode_configures_roots_and_resolves_identity(self):
+        # hermes_home is always injected by MemoryManager.initialize_all, and the
+        # roots are derived from it — without one there is nothing to configure.
+        env = {**_NO_URL, "COGNEE_EMBEDDED": "true"}
+        p, rec = _make_provider()
+        with tempfile.TemporaryDirectory() as home:
+            with mock.patch.dict("os.environ", env, clear=False):
+                p.initialize("sid", hermes_home=home)
+            self.assertFalse(p._remote_mode)
+            self.assertIsNone(rec["served"])
+            self.assertTrue(rec["roots_called"])
+            self.assertTrue(rec["identity_called"])
+            roots = p._backend.only_call("configure_local_roots")
+        self.assertTrue(roots["data_root"].startswith(home))
+        self.assertTrue(roots["system_root"].startswith(home))
+
+    def test_embedded_mode_without_hermes_home_configures_no_roots(self):
         env = {**_NO_URL, "COGNEE_EMBEDDED": "true"}
         p, rec = _make_provider()
         with mock.patch.dict("os.environ", env, clear=False):
             p.initialize("sid")
-        self.assertFalse(p._remote_mode)
-        self.assertIsNone(rec["served"])
-        self.assertTrue(rec["roots_called"])
-        self.assertTrue(rec["identity_called"])
-        self.assertEqual(p._user, "USER")
+        self.assertFalse(rec["roots_called"])
 
     def test_default_mode_ensures_local_server_and_serves_localhost(self):
         env = {**_NO_URL, "COGNEE_EMBEDDED": ""}
@@ -133,7 +162,6 @@ class TestInitializeModes(unittest.TestCase):
         ensure.assert_called_once()
         self.assertTrue(p._remote_mode)
         self.assertEqual(rec["served"], ("http://127.0.0.1:8000", ""))
-        self.assertIsNone(p._user)
         self.assertFalse(rec["identity_called"])
 
     def test_local_server_failure_raises_not_silently_embedded(self):
@@ -156,41 +184,11 @@ class TestInitializeModes(unittest.TestCase):
         # local graph (data divergence / masked config error).
         env = {**_NO_URL, "COGNEE_BASE_URL": "https://cloud.example/api"}
         p, rec = _make_provider()
-
-        async def boom(url, key):
-            raise RuntimeError("unreachable")
-
-        p._do_serve = boom
+        p._backend.errors["connect"] = RuntimeError("unreachable")
         with mock.patch.dict("os.environ", env, clear=False):
             with self.assertRaises(RuntimeError):
                 p.initialize("sid")
         self.assertFalse(rec["roots_called"])
-
-
-class TestUserKwarg(unittest.TestCase):
-    def test_omitted_in_remote_mode_even_with_user_set(self):
-        p, _ = _make_provider()
-        p._remote_mode = True
-        p._user = "USER"
-        kwargs = {}
-        p._add_user_kwarg(kwargs)
-        self.assertNotIn("user", kwargs)  # omitted, not user=None
-
-    def test_included_in_embedded_mode(self):
-        p, _ = _make_provider()
-        p._remote_mode = False
-        p._user = "USER"
-        kwargs = {}
-        p._add_user_kwarg(kwargs)
-        self.assertEqual(kwargs["user"], "USER")
-
-    def test_omitted_when_user_is_none(self):
-        p, _ = _make_provider()
-        p._remote_mode = False
-        p._user = None
-        kwargs = {}
-        p._add_user_kwarg(kwargs)
-        self.assertNotIn("user", kwargs)
 
 
 class TestImproveBackgroundDecision(unittest.TestCase):
@@ -203,15 +201,9 @@ class TestImproveBackgroundDecision(unittest.TestCase):
         p._improve_on_end = True
         p._remote_mode = remote_mode
         p._config = {"improve_timeout": 300, "improve_background": env_override or ""}
-        captured = {}
-
-        async def fake_improve(run_in_background=False):
-            captured["bg"] = run_in_background
-
-        p._do_improve = fake_improve
         p._is_breaker_open = lambda: False
         p.on_session_end([])
-        return captured.get("bg")
+        return p._backend.only_call("improve")["background"]
 
     def test_server_mode_backgrounds(self):
         self.assertTrue(self._run_session_end(remote_mode=True))

--- a/integrations/hermes-agent/tests/test_tool_contract.py
+++ b/integrations/hermes-agent/tests/test_tool_contract.py
@@ -20,7 +20,7 @@ if str(ROOT) not in sys.path:
 
 from _char_helpers import (  # noqa: E402
     RememberResultStub,
-    fake_cognee,
+    fake_backend,
     make_provider,
 )
 
@@ -46,7 +46,7 @@ class _ModelDumpItem:
 
 class TestRecallEnvelope(unittest.TestCase):
     def test_hit_returns_results_and_count(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.results["recall"] = [{"text": "alpha"}, {"text": "beta"}]
             provider = make_provider()
             out = _call(provider, "cognee_recall", {"query": "q"})
@@ -54,27 +54,27 @@ class TestRecallEnvelope(unittest.TestCase):
         self.assertEqual([item["text"] for item in out["results"]], ["alpha", "beta"])
 
     def test_miss_returns_result_message_and_zero_count(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.results["recall"] = []
             provider = make_provider()
             out = _call(provider, "cognee_recall", {"query": "q"})
         self.assertEqual(out, {"result": "No relevant Cognee memory found.", "count": 0})
 
     def test_missing_query_is_an_error_and_calls_nothing(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             out = _call(provider, "cognee_recall", {})
         self.assertEqual(out, {"error": "Missing required parameter: query"})
         self.assertEqual(fake.kwargs_for("recall"), [])
 
     def test_blank_query_is_an_error(self):
-        with fake_cognee():
+        with fake_backend():
             provider = make_provider()
             out = _call(provider, "cognee_recall", {"query": "   "})
         self.assertEqual(out, {"error": "Missing required parameter: query"})
 
     def test_backend_failure_is_reported_as_error_text(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.errors["recall"] = RuntimeError("boom")
             provider = make_provider()
             out = _call(provider, "cognee_recall", {"query": "q"})
@@ -84,8 +84,8 @@ class TestRecallEnvelope(unittest.TestCase):
 
 class TestRememberEnvelope(unittest.TestCase):
     def test_success_envelope(self):
-        with fake_cognee() as fake:
-            fake.results["remember"] = RememberResultStub("running")
+        with fake_backend() as fake:
+            fake.results["remember_permanent"] = RememberResultStub("running")
             provider = make_provider()
             out = _call(provider, "cognee_remember", {"content": "fact"})
         self.assertEqual(out, {"result": "Content stored in Cognee.", "status": "running"})
@@ -96,22 +96,22 @@ class TestRememberEnvelope(unittest.TestCase):
         # backend returns a *dict*, which has no ``.status`` attribute — so it
         # would silently always report "completed". The HTTP backend must either
         # return a status-bearing object or the handler must read dict keys too.
-        with fake_cognee() as fake:
-            fake.results["remember"] = {"status": "running"}
+        with fake_backend() as fake:
+            fake.results["remember_permanent"] = {"status": "running"}
             provider = make_provider()
             out = _call(provider, "cognee_remember", {"content": "fact"})
         self.assertEqual(out["status"], "completed")
 
     def test_missing_content_is_an_error_and_calls_nothing(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             out = _call(provider, "cognee_remember", {})
         self.assertEqual(out, {"error": "Missing required parameter: content"})
-        self.assertEqual(fake.kwargs_for("remember"), [])
+        self.assertEqual(fake.kwargs_for("remember_permanent"), [])
 
     def test_backend_failure_is_reported_as_error_text(self):
-        with fake_cognee() as fake:
-            fake.errors["remember"] = RuntimeError("nope")
+        with fake_backend() as fake:
+            fake.errors["remember_permanent"] = RuntimeError("nope")
             provider = make_provider()
             out = _call(provider, "cognee_remember", {"content": "fact"})
         self.assertTrue(out["error"].startswith("Cognee remember failed:"))
@@ -119,21 +119,21 @@ class TestRememberEnvelope(unittest.TestCase):
 
 class TestForgetEnvelope(unittest.TestCase):
     def test_requires_dataset_or_everything(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             out = _call(provider, "cognee_forget", {})
         self.assertEqual(out, {"error": "Specify dataset or set everything=true."})
         self.assertEqual(fake.kwargs_for("forget"), [])
 
     def test_success_envelope_passes_backend_details_through(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.results["forget"] = {"deleted": 3}
             provider = make_provider()
             out = _call(provider, "cognee_forget", {"dataset": "hermes"})
         self.assertEqual(out, {"result": "Cognee memory deleted.", "details": {"deleted": 3}})
 
     def test_backend_failure_is_reported_as_error_text(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.errors["forget"] = RuntimeError("denied")
             provider = make_provider()
             out = _call(provider, "cognee_forget", {"everything": True})
@@ -142,13 +142,13 @@ class TestForgetEnvelope(unittest.TestCase):
 
 class TestDispatch(unittest.TestCase):
     def test_unknown_tool_names_the_tool(self):
-        with fake_cognee():
+        with fake_backend():
             provider = make_provider()
             out = _call(provider, "cognee_nope", {})
         self.assertEqual(out, {"error": "Unknown Cognee tool: cognee_nope"})
 
     def test_open_breaker_short_circuits_every_tool_without_calling_the_backend(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             provider._is_breaker_open = lambda: True
             for tool, args in (
@@ -183,7 +183,7 @@ class TestDispatch(unittest.TestCase):
 
 class TestResultNormalization(unittest.TestCase):
     def _first(self, item):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             fake.results["recall"] = [item]
             provider = make_provider()
             out = _call(provider, "cognee_recall", {"query": "q"})
@@ -245,40 +245,40 @@ class TestResultNormalization(unittest.TestCase):
 
 class TestRecallPayload(unittest.TestCase):
     def _recall_kwargs(self, args, **provider_kwargs):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(**provider_kwargs)
             provider.handle_tool_call("cognee_recall", args)
             return fake.only_call("recall")
 
-    def test_query_text_top_k_and_auto_route_always_sent(self):
+    def test_query_top_k_and_auto_route_always_sent(self):
         kwargs = self._recall_kwargs({"query": "hello"}, top_k=7, auto_route=False)
-        self.assertEqual(kwargs["query_text"], "hello")
+        self.assertEqual(kwargs["query"], "hello")
         self.assertEqual(kwargs["top_k"], 7)
         self.assertIs(kwargs["auto_route"], False)
 
-    def test_auto_scope_sends_both_session_and_datasets(self):
+    def test_auto_scope_targets_both_session_and_datasets(self):
         kwargs = self._recall_kwargs({"query": "q"}, session_cognee_id="hermes_abc")
         self.assertEqual(kwargs["session_id"], "hermes_abc")
         self.assertEqual(kwargs["datasets"], ["hermes"])
 
     def test_missing_scope_defaults_to_auto(self):
         kwargs = self._recall_kwargs({"query": "q", "scope": None})
-        self.assertIn("session_id", kwargs)
-        self.assertIn("datasets", kwargs)
+        self.assertIsNotNone(kwargs["session_id"])
+        self.assertIsNotNone(kwargs["datasets"])
 
-    def test_session_scope_sends_session_only(self):
+    def test_session_scope_targets_the_session_only(self):
         kwargs = self._recall_kwargs({"query": "q", "scope": "session"})
-        self.assertIn("session_id", kwargs)
-        self.assertNotIn("datasets", kwargs)
+        self.assertIsNotNone(kwargs["session_id"])
+        self.assertIsNone(kwargs["datasets"])
 
-    def test_graph_scope_sends_datasets_only(self):
+    def test_graph_scope_targets_datasets_only(self):
         kwargs = self._recall_kwargs({"query": "q", "scope": "graph"})
         self.assertEqual(kwargs["datasets"], ["hermes"])
-        self.assertNotIn("session_id", kwargs)
+        self.assertIsNone(kwargs["session_id"])
 
     def test_scope_is_case_insensitive(self):
         kwargs = self._recall_kwargs({"query": "q", "scope": "GRAPH"})
-        self.assertNotIn("session_id", kwargs)
+        self.assertIsNone(kwargs["session_id"])
 
     def test_search_type_applied_outside_session_scope(self):
         kwargs = self._recall_kwargs({"query": "q", "scope": "graph", "search_type": "CHUNKS"})
@@ -286,19 +286,22 @@ class TestRecallPayload(unittest.TestCase):
 
     def test_search_type_ignored_in_session_scope(self):
         kwargs = self._recall_kwargs({"query": "q", "scope": "session", "search_type": "CHUNKS"})
-        self.assertNotIn("query_type", kwargs)
+        self.assertIsNone(kwargs["query_type"])
 
-    def test_unknown_search_type_falls_back_to_graph_completion(self):
+    def test_unrecognized_search_type_is_passed_through(self):
+        # The provider does not police search-type names; each transport resolves
+        # them and falls back (see test_sdk_backend). That keeps a search type
+        # added by a future cognee working without a provider change.
         kwargs = self._recall_kwargs({"query": "q", "search_type": "NOT_A_TYPE"})
-        self.assertEqual(kwargs["query_type"], "GRAPH_COMPLETION")
+        self.assertEqual(kwargs["query_type"], "NOT_A_TYPE")
 
     def test_no_query_type_when_search_type_absent(self):
-        self.assertNotIn("query_type", self._recall_kwargs({"query": "q"}))
+        self.assertIsNone(self._recall_kwargs({"query": "q"})["query_type"])
 
 
 class TestTopKClamping(unittest.TestCase):
     def _top_k(self, args, configured=5):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(top_k=configured)
             provider.handle_tool_call("cognee_recall", {"query": "q", **args})
             return fake.only_call("recall")["top_k"]
@@ -324,32 +327,37 @@ class TestTopKClamping(unittest.TestCase):
 
 class TestRememberPayload(unittest.TestCase):
     def test_explicit_remember_targets_the_permanent_graph(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider(session_cognee_id="hermes_s9")
             provider.handle_tool_call("cognee_remember", {"content": "durable fact"})
-            kwargs = fake.only_call("remember")
-        self.assertEqual(kwargs["data"], "durable fact")
-        self.assertEqual(kwargs["dataset_name"], "hermes")
-        self.assertIs(kwargs["self_improvement"], True)
+            kwargs = fake.only_call("remember_permanent")
+        self.assertEqual(kwargs["text"], "durable fact")
+        self.assertEqual(kwargs["dataset"], "hermes")
+        # Linked to the current session so the graph write keeps its provenance.
         self.assertEqual(kwargs["session_ids"], ["hermes_s9"])
-        self.assertNotIn("session_id", kwargs)
+
+    def test_explicit_remember_does_not_use_the_session_cache(self):
+        with fake_backend() as fake:
+            provider = make_provider()
+            provider.handle_tool_call("cognee_remember", {"content": "durable fact"})
+            self.assertEqual(fake.kwargs_for("remember_session"), [])
 
     def test_dataset_argument_overrides_the_provider_dataset(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             provider.handle_tool_call("cognee_remember", {"content": "c", "dataset": "other"})
-            self.assertEqual(fake.only_call("remember")["dataset_name"], "other")
+            self.assertEqual(fake.only_call("remember_permanent")["dataset"], "other")
 
     def test_content_is_stripped(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             provider.handle_tool_call("cognee_remember", {"content": "  padded  "})
-            self.assertEqual(fake.only_call("remember")["data"], "padded")
+            self.assertEqual(fake.only_call("remember_permanent")["text"], "padded")
 
 
 class TestForgetPayload(unittest.TestCase):
     def test_dataset_scoped_delete(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             provider.handle_tool_call("cognee_forget", {"dataset": "hermes"})
             kwargs = fake.only_call("forget")
@@ -357,16 +365,16 @@ class TestForgetPayload(unittest.TestCase):
         self.assertIs(kwargs["everything"], False)
         self.assertIs(kwargs["memory_only"], False)
 
-    def test_everything_omits_the_dataset(self):
-        with fake_cognee() as fake:
+    def test_everything_is_forwarded(self):
+        # Whether a wipe-everything request also carries the dataset is a wire
+        # detail of each transport — see test_sdk_backend.
+        with fake_backend() as fake:
             provider = make_provider()
             provider.handle_tool_call("cognee_forget", {"dataset": "hermes", "everything": True})
-            kwargs = fake.only_call("forget")
-        self.assertIs(kwargs["everything"], True)
-        self.assertNotIn("dataset", kwargs)
+            self.assertIs(fake.only_call("forget")["everything"], True)
 
     def test_memory_only_is_forwarded(self):
-        with fake_cognee() as fake:
+        with fake_backend() as fake:
             provider = make_provider()
             provider.handle_tool_call("cognee_forget", {"dataset": "hermes", "memory_only": True})
             self.assertIs(fake.only_call("forget")["memory_only"], True)

--- a/integrations/hermes-agent/tests/test_tool_contract.py
+++ b/integrations/hermes-agent/tests/test_tool_contract.py
@@ -1,0 +1,376 @@
+"""Characterization: the model-visible tool contract and the request payloads.
+
+Hermes hands ``handle_tool_call``'s return string straight to the model, so the
+JSON envelope shapes here are a behavioural contract, not an implementation
+detail. The recorded cognee kwargs are the other half of the contract: they are
+what the HTTP request bodies must reproduce field for field.
+
+Every test in this module must keep passing, unchanged, after the transport
+swap. Run standalone with ``python3 tests/test_tool_contract.py``.
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from _char_helpers import (  # noqa: E402
+    RememberResultStub,
+    fake_cognee,
+    make_provider,
+)
+
+
+def _call(provider, tool, args):
+    return json.loads(provider.handle_tool_call(tool, args))
+
+
+class _ModelDumpItem:
+    """A pydantic-style result object (``model_dump`` returning a dict)."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def model_dump(self):
+        return self._payload
+
+
+# --------------------------------------------------------------------------
+# Envelopes
+# --------------------------------------------------------------------------
+
+
+class TestRecallEnvelope(unittest.TestCase):
+    def test_hit_returns_results_and_count(self):
+        with fake_cognee() as fake:
+            fake.results["recall"] = [{"text": "alpha"}, {"text": "beta"}]
+            provider = make_provider()
+            out = _call(provider, "cognee_recall", {"query": "q"})
+        self.assertEqual(out["count"], 2)
+        self.assertEqual([item["text"] for item in out["results"]], ["alpha", "beta"])
+
+    def test_miss_returns_result_message_and_zero_count(self):
+        with fake_cognee() as fake:
+            fake.results["recall"] = []
+            provider = make_provider()
+            out = _call(provider, "cognee_recall", {"query": "q"})
+        self.assertEqual(out, {"result": "No relevant Cognee memory found.", "count": 0})
+
+    def test_missing_query_is_an_error_and_calls_nothing(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            out = _call(provider, "cognee_recall", {})
+        self.assertEqual(out, {"error": "Missing required parameter: query"})
+        self.assertEqual(fake.kwargs_for("recall"), [])
+
+    def test_blank_query_is_an_error(self):
+        with fake_cognee():
+            provider = make_provider()
+            out = _call(provider, "cognee_recall", {"query": "   "})
+        self.assertEqual(out, {"error": "Missing required parameter: query"})
+
+    def test_backend_failure_is_reported_as_error_text(self):
+        with fake_cognee() as fake:
+            fake.errors["recall"] = RuntimeError("boom")
+            provider = make_provider()
+            out = _call(provider, "cognee_recall", {"query": "q"})
+        self.assertTrue(out["error"].startswith("Cognee recall failed:"))
+        self.assertIn("boom", out["error"])
+
+
+class TestRememberEnvelope(unittest.TestCase):
+    def test_success_envelope(self):
+        with fake_cognee() as fake:
+            fake.results["remember"] = RememberResultStub("running")
+            provider = make_provider()
+            out = _call(provider, "cognee_remember", {"content": "fact"})
+        self.assertEqual(out, {"result": "Content stored in Cognee.", "status": "running"})
+
+    def test_status_falls_back_to_completed_without_a_status_attribute(self):
+        # NOTE for the HTTP swap: the SDK returns a RememberResult *object*, so
+        # ``getattr(result, "status", ...)`` picks up the real status. An HTTP
+        # backend returns a *dict*, which has no ``.status`` attribute — so it
+        # would silently always report "completed". The HTTP backend must either
+        # return a status-bearing object or the handler must read dict keys too.
+        with fake_cognee() as fake:
+            fake.results["remember"] = {"status": "running"}
+            provider = make_provider()
+            out = _call(provider, "cognee_remember", {"content": "fact"})
+        self.assertEqual(out["status"], "completed")
+
+    def test_missing_content_is_an_error_and_calls_nothing(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            out = _call(provider, "cognee_remember", {})
+        self.assertEqual(out, {"error": "Missing required parameter: content"})
+        self.assertEqual(fake.kwargs_for("remember"), [])
+
+    def test_backend_failure_is_reported_as_error_text(self):
+        with fake_cognee() as fake:
+            fake.errors["remember"] = RuntimeError("nope")
+            provider = make_provider()
+            out = _call(provider, "cognee_remember", {"content": "fact"})
+        self.assertTrue(out["error"].startswith("Cognee remember failed:"))
+
+
+class TestForgetEnvelope(unittest.TestCase):
+    def test_requires_dataset_or_everything(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            out = _call(provider, "cognee_forget", {})
+        self.assertEqual(out, {"error": "Specify dataset or set everything=true."})
+        self.assertEqual(fake.kwargs_for("forget"), [])
+
+    def test_success_envelope_passes_backend_details_through(self):
+        with fake_cognee() as fake:
+            fake.results["forget"] = {"deleted": 3}
+            provider = make_provider()
+            out = _call(provider, "cognee_forget", {"dataset": "hermes"})
+        self.assertEqual(out, {"result": "Cognee memory deleted.", "details": {"deleted": 3}})
+
+    def test_backend_failure_is_reported_as_error_text(self):
+        with fake_cognee() as fake:
+            fake.errors["forget"] = RuntimeError("denied")
+            provider = make_provider()
+            out = _call(provider, "cognee_forget", {"everything": True})
+        self.assertTrue(out["error"].startswith("Cognee forget failed:"))
+
+
+class TestDispatch(unittest.TestCase):
+    def test_unknown_tool_names_the_tool(self):
+        with fake_cognee():
+            provider = make_provider()
+            out = _call(provider, "cognee_nope", {})
+        self.assertEqual(out, {"error": "Unknown Cognee tool: cognee_nope"})
+
+    def test_open_breaker_short_circuits_every_tool_without_calling_the_backend(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            provider._is_breaker_open = lambda: True
+            for tool, args in (
+                ("cognee_recall", {"query": "q"}),
+                ("cognee_remember", {"content": "c"}),
+                ("cognee_forget", {"everything": True}),
+            ):
+                out = _call(provider, tool, args)
+                self.assertIn("temporarily unavailable", out["error"])
+        self.assertEqual(fake.calls, [])
+
+    def test_tool_schemas_are_the_three_declared_tools_with_required_params(self):
+        provider = make_provider()
+        schemas = {schema["name"]: schema for schema in provider.get_tool_schemas()}
+        self.assertEqual(
+            set(schemas),
+            {"cognee_recall", "cognee_remember", "cognee_forget"},
+        )
+        self.assertEqual(schemas["cognee_recall"]["parameters"]["required"], ["query"])
+        self.assertEqual(schemas["cognee_remember"]["parameters"]["required"], ["content"])
+        self.assertEqual(schemas["cognee_forget"]["parameters"]["required"], [])
+        self.assertEqual(
+            set(schemas["cognee_recall"]["parameters"]["properties"]),
+            {"query", "scope", "search_type", "top_k"},
+        )
+
+
+# --------------------------------------------------------------------------
+# Result normalization — decides what text the model actually sees
+# --------------------------------------------------------------------------
+
+
+class TestResultNormalization(unittest.TestCase):
+    def _first(self, item):
+        with fake_cognee() as fake:
+            fake.results["recall"] = [item]
+            provider = make_provider()
+            out = _call(provider, "cognee_recall", {"query": "q"})
+        return out["results"][0]
+
+    def test_answer_wins_over_text_and_content(self):
+        item = self._first({"answer": "A", "text": "T", "content": "C", "summary": "S"})
+        self.assertEqual(item["text"], "A")
+
+    def test_text_wins_over_content(self):
+        self.assertEqual(self._first({"text": "T", "content": "C"})["text"], "T")
+
+    def test_content_wins_over_chunk_text(self):
+        self.assertEqual(self._first({"content": "C", "chunk_text": "K"})["text"], "C")
+
+    def test_chunk_text_wins_over_summary(self):
+        self.assertEqual(self._first({"chunk_text": "K", "summary": "S"})["text"], "K")
+
+    def test_summary_is_the_last_resort_key(self):
+        self.assertEqual(self._first({"summary": "S"})["text"], "S")
+
+    def test_model_dump_objects_are_coerced(self):
+        item = self._first(_ModelDumpItem({"answer": "from-model-dump"}))
+        self.assertEqual(item["text"], "from-model-dump")
+
+    def test_plain_string_results_become_text(self):
+        self.assertEqual(self._first("bare string")["text"], "bare string")
+
+    def test_source_defaults_to_cognee(self):
+        self.assertEqual(self._first({"text": "T"})["source"], "cognee")
+
+    def test_source_prefers_source_then_underscore_source(self):
+        self.assertEqual(self._first({"text": "T", "source": "graph"})["source"], "graph")
+        self.assertEqual(self._first({"text": "T", "_source": "session"})["source"], "session")
+
+    def test_optional_metadata_included_only_when_present(self):
+        rich = self._first(
+            {
+                "text": "T",
+                "score": 0.5,
+                "dataset": "d",
+                "dataset_name": "dn",
+                "node_name": "nn",
+            }
+        )
+        self.assertEqual(rich["score"], 0.5)
+        self.assertEqual(rich["dataset"], "d")
+        self.assertEqual(rich["dataset_name"], "dn")
+        self.assertEqual(rich["node_name"], "nn")
+
+        plain = self._first({"text": "T", "score": None})
+        self.assertEqual(set(plain), {"text", "source"})
+
+
+# --------------------------------------------------------------------------
+# Request payloads — what the HTTP bodies must reproduce
+# --------------------------------------------------------------------------
+
+
+class TestRecallPayload(unittest.TestCase):
+    def _recall_kwargs(self, args, **provider_kwargs):
+        with fake_cognee() as fake:
+            provider = make_provider(**provider_kwargs)
+            provider.handle_tool_call("cognee_recall", args)
+            return fake.only_call("recall")
+
+    def test_query_text_top_k_and_auto_route_always_sent(self):
+        kwargs = self._recall_kwargs({"query": "hello"}, top_k=7, auto_route=False)
+        self.assertEqual(kwargs["query_text"], "hello")
+        self.assertEqual(kwargs["top_k"], 7)
+        self.assertIs(kwargs["auto_route"], False)
+
+    def test_auto_scope_sends_both_session_and_datasets(self):
+        kwargs = self._recall_kwargs({"query": "q"}, session_cognee_id="hermes_abc")
+        self.assertEqual(kwargs["session_id"], "hermes_abc")
+        self.assertEqual(kwargs["datasets"], ["hermes"])
+
+    def test_missing_scope_defaults_to_auto(self):
+        kwargs = self._recall_kwargs({"query": "q", "scope": None})
+        self.assertIn("session_id", kwargs)
+        self.assertIn("datasets", kwargs)
+
+    def test_session_scope_sends_session_only(self):
+        kwargs = self._recall_kwargs({"query": "q", "scope": "session"})
+        self.assertIn("session_id", kwargs)
+        self.assertNotIn("datasets", kwargs)
+
+    def test_graph_scope_sends_datasets_only(self):
+        kwargs = self._recall_kwargs({"query": "q", "scope": "graph"})
+        self.assertEqual(kwargs["datasets"], ["hermes"])
+        self.assertNotIn("session_id", kwargs)
+
+    def test_scope_is_case_insensitive(self):
+        kwargs = self._recall_kwargs({"query": "q", "scope": "GRAPH"})
+        self.assertNotIn("session_id", kwargs)
+
+    def test_search_type_applied_outside_session_scope(self):
+        kwargs = self._recall_kwargs({"query": "q", "scope": "graph", "search_type": "CHUNKS"})
+        self.assertEqual(kwargs["query_type"], "CHUNKS")
+
+    def test_search_type_ignored_in_session_scope(self):
+        kwargs = self._recall_kwargs({"query": "q", "scope": "session", "search_type": "CHUNKS"})
+        self.assertNotIn("query_type", kwargs)
+
+    def test_unknown_search_type_falls_back_to_graph_completion(self):
+        kwargs = self._recall_kwargs({"query": "q", "search_type": "NOT_A_TYPE"})
+        self.assertEqual(kwargs["query_type"], "GRAPH_COMPLETION")
+
+    def test_no_query_type_when_search_type_absent(self):
+        self.assertNotIn("query_type", self._recall_kwargs({"query": "q"}))
+
+
+class TestTopKClamping(unittest.TestCase):
+    def _top_k(self, args, configured=5):
+        with fake_cognee() as fake:
+            provider = make_provider(top_k=configured)
+            provider.handle_tool_call("cognee_recall", {"query": "q", **args})
+            return fake.only_call("recall")["top_k"]
+
+    def test_absent_top_k_uses_provider_default(self):
+        self.assertEqual(self._top_k({}, configured=9), 9)
+
+    def test_zero_is_falsy_and_falls_back_to_provider_default(self):
+        self.assertEqual(self._top_k({"top_k": 0}, configured=9), 9)
+
+    def test_negative_clamps_to_one(self):
+        self.assertEqual(self._top_k({"top_k": -3}), 1)
+
+    def test_above_twenty_clamps_to_twenty(self):
+        self.assertEqual(self._top_k({"top_k": 50}), 20)
+
+    def test_in_range_passes_through(self):
+        self.assertEqual(self._top_k({"top_k": 12}), 12)
+
+    def test_numeric_string_is_accepted(self):
+        self.assertEqual(self._top_k({"top_k": "8"}), 8)
+
+
+class TestRememberPayload(unittest.TestCase):
+    def test_explicit_remember_targets_the_permanent_graph(self):
+        with fake_cognee() as fake:
+            provider = make_provider(session_cognee_id="hermes_s9")
+            provider.handle_tool_call("cognee_remember", {"content": "durable fact"})
+            kwargs = fake.only_call("remember")
+        self.assertEqual(kwargs["data"], "durable fact")
+        self.assertEqual(kwargs["dataset_name"], "hermes")
+        self.assertIs(kwargs["self_improvement"], True)
+        self.assertEqual(kwargs["session_ids"], ["hermes_s9"])
+        self.assertNotIn("session_id", kwargs)
+
+    def test_dataset_argument_overrides_the_provider_dataset(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            provider.handle_tool_call("cognee_remember", {"content": "c", "dataset": "other"})
+            self.assertEqual(fake.only_call("remember")["dataset_name"], "other")
+
+    def test_content_is_stripped(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            provider.handle_tool_call("cognee_remember", {"content": "  padded  "})
+            self.assertEqual(fake.only_call("remember")["data"], "padded")
+
+
+class TestForgetPayload(unittest.TestCase):
+    def test_dataset_scoped_delete(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            provider.handle_tool_call("cognee_forget", {"dataset": "hermes"})
+            kwargs = fake.only_call("forget")
+        self.assertEqual(kwargs["dataset"], "hermes")
+        self.assertIs(kwargs["everything"], False)
+        self.assertIs(kwargs["memory_only"], False)
+
+    def test_everything_omits_the_dataset(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            provider.handle_tool_call("cognee_forget", {"dataset": "hermes", "everything": True})
+            kwargs = fake.only_call("forget")
+        self.assertIs(kwargs["everything"], True)
+        self.assertNotIn("dataset", kwargs)
+
+    def test_memory_only_is_forwarded(self):
+        with fake_cognee() as fake:
+            provider = make_provider()
+            provider.handle_tool_call("cognee_forget", {"dataset": "hermes", "memory_only": True})
+            self.assertIs(fake.only_call("forget")["memory_only"], True)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/integrations/hermes-agent/uv.lock
+++ b/integrations/hermes-agent/uv.lock
@@ -696,7 +696,7 @@ wheels = [
 
 [[package]]
 name = "cognee"
-version = "1.2.1"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -746,14 +746,14 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/f1/7eca21f6bb468a86d0f57cefcae642382b614b3af3da8b7c83f90a3f1aa4/cognee-1.2.1.tar.gz", hash = "sha256:c527d3b58978759a73079fbb7e081620499f2bd8d80dc01dd4466971123b9a81", size = 19272567, upload-time = "2026-06-21T18:30:04.128Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/21/68e640d10ea9445b55b01715a8ae87a9d469e443614a87261c18c3e507e8/cognee-1.4.0.tar.gz", hash = "sha256:e783dd802ea25471b2c6feec317e8628fa99d67ed9223f22ca339add8fb7da1a", size = 23166925, upload-time = "2026-07-17T15:39:36.9Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/4a/ccdb4b5a6256559cf8bcdb13b483cade9a5c7432a2a65d01dd13c1ccb56d/cognee-1.2.1-py3-none-any.whl", hash = "sha256:4d3248d7551ae07b5248dd82ca2756e75e2c8891404e8823e524c0d00cf718d1", size = 2830094, upload-time = "2026-06-21T18:30:00.918Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f7/2388c4307fb1c5a20e02dad9188fad96f62f28d46f930e12fa402462732a/cognee-1.4.0-py3-none-any.whl", hash = "sha256:51ed9f1f8ca5b5caf215b00f10522e6291e6f3e82f19aaf2864e21ec8176ee0d", size = 3555996, upload-time = "2026-07-17T15:39:33.348Z" },
 ]
 
 [[package]]
 name = "cognee-integration-hermes-agent"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },
@@ -766,7 +766,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "cognee", specifier = ">=1.0.0,<2.0.0" }]
+requires-dist = [{ name = "cognee", specifier = ">=1.2.1,<=1.4.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -938,7 +938,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [

--- a/integrations/hermes-agent/uv.lock
+++ b/integrations/hermes-agent/uv.lock
@@ -753,7 +753,7 @@ wheels = [
 
 [[package]]
 name = "cognee-integration-hermes-agent"
-version = "0.2.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -66,11 +66,19 @@ integrations:
     language: python
     registry: pypi
     package_name: "cognee-integration-hermes-agent"
-    cognee_dependency: sdk
-    current_version: "0.1.0"
+    cognee_dependency: http-api
+    current_version: "0.2.0"
     migration_status: done
     source_repo: https://github.com/NousResearch/hermes-agent/pull/7418
-    notes: "Standalone Hermes memory provider plugin; replaces closed in-tree PR path"
+    notes: >-
+      Standalone Hermes memory provider plugin; replaces closed in-tree PR path.
+      Talks to a cognee server over the REST API (as claude-code/codex/openclaw do);
+      still needs the cognee package installed, both to spawn the local server and
+      for the opt-in in-process mode (COGNEE_EMBEDDED=true, COGNEE_TRANSPORT=sdk).
+      NOT published: Hermes discovers memory providers by directory scan only, so a
+      pip install cannot activate it — install under $HERMES_HOME/plugins/cognee.
+      Publishing needs either an upstream entry-point-discovery change or a switch
+      to git/directory distribution.
 
   - slug: dify
     name: "Cognee Tool Plugin for Dify"

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -75,10 +75,10 @@ integrations:
       Talks to a cognee server over the REST API (as claude-code/codex/openclaw do);
       still needs the cognee package installed, both to spawn the local server and
       for the opt-in in-process mode (COGNEE_EMBEDDED=true, COGNEE_TRANSPORT=sdk).
-      NOT published: Hermes discovers memory providers by directory scan only, so a
-      pip install cannot activate it — install under $HERMES_HOME/plugins/cognee.
-      Publishing needs either an upstream entry-point-discovery change or a switch
-      to git/directory distribution.
+      Hermes discovers memory providers by directory scan only, so the wheel ships
+      a cognee-hermes-install console script that copies the plugin into
+      $HERMES_HOME/plugins/cognee (re-run after pip install -U). Published to PyPI
+      from CI on hermes-agent-v* tags (hermes-agent-publish.yml).
 
   - slug: dify
     name: "Cognee Tool Plugin for Dify"

--- a/integrations/inventory.yml
+++ b/integrations/inventory.yml
@@ -67,7 +67,7 @@ integrations:
     registry: pypi
     package_name: "cognee-integration-hermes-agent"
     cognee_dependency: http-api
-    current_version: "0.2.0"
+    current_version: "1.0.0"
     migration_status: done
     source_repo: https://github.com/NousResearch/hermes-agent/pull/7418
     notes: >-


### PR DESCRIPTION
This PR brings the Hermes memory plugin in line with the Claude Code / Codex / OpenClaw
cognee plugins: same transport, same conventions, same local server — and fixes
the silent data-loss bugs found along the way.

### Transport: direct HTTP by default
- New `MemoryBackend` seam splits Hermes semantics (provider) from how bytes
  reach cognee. The default transport is now a stdlib-only REST client
  (`http_backend.py`), like the other plugins; `COGNEE_TRANSPORT=sdk` restores
  the SDK client, and `COGNEE_EMBEDDED=true` keeps the in-process mode.
- Why: the SDK's `CloudClient` silently drops `session_ids` on `improve()`, so
  the session-to-graph bridge had degraded into a dataset-wide improve.
- Session turns now actually reach the session cache, via typed QA entries on
  `/api/v1/remember/entry` — the multipart document path reported
  `session_stored` while the server discarded every turn (live-diagnosed).

### Shared brain (parity with the other plugins)
- Default dataset `agent_sessions` (`COGNEE_PLUGIN_DATASET`, with the 0.1.x
  `COGNEE_DATASET` as alias), storage in `~/.cognee/{data,system}`, local server
  on port 8011, one shared minted API key at `~/.cognee-plugin/api_key.json` in
  the other plugins' exact format. Memory written in any plugin is recallable
  in all of them; isolation recipes are documented in the README.
- The spawned server env mirrors the other bootstraps (`CACHING`,
  `AUTO_FEEDBACK`, `CACHE_ROOT_DIRECTORY`, `LLM_INSTRUCTOR_MODE`,
  `COGNEE_IMPROVE_SUBMIT_TIMEOUT`), so the server behaves identically no matter
  which plugin boots it.

### Lifecycle hardening
- **Boot**: deadline raised 30s → 600s (cold first boots run migrations), made
  safe by failing fast when the spawned server dies with nothing listening on
  the port — a broken install errors in seconds instead of hanging session
  start for 10 minutes.
- **Crash-safe close**: a detached exit watcher polls the Hermes PID and, on
  unclean death, runs `improve(session_ids)` and then unregisters — so no
  session is lost and no server lingers. Clean shutdown disarms it.
- **Dataset ensure**: idempotent `POST /api/v1/datasets` at startup, so a
  recall-first session on a fresh server or cloud tenant works.
- **Cloud**: a remote `COGNEE_BASE_URL` without `COGNEE_API_KEY` now fails at
  startup with a clear error instead of 401-ing on every call; default-user
  login credentials never leave the machine. An unreachable URL also fails at
  startup. No silent fallbacks between modes; a failed init keeps memory off.
- cognee bounded to `>=1.2.1,<=1.4.0` (wire-contract floor, live-verified cap;
  lockfile resolves 1.4.0).

### Tests
34 → 308 unit tests (wire-format per transport, config/lifecycle contracts,
exit-watcher including a live killed-parent run), plus opt-in live integration
tests (`COGNEE_RUN_INTEGRATION=1`) that boot a real server: connect/mint/
register, concurrency without `database is locked`, and an LLM-backed round
trip. Live tests now use isolated storage roots and reap their servers.

### Breaking / migration (0.1.x → 0.2.0)
Port 8000 → 8011, dataset `hermes` → `agent_sessions`, storage → `~/.cognee`.
Old memory is not deleted but needs `COGNEE_DATASET=hermes` (or a data
migration) to be found; stop any old plugin-started server on 8000. Details in
the CHANGELOG.
