### PR TITLE
fix: fix false unreachable status. add not-responding status

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "author": {
         "name": "Cognee"
       },

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": {
     "name": "Cognee"
   },

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,6 +10,37 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.3]
+
+### Fixed
+- **False `✕ (unreachable)` in the status line.** Probe and recall
+  timeouts were classified as "unreachable" and persisted into the shared
+  connection state, so a busy-but-healthy server randomly turned the bar red
+  and skipped recall — in both local and cloud mode. Timeouts are now a
+  no-verdict: transport failures are classified (connection refused / DNS →
+  `unreachable`; timeout → keep prior state), and `unreachable` is only ever
+  written on positive absence.
+  - The recall attempt itself is now the health probe: a successful scope call
+    marks ready, a refused connection marks `unreachable`, a 401/403 marks
+    `auth_failed` (detected from the real request, remaining scopes skipped),
+    and all-5xx marks `server_error`. The synthetic pre-recall probe survives
+    only as a re-entry check while the marker holds a failure state.
+  - The recall circuit breaker is keyed by `base_url` (cloud failures no
+    longer red a local bar, and vice versa), counts failures in a sliding
+    window instead of forever, re-arms half-open after cooldown, never counts
+    timeouts, and the status line renders its real trip reason.
+  - The renderer shows a red ✕ only for fresh, definitive failures (30 min
+    TTL); stale or ambiguous state renders no glyph.
+  - Breaker state writes use tmp + atomic replace so readers never see a torn
+    file.
+
+### Added
+- **`✕ (not_responding)` status** — distinct from `unreachable`: the server
+  accepts connections but hasn't answered for N consecutive timeout-only
+  prompts (default 3, `COGNEE_SLOW_STREAK_THRESHOLD`; streak window
+  `COGNEE_SLOW_STREAK_WINDOW`, 600s). A single slow response never triggers
+  it. Lifted back to `●` by the next successful probe or recall.
+
 ## [1.2.2]
 
 ### Fixed

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -222,11 +222,12 @@ A connection glyph precedes the line:
 ```
 ● cognee: agent_sessions · cloud          # connected (server up and authenticated)
 ✕ (incorrect_cognee_api_key) cognee: … · cloud   # server reachable, but COGNEE_API_KEY was rejected
-✕ (unreachable) cognee: … · cloud         # server down / not reachable
+✕ (unreachable) cognee: … · cloud         # server positively absent (connection refused / DNS)
 ✕ (server_error) cognee: … · cloud        # server returned a 5xx
+✕ (not_responding) cognee: … · cloud      # server up, but N consecutive recalls timed out
 ```
 
-`●` shows once the server is confirmed up **and** authenticated. On a failure the glyph flips to `✕ (<reason>)` — `incorrect_cognee_api_key` (a missing, wrong, or expired `COGNEE_API_KEY`), `unreachable` (server down, including a server that dies mid-session), or `server_error` (5xx). The state is recorded by the hooks that already talk to the server (SessionStart, and the per-prompt recall), so the line stays green until a failure is actually observed, and clears back to `●` on the next success. The glyph is read from local state only — no network on refresh. It is **colour-coded**: a bold green `●` when the connection is confirmed good, and a bold red `✕ (<reason>)` — reason included, so the whole verdict reads as one unit — when it is confirmed bad. The LLM-key failure is red as well — the two are told apart by the reason itself (`incorrect_cognee_api_key` for the key this plugin uses to reach the server, `incorrect_llm_api_key` for the key the local server uses to reach the LLM) rather than by colour.
+`●` shows once the server is confirmed up **and** authenticated. On a failure the glyph flips to `✕ (<reason>)` — `incorrect_cognee_api_key` (a missing, wrong, or expired `COGNEE_API_KEY`), `unreachable` (server positively absent: connection refused or DNS failure, including a server that dies mid-session), `server_error` (5xx), or `not_responding` (the server accepts connections but hasn't answered for several consecutive prompts — a single slow response never triggers it, so a busy server is not misreported as unreachable). The state is recorded by the hooks that already talk to the server (SessionStart, and the per-prompt recall), so the line stays green until a failure is actually observed, and clears back to `●` on the next success. The glyph is read from local state only — no network on refresh. It is **colour-coded**: a bold green `●` when the connection is confirmed good, and a bold red `✕ (<reason>)` — reason included, so the whole verdict reads as one unit — when it is confirmed bad. The LLM-key failure is red as well — the two are told apart by the reason itself (`incorrect_cognee_api_key` for the key this plugin uses to reach the server, `incorrect_llm_api_key` for the key the local server uses to reach the LLM) rather than by colour.
 
 | Env var | Default | Effect |
 |---|---|---|

--- a/integrations/claude-code/scripts/_cognee_client.py
+++ b/integrations/claude-code/scripts/_cognee_client.py
@@ -63,7 +63,13 @@ def _write(servers):
     try:
         path = _state_path()
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps({"servers": servers}), encoding="utf-8")
+        # pid-suffixed tmp + atomic replace, matching the other marker writers:
+        # readers (other hooks, the status-line renderer) can never see a torn
+        # file. Concurrent writers remain last-write-wins — accepted for this
+        # advisory state; serializing them would need file locking.
+        tmp = path.with_name(".breaker-%d.json.tmp" % os.getpid())
+        tmp.write_text(json.dumps({"servers": servers}), encoding="utf-8")
+        os.replace(tmp, path)
     except Exception:
         pass
 

--- a/integrations/claude-code/scripts/_cognee_client.py
+++ b/integrations/claude-code/scripts/_cognee_client.py
@@ -30,6 +30,10 @@ load_env_file()
 # Tunables (mirror Hermes's provider defaults).
 _THRESHOLD = int(os.environ.get("COGNEE_BREAKER_THRESHOLD", "5"))
 _COOLDOWN = float(os.environ.get("COGNEE_BREAKER_COOLDOWN", "120"))
+# Sliding window: only failures within this many seconds of each other count
+# toward the threshold. Without it, five isolated blips spread over days would
+# open the breaker "out of nowhere" long after the last real problem.
+_WINDOW = float(os.environ.get("COGNEE_BREAKER_WINDOW", "300"))
 _RECALL_TIMEOUT = float(os.environ.get("COGNEE_RECALL_TIMEOUT", "120"))
 
 
@@ -38,55 +42,129 @@ def _state_path():
     return pathlib.Path(base) / "recall-breaker.json"
 
 
+def _norm_url(service_url):
+    return str(service_url or "").strip().rstrip("/")
+
+
 def _read():
+    """The per-server breaker map {url: entry}. A legacy flat file (top-level
+    ``failures``/``cooldown_until``, not keyed by server) is discarded rather
+    than migrated: it conflated every server on the machine, which is one of
+    the bugs this schema exists to fix."""
     try:
         data = json.loads(_state_path().read_text(encoding="utf-8"))
-        return data if isinstance(data, dict) else {}
     except Exception:
         return {}
+    servers = data.get("servers") if isinstance(data, dict) else None
+    return servers if isinstance(servers, dict) else {}
 
 
-def _write(state):
+def _write(servers):
     try:
         path = _state_path()
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(state), encoding="utf-8")
+        path.write_text(json.dumps({"servers": servers}), encoding="utf-8")
     except Exception:
         pass
 
 
-def breaker_open(now=None):
-    """Return (is_open, retry_in_seconds). Open while we're inside the cooldown window."""
+def _entry(servers, url):
+    entry = servers.get(url)
+    return entry if isinstance(entry, dict) else {}
+
+
+def _recent_failures(entry, now):
+    """This server's failure timestamps still inside the sliding window."""
+    stamps = entry.get("failures")
+    if not isinstance(stamps, list):
+        return []
+    out = []
+    for value in stamps:
+        try:
+            ts = float(value)
+        except (TypeError, ValueError):
+            continue
+        if now - ts <= _WINDOW:
+            out.append(ts)
+    return out
+
+
+def breaker_open(service_url="", now=None):
+    """Return (is_open, retry_in_seconds) for this server.
+
+    Open while inside the cooldown window. With no ``service_url`` (doctor /
+    legacy callers), reports the worst open entry across all servers.
+    """
     now = time.time() if now is None else now
-    until = float(_read().get("cooldown_until") or 0.0)
-    return (True, int(until - now)) if now < until else (False, 0)
+    servers = _read()
+    urls = [_norm_url(service_url)] if _norm_url(service_url) else list(servers)
+    worst = 0.0
+    for url in urls:
+        try:
+            until = float(_entry(servers, url).get("cooldown_until") or 0.0)
+        except (TypeError, ValueError):
+            until = 0.0
+        worst = max(worst, until)
+    return (True, int(worst - now)) if now < worst else (False, 0)
 
 
-def record_failure(error="", now=None):
-    """Count a backend failure; open the breaker once we hit the threshold."""
+def breaker_reason(service_url=""):
+    """The reason the breaker last tripped for this server ("" if never)."""
+    servers = _read()
+    url = _norm_url(service_url)
+    if not url and servers:
+        url = next(iter(servers))
+    return str(_entry(servers, url).get("reason") or "")
+
+
+def record_failure(error="", now=None, service_url="", reason="unreachable"):
+    """Count a hard backend failure; open the breaker at the windowed threshold.
+
+    Only definitive trouble belongs here — UNREACHABLE (positively absent) or
+    5xx. Timeouts are no-verdict and must NOT be recorded (see the transient
+    envelope handling in ``recall``). When the breaker trips, the counted
+    failures are consumed: after the cooldown the breaker is half-open, and a
+    single new failure starts a fresh count instead of instantly re-opening.
+    """
     now = time.time() if now is None else now
-    state = _read()
-    failures = int(state.get("failures") or 0) + 1
-    state["failures"] = failures
-    state["last_error"] = str(error)[:200]
-    if failures >= _THRESHOLD:
-        state["cooldown_until"] = now + _COOLDOWN
-    _write(state)
+    url = _norm_url(service_url)
+    servers = _read()
+    entry = _entry(servers, url)
+    failures = _recent_failures(entry, now)
+    failures.append(now)
+    if len(failures) >= _THRESHOLD:
+        entry = {
+            "failures": [],
+            "cooldown_until": now + _COOLDOWN,
+            "reason": str(reason or "unreachable"),
+            "last_error": str(error)[:200],
+        }
+    else:
+        entry = dict(entry)
+        entry["failures"] = failures
+        entry["last_error"] = str(error)[:200]
+    servers[url] = entry
+    _write(servers)
 
 
-def record_success():
-    """Backend answered — clear the breaker."""
-    _write({"failures": 0, "cooldown_until": 0.0})
+def record_success(service_url=""):
+    """Backend answered — clear this server's breaker entry."""
+    servers = _read()
+    servers.pop(_norm_url(service_url), None)
+    _write(servers)
 
 
 def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *, timeout=None):
     """Breaker-wrapped recall. Returns a list, an error-envelope dict, or UNREACHABLE.
 
-    Only genuine backend trouble trips the breaker: UNREACHABLE (connection
-    failure) or a 5xx. A reachable 4xx (e.g. 401/403 auth) is a config problem —
-    surfaced, but it does NOT open the breaker (waiting wouldn't fix it).
+    Only genuine backend trouble trips the breaker: UNREACHABLE (positively
+    absent — refused/DNS) or a 5xx. A reachable 4xx (e.g. 401/403 auth) is a
+    config problem — surfaced, but it does NOT open the breaker (waiting
+    wouldn't fix it). A transient envelope (timeout / unclassifiable transport
+    error) is no verdict at all: it neither counts as a failure nor clears the
+    window — a busy server must not be branded unreachable by its own latency.
     """
-    is_open, retry = breaker_open()
+    is_open, retry = breaker_open(service_url)
     if is_open:
         # We're in cooldown: surface a clear message and do NOT call (and, since
         # this isn't UNREACHABLE, the wrapper won't fall back to the CLI either —
@@ -104,11 +182,15 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
         timeout=timeout or _RECALL_TIMEOUT,
     )
     if result == UNREACHABLE:
-        record_failure("unreachable")
+        record_failure("unreachable", service_url=service_url, reason="unreachable")
     elif isinstance(result, dict) and int(result.get("status") or 0) >= 500:
-        record_failure("http %s" % result.get("status"))
+        record_failure(
+            "http %s" % result.get("status"), service_url=service_url, reason="server_error"
+        )
+    elif isinstance(result, dict) and result.get("transient"):
+        pass  # no verdict: leave the breaker exactly as it was
     else:
-        record_success()
+        record_success(service_url)
     return result
 
 

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -24,6 +24,7 @@ from typing import Optional
 
 import _proc
 from _env_file import load_env_file
+from _recall_http import DOWN, SLOW, UNKNOWN, classify_transport_exception
 
 # One-time config: ~/.cognee/.env acts like shell exports (setdefault — a real
 # export still wins). Loaded before any env read below or in importers.
@@ -1340,30 +1341,51 @@ def http_api_ready() -> bool:
     return bool(service_url and api_key)
 
 
-def server_health_ok(service_url: str = "", timeout: float = 1.0) -> bool:
-    """Return True iff GET {service_url}/health responds 200 (server serving).
+def probe_health(service_url: str = "", timeout: float = 1.0) -> str:
+    """Classified GET {service_url}/health probe.
 
-    The Cognee server runs migrations in its FastAPI lifespan *before* it
-    serves, so a 200 here reliably means migrations are done and the DBs are
-    reachable.
+    Returns:
+      "ready"   — 200 (the server runs migrations in its FastAPI lifespan
+                  *before* it serves, so this reliably means migrations are
+                  done and the DBs are reachable)
+      "down"    — connection refused / DNS / unroutable: positively absent
+      "slow"    — timed out: NO verdict (a busy server times out; a dead one
+                  refuses in milliseconds). Callers must keep prior state.
+      "unknown" — non-200 status, SSL trouble, resets, or no URL: no verdict
     """
     base = _normalize_service_url(service_url or _local_api_url())
     if not base:
-        return False
+        return UNKNOWN
     try:
         with urllib.request.urlopen(
             f"{base}/health", timeout=timeout, context=_https_context()
         ) as resp:
-            return resp.status == 200
-    except (urllib.error.URLError, TimeoutError, OSError):
-        return False
+            return "ready" if resp.status == 200 else UNKNOWN
+    except Exception as exc:
+        verdict = classify_transport_exception(exc)
+        return verdict if verdict in (DOWN, SLOW) else UNKNOWN
+
+
+def server_health_ok(service_url: str = "", timeout: float = 1.0) -> bool:
+    """Return True iff /health responds 200. Boolean face of ``probe_health``.
+
+    Callers that must react to *failures* should use ``probe_health`` instead:
+    this bool cannot distinguish "down" (write a failure state) from "slow"
+    (no verdict — keep prior state).
+    """
+    return probe_health(service_url, timeout=timeout) == "ready"
 
 
 # Connection states recorded in the (shared) server-ready marker. "ready" means
 # the server is up AND authenticated; the failure states carry the reason shown
 # in the status line as "✕ (<state>)". Any non-"ready" state makes
 # server_ready_hint return False so recall does not attempt against a bad backend.
-CONNECTION_STATES = ("ready", "auth_failed", "unreachable", "server_error")
+# "unreachable" is reserved for POSITIVE absence (connection refused / DNS /
+# unroutable). "not_responding" is deliberately distinct: the server exists
+# (connections are not refused) but has not answered within budget for N
+# consecutive prompts — written only by the slow-streak escalation (see
+# record_slow_probe), never by a lone timeout.
+CONNECTION_STATES = ("ready", "auth_failed", "unreachable", "server_error", "not_responding")
 
 
 # Per-session copies of the status markers. The shared files above are
@@ -1451,6 +1473,83 @@ def mark_server_ready(service_url: str, version: str = "") -> None:
     write_connection_state("ready", service_url, version=version)
 
 
+# Slow-server hysteresis. A single timeout is "no verdict" and must not touch
+# the connection marker — but N consecutive timeout-only prompts with no
+# success in between are a pattern (wedged server, packet-dropping network),
+# not a blip. This counter, keyed by base_url, is how a lone blip stays
+# invisible while a persistent stall still escalates to a visible "slow" state
+# (and recall backoff) instead of leaving the bar green forever.
+_SLOW_STREAK_FILE = _PLUGIN_DIR / "slow-streak.json"
+
+
+def slow_streak_threshold() -> int:
+    """Consecutive timeout-only prompts before escalating to state "slow"."""
+    try:
+        return max(1, int(os.environ.get("COGNEE_SLOW_STREAK_THRESHOLD", "3") or 3))
+    except (TypeError, ValueError):
+        return 3
+
+
+def _slow_streak_window_seconds() -> float:
+    """Ticks further apart than this don't chain — a streak must be recent."""
+    try:
+        return float(os.environ.get("COGNEE_SLOW_STREAK_WINDOW", "600") or 600)
+    except (TypeError, ValueError):
+        return 600.0
+
+
+def _read_slow_streaks() -> dict:
+    try:
+        raw = json.loads(_SLOW_STREAK_FILE.read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except Exception:
+        return {}
+
+
+def _write_slow_streaks(state: dict) -> None:
+    try:
+        _SLOW_STREAK_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _SLOW_STREAK_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(state), encoding="utf-8")
+        os.replace(tmp, _SLOW_STREAK_FILE)
+    except Exception:
+        pass
+
+
+def record_slow_probe(service_url: str) -> int:
+    """Count a consecutive no-verdict (timeout) observation; return the streak.
+
+    The streak resets itself when the previous tick is older than the window —
+    two timeouts hours apart are noise, not a pattern. The caller escalates to
+    ``write_connection_state("not_responding", ...)`` once the return value
+    reaches ``slow_streak_threshold()``.
+    """
+    url = _normalize_service_url(service_url)
+    now = datetime.now(timezone.utc).timestamp()
+    state = _read_slow_streaks()
+    entry = state.get(url) if isinstance(state.get(url), dict) else {}
+    try:
+        last_at = float(entry.get("last_at") or 0)
+        count = int(entry.get("count") or 0)
+    except (TypeError, ValueError):
+        last_at, count = 0.0, 0
+    if now - last_at > _slow_streak_window_seconds():
+        count = 0
+    count += 1
+    state[url] = {"count": count, "last_at": now}
+    _write_slow_streaks(state)
+    return count
+
+
+def clear_slow_streak(service_url: str) -> None:
+    """A definitive observation (success OR hard failure) ends the streak."""
+    url = _normalize_service_url(service_url)
+    state = _read_slow_streaks()
+    if url in state:
+        state.pop(url, None)
+        _write_slow_streaks(state)
+
+
 def same_connection_target(service_url: str, prior_url: str) -> bool:
     """True unless the two URLs are *provably* different servers.
 
@@ -1501,10 +1600,14 @@ def authed_liveness(service_url: str = "", api_key: str = "", timeout: float = 1
       "ready"        — 2xx (server up and the key is accepted)
       "auth_failed"  — 401/403 (server up, key rejected)
       "server_error" — 5xx
-      "unreachable"  — connection refused / timeout / DNS
-      "unknown"      — endpoint absent (404/405) or no key to send; caller should
-                       fall back to ``server_health_ok`` rather than trust this
-    Returns a string in ``CONNECTION_STATES`` or "unknown". Never raises.
+      "unreachable"  — connection refused / DNS / unroutable (positively absent)
+      "slow"         — timed out: NO verdict, the server may simply be busy.
+                       Callers must keep their prior state, not record a failure.
+      "unknown"      — endpoint absent (404/405), no key to send, or an
+                       unclassifiable transport error; caller should fall back
+                       to ``probe_health`` rather than trust this
+    Returns a string in ``CONNECTION_STATES``, "slow", or "unknown" — "slow"
+    is a probe verdict only, never a recorded marker state. Never raises.
     """
     base = _normalize_service_url(service_url or _local_api_url())
     if not base:
@@ -1530,8 +1633,11 @@ def authed_liveness(service_url: str = "", api_key: str = "", timeout: float = 1
         if exc.code >= 500:
             return "server_error"
         return "unknown"
-    except (urllib.error.URLError, TimeoutError, OSError):
-        return "unreachable"
+    except Exception as exc:
+        verdict = classify_transport_exception(exc)
+        if verdict == DOWN:
+            return "unreachable"
+        return "slow" if verdict == SLOW else "unknown"
 
 
 # LLM-key health surfaced in the status line — LOCAL mode only, since LLM_API_KEY

--- a/integrations/claude-code/scripts/_recall_http.py
+++ b/integrations/claude-code/scripts/_recall_http.py
@@ -7,9 +7,13 @@ plugin venv (the same constraint ``cognee-search.sh`` already works under).
 Contract — what gets printed to stdout:
   * a JSON **list** on a 2xx response. An **empty list is authoritative**:
     the server searched and found nothing.
-  * the sentinel ``UNREACHABLE`` ONLY when the server cannot be reached
-    (connection refused, timeout, DNS). The caller may then fall back to the
-    local CLI as a degraded path.
+  * the sentinel ``UNREACHABLE`` ONLY when the server is positively absent
+    (connection refused, DNS failure, unroutable host). The caller may then
+    fall back to the local CLI as a degraded path. A **timeout is NOT
+    unreachable**: a dead server refuses in milliseconds, a busy one times
+    out — so timeouts return a *transient* error envelope instead (see below),
+    and the caller keeps its prior view of the server rather than declaring
+    it down.
   * a JSON **error object** ``{"error", "status", "authoritative": false}`` on
     any HTTP error (5xx, 4xx, and especially **401/403** auth rejections) or an
     error-shaped 2xx body. The caller MUST NOT fall back to the local CLI here:
@@ -21,8 +25,10 @@ Contract — what gets printed to stdout:
 Diagnostics also go to stderr so the caller can surface them.
 """
 
+import errno
 import json
 import os
+import socket
 import ssl
 import sys
 import urllib.error
@@ -30,6 +36,46 @@ import urllib.parse
 import urllib.request
 
 UNREACHABLE = "UNREACHABLE"
+
+# Transport-exception verdicts (classify_transport_exception). Only DOWN is
+# evidence the server is absent; SLOW means it exists but did not answer in
+# time, and UNKNOWN is anything we cannot classify. The distinction matters:
+# a dead local server refuses connections in milliseconds, while a busy one
+# times out — conflating the two is what painted false "unreachable" states.
+DOWN = "down"
+SLOW = "slow"
+UNKNOWN = "unknown"
+
+# Errnos that positively identify an absent/unroutable server.
+_DOWN_ERRNOS = {errno.ECONNREFUSED, errno.EHOSTUNREACH, errno.ENETUNREACH}
+
+
+def classify_transport_exception(exc) -> str:
+    """Classify a transport failure as DOWN, SLOW, or UNKNOWN.
+
+    Unwraps ``urllib.error.URLError`` (the real cause lives in ``.reason``, and
+    can be an exception *or* a plain string). Order matters below:
+    ``TimeoutError`` and ``ConnectionRefusedError`` are OSError subclasses, and
+    ``ssl.SSLError`` is too, so the generic errno check must come last.
+    """
+    if isinstance(exc, urllib.error.HTTPError):
+        # The server answered; HTTP statuses are the caller's business.
+        return UNKNOWN
+    if isinstance(exc, urllib.error.URLError):
+        exc = exc.reason
+    if isinstance(exc, str):
+        return SLOW if "timed out" in exc else UNKNOWN
+    if isinstance(exc, (TimeoutError, socket.timeout)):
+        return SLOW
+    if isinstance(exc, socket.gaierror):
+        return DOWN
+    if isinstance(exc, ConnectionRefusedError):
+        return DOWN
+    if isinstance(exc, ssl.SSLError):
+        return UNKNOWN
+    if isinstance(exc, OSError) and getattr(exc, "errno", None) in _DOWN_ERRNOS:
+        return DOWN
+    return UNKNOWN
 
 
 # macOS Python installations often lack root CA certs in the default bundle.
@@ -88,12 +134,18 @@ def coerce_scope(value, default="auto"):
         return default
 
 
-def _error(status, message):
-    """An error envelope — reachable server, but the request was rejected/failed.
+def _error(status, message, *, transient=False):
+    """An error envelope — the request failed, but the server is NOT known dead.
 
     Distinct from UNREACHABLE so the caller does NOT fall back to the local CLI.
+    ``transient=True`` marks a no-verdict failure (timeout / unclassifiable
+    transport error): the breaker must count it as neither success nor failure,
+    and no connection state should be rewritten because of it.
     """
-    return {"error": message, "status": status, "authoritative": False}
+    envelope = {"error": message, "status": status, "authoritative": False}
+    if transient:
+        envelope["transient"] = True
+    return envelope
 
 
 def do_recall(
@@ -154,11 +206,21 @@ def do_recall(
             msg = "server returned HTTP %s for /api/v1/recall" % e.code
         sys.stderr.write("[cognee-search] %s — NOT falling back to local CLI\n" % msg)
         return _error(e.code, msg)
-    except Exception as e:  # URLError / timeout / OSError → genuinely unreachable
+    except Exception as e:
+        verdict = classify_transport_exception(e)
+        if verdict == DOWN:  # refused / DNS / unroutable → positively absent
+            sys.stderr.write(
+                "[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+            )
+            return UNREACHABLE
+        # SLOW (timed out — alive but busy) or UNKNOWN (SSL / reset / a bug in
+        # our own request building): no verdict on the server. Not UNREACHABLE
+        # (no CLI fallback, no "down" marker) and flagged transient so the
+        # breaker counts it as neither success nor failure.
         sys.stderr.write(
-            "[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+            "[cognee-search] no verdict (%s) from %s: %s\n" % (verdict, service_url, str(e)[:160])
         )
-        return UNREACHABLE
+        return _error(0, "recall %s: %s" % (verdict, str(e)[:160]), transient=True)
 
     # The server responded. A body we can't parse is a SERVER-side bug, not an
     # unreachable server — report it as an error (do NOT trigger the CLI fallback).

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -115,14 +115,22 @@ def _mode_label() -> str:
     return f"{style}{mode}\033[0m" if style else mode
 
 
-_FAIL_STATES = ("auth_failed", "unreachable", "server_error")
+_FAIL_STATES = ("auth_failed", "unreachable", "server_error", "not_responding")
 # Of those, the ones that are a property of the SERVER rather than of the credential
 # the observing session happened to use. Only these may cross session boundaries: if
 # one terminal can't reach the server, neither can the others — but one terminal's
 # rejected API key says nothing about anyone else's. Letting auth_failed cross put a
 # red ✕ (incorrect_cognee_api_key) on a healthy local terminal for a few seconds
 # whenever a keyless cloud terminal started up.
-_SERVER_WIDE_FAIL_STATES = ("unreachable", "server_error")
+# "not_responding" (N consecutive recall timeouts) is server-wide too: a server
+# that isn't answering one terminal isn't answering the others either.
+_SERVER_WIDE_FAIL_STATES = ("unreachable", "server_error", "not_responding")
+
+# A failure verdict is only worth a red ✕ while it is FRESH. The hooks refresh a
+# genuine outage on every prompt (probe or recall attempt), so a failure marker
+# older than this means no session has re-confirmed it — ambiguous, and ambiguity
+# renders no glyph (same as the warming case) rather than a stale accusation.
+_FAIL_STATE_STALE_SECONDS = 30 * 60
 
 
 def _active_base_url() -> str:
@@ -241,14 +249,43 @@ def _url_mismatch(active_url: str, marked_url: str) -> bool:
     return bool(active_url and marked_url and active_url != marked_url)
 
 
+def _breaker_glyph(active_url: str) -> str:
+    """Red ✕ when THIS server's breaker is open, labeled with the real trip reason.
+
+    The breaker file is keyed by base_url (SDK-356): an entry for a different
+    server — a cloud tenant while this terminal is local, or Codex's target —
+    must not red this bar. A legacy flat file (machine-wide, target-blind) is
+    ignored for the same reason. The reason travels from the trip site, so a
+    breaker opened by 5xx reads ``server_error``, not a false ``unreachable``.
+    """
+    try:
+        raw = json.loads(_BREAKER_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    servers = raw.get("servers") if isinstance(raw, dict) else None
+    if not isinstance(servers, dict):
+        return ""
+    entry = servers.get(active_url.rstrip("/"))
+    if not isinstance(entry, dict):
+        return ""
+    try:
+        if float(entry.get("cooldown_until", 0) or 0) <= time.time():
+            return ""
+    except (TypeError, ValueError):
+        return ""
+    reason = str(entry.get("reason") or "unreachable")
+    return _fail_glyph(_REASON_LABELS.get(reason, reason))
+
+
 def _health_prefix(session_id: str = "") -> str:
     """Server-connection glyph for THIS session, from local markers (no network).
 
-    Precedence — we keep it green until we actually know it is red:
-      1. a recorded failure state in the marker → ``✕ (<reason>)``
-      2. an open recall breaker (repeated recall failure) → ``✕ (unreachable)``
+    Precedence — red is reserved for CONFIRMED, FRESH, DEFINITIVE failures:
+      1. a fresh recorded failure state in the marker → ``✕ (<reason>)``
+         (older than _FAIL_STATE_STALE_SECONDS → ambiguous → no glyph)
+      2. an open recall breaker for THIS base_url → ``✕ (<trip reason>)``
       3. a "ready" marker → ``● ``
-      4. otherwise (no marker / warming / different target) → no glyph
+      4. otherwise (no marker / warming / stale / different target) → no glyph
     The marker (``server-ready.json``) carries {state, base_url, ...}; a state is
     trusted only when its base_url matches this session's, so a local-ready marker
     never greens a cloud session (or vice versa).
@@ -263,26 +300,18 @@ def _health_prefix(session_id: str = "") -> str:
         # Legacy marker (no 'state', has ready_at) reads as ready.
         state = str(marker.get("state") or ("ready" if marker.get("ready_at") else ""))
         if state in _FAIL_STATES:
-            return _fail_glyph(_REASON_LABELS.get(state, state))
+            if time.time() - _checked_at(marker) <= _FAIL_STATE_STALE_SECONDS:
+                return _fail_glyph(_REASON_LABELS.get(state, state))
+            # Stale verdict: nobody has re-confirmed the failure — treat as
+            # unknown rather than keep accusing a server that may be fine.
+            return _breaker_glyph(active_url)
         if state == "ready":
             # Breaker override: recall is failing repeatedly even if the last
             # readiness write still says ready — that means we now know it's red.
-            try:
-                raw = json.loads(_BREAKER_PATH.read_text(encoding="utf-8"))
-                if isinstance(raw, dict) and float(raw.get("cooldown_until", 0) or 0) > time.time():
-                    return _fail_glyph("unreachable")
-            except Exception:
-                pass
-            return _ok_glyph()
+            return _breaker_glyph(active_url) or _ok_glyph()
 
     # No usable marker: fall back to the breaker as the only failure signal.
-    try:
-        raw = json.loads(_BREAKER_PATH.read_text(encoding="utf-8"))
-        if isinstance(raw, dict) and float(raw.get("cooldown_until", 0) or 0) > time.time():
-            return _fail_glyph("unreachable")
-    except Exception:
-        pass
-    return ""
+    return _breaker_glyph(active_url)
 
 
 def _update_segment() -> str:

--- a/integrations/claude-code/scripts/session-context-lookup.py
+++ b/integrations/claude-code/scripts/session-context-lookup.py
@@ -22,26 +22,30 @@ sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
     authed_liveness,
     bounded_dim_mismatch_hint,
+    clear_slow_streak,
     elapsed_ms,
     get_session_key,
     hook_log,
     load_resolved,
     mark_server_ready,
     notify,
+    probe_health,
     quiet_hook_output,
     read_and_reset_save_counter,
     read_connection_state,
     recall_via_http,
+    record_slow_probe,
     resolve_runtime_mode,
     resolve_session_key_from_payload,
     resolve_user,
     same_connection_target,
-    server_health_ok,
     server_ready_hint,
     service_url_is_local,
     set_session_key,
+    slow_streak_threshold,
     write_connection_state,
 )
+from _recall_http import DOWN, SLOW, classify_transport_exception
 from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
 
 
@@ -181,42 +185,49 @@ async def _run(prompt: str) -> dict | None:
             "api_key_present": runtime.get("api_key_present", False),
         },
     )
-    # Readiness gate: never block the user's prompt on a warming/migrating
-    # backend. Trust a fresh readiness marker (zero-network); on a miss, do one
-    # short /health probe and record the result. If still not ready, skip recall
-    # entirely so the prompt is answered at full speed (memory turns on later).
+    # Readiness gate, redesigned (SDK-356): the recall attempt itself is the
+    # probe. A fresh "ready" marker or a merely-stale/unknown state goes
+    # STRAIGHT to recall — a successful scope call is an authenticated,
+    # real-workload confirmation that beats any synthetic /health check, and
+    # the recall budget already bounds the worst case. Probing survives only
+    # as a cheap re-entry gate while the marker holds a KNOWN failure state,
+    # so a confirmed-bad backend costs one bounded probe per prompt instead of
+    # the full budget.
     service_url = runtime.get("base_url", "")
     probe_timeout = _float_env("COGNEE_READY_PROBE_TIMEOUT", 1.0)
-    if not server_ready_hint(service_url):
+    prior = read_connection_state()
+    # Permissive on purpose: "same target" unless the two URLs provably differ,
+    # so a recorded state still applies when a URL is unknown. Mirrors the
+    # renderer's _url_mismatch (equivalence pinned by
+    # tests/test_connection_target_match.py).
+    prior_same_target = same_connection_target(service_url, str(prior.get("base_url") or ""))
+    prior_state = str(prior.get("state") or ("ready" if prior.get("ready_at") else ""))
+    known_bad = prior_same_target and prior_state in (
+        "auth_failed",
+        "unreachable",
+        "server_error",
+        "not_responding",
+    )
+    if known_bad:
         # Prefer an AUTHENTICATED probe so a bad/expired key is classified as
         # auth_failed instead of being masked as "ready" by an unauthenticated
         # /health 200. Fall back to /health only when the authed probe can't
         # classify (no key, or the endpoint is absent on an older server).
         state = authed_liveness(service_url, timeout=probe_timeout)
         if state == "unknown":
-            state = (
-                "ready" if server_health_ok(service_url, timeout=probe_timeout) else "unreachable"
-            )
-
+            health = probe_health(service_url, timeout=probe_timeout)
+            state = {"ready": "ready", "down": "unreachable"}.get(health, health)
         if state == "ready":
             mark_server_ready(service_url)
+            clear_slow_streak(service_url)
+            # fall through to recall below
         else:
-            # A recorded failure (auth_failed / unreachable / server_error) makes
-            # the status line show ✕ (<reason>) and recall skip this turn. Suppress
-            # the write only during a genuine cold-start warm-up: an "unreachable"
-            # with no prior ready marker for this URL is likely the server still
-            # migrating, so stay silent rather than flash a false red.
-            prior = read_connection_state()
-            # Permissive on purpose: "same target" unless the two URLs provably differ,
-            # so a server that really did die is still reported when a URL is unknown.
-            # Mirrors the renderer's _url_mismatch (equivalence pinned by
-            # tests/test_connection_target_match.py).
-            same_target = same_connection_target(service_url, str(prior.get("base_url") or ""))
-            warming = state == "unreachable" and not (
-                str(prior.get("state")) == "ready" and same_target
-            )
-            if not warming:
+            if state in ("auth_failed", "unreachable", "server_error"):
+                # A definitive verdict: refresh/replace the recorded failure.
                 write_connection_state(state, service_url, detail="authed liveness probe")
+                clear_slow_streak(service_url)
+            # "slow"/"unknown" from the probe is NO verdict — keep the recorded
+            # state untouched rather than promote a timeout to a failure.
             hook_log("recall_skipped_not_ready", {"base_url": service_url, "state": state})
             return None
 
@@ -285,12 +296,21 @@ async def _run(prompt: str) -> dict | None:
         try:
             from _cognee_client import breaker_open
 
-            _bopen, _bretry = breaker_open()
+            _bopen, _bretry = breaker_open(service_url)
         except Exception:
             _bopen, _bretry = False, 0
         if _bopen:
             hook_log("recall_breaker_open", {"retry_in": _bretry})
             scope_specs = []
+    # Health accounting for this prompt's recall attempts (the attempt IS the
+    # probe): a scope that returns is proof of life; a refused connection is
+    # proof of death; timeouts alone are no verdict and only feed the streak.
+    scopes_ok = 0  # calls that returned (even empty — the server answered)
+    scopes_answered_err = 0  # HTTP-level errors: reachable, but not healthy
+    scope_timeouts = 0
+    server_down = False
+    auth_rejected = False  # 401/403: the server answered and rejected OUR key
+    server_errors = 0  # 5xx answers: reachable but failing
     for scope_list, qtype, context_profile in scope_specs:
         # Clamp each call to what is left of the budget so a single scope can
         # never overshoot the deadline (previously a scope dispatched just
@@ -334,8 +354,28 @@ async def _run(prompt: str) -> dict | None:
                 )
             if part:
                 results.extend(part)
+            scopes_ok += 1
         except Exception as exc:
-            hook_log("recall_error", {"scope": scope_list, "error": str(exc)[:200]})
+            import urllib.error as _urlerr
+
+            if isinstance(exc, asyncio.TimeoutError):
+                verdict = SLOW  # pre-3.11 asyncio.TimeoutError isn't TimeoutError
+            else:
+                verdict = classify_transport_exception(exc)
+            if isinstance(exc, _urlerr.HTTPError):
+                scopes_answered_err += 1
+                if exc.code in (401, 403):
+                    auth_rejected = True
+                elif exc.code >= 500:
+                    server_errors += 1
+            elif verdict == SLOW:
+                scope_timeouts += 1
+            elif verdict == DOWN:
+                server_down = True
+            hook_log(
+                "recall_error",
+                {"scope": scope_list, "error": str(exc)[:200], "verdict": verdict},
+            )
         finally:
             # hits = raw count from this scope's call (pre-bucketing/filtering);
             # elapsed_ms measured around the call, recorded even when it errored.
@@ -343,6 +383,92 @@ async def _run(prompt: str) -> dict | None:
                 "hits": len(part or []),
                 "elapsed_ms": round((time.monotonic() - t0) * 1000, 1),
             }
+        if server_down:
+            # Positively absent (refused/DNS): the remaining scopes would fail
+            # the same way in milliseconds each — stop here.
+            hook_log("recall_server_down", {"base_url": service_url})
+            break
+        if auth_rejected:
+            # Every scope shares the same API key, so the remaining scopes are
+            # doomed to the same 401/403 — don't spend the budget on them.
+            hook_log("recall_auth_rejected", {"base_url": service_url})
+            break
+
+    # Fold this prompt's recall outcomes back into the shared health state.
+    # Best-effort: accounting must never break the keystroke->answer path.
+    try:
+        if server_down:
+            # Suppress the write during a genuine cold-start warm-up: a refused
+            # connection with no prior ready marker for this URL is likely the
+            # server still launching/migrating — stay quiet rather than flash a
+            # false red (and don't feed the breaker with warm-up refusals).
+            warming = not (prior_state == "ready" and prior_same_target)
+            if not warming:
+                write_connection_state(
+                    "unreachable", service_url, detail="connection refused during recall"
+                )
+                clear_slow_streak(service_url)
+                if cloud_mode:
+                    try:
+                        from _cognee_client import record_failure as _breaker_failure
+
+                        _breaker_failure(
+                            "connection refused",
+                            service_url=service_url,
+                            reason="unreachable",
+                        )
+                    except Exception:
+                        pass
+        elif auth_rejected and not scopes_ok:
+            # The server answered and rejected the key — definitive, and the
+            # same signal the pre-recall authed probe used to provide, now from
+            # a real request. The re-entry gate's authed probe lifts the state
+            # once the key is fixed.
+            write_connection_state("auth_failed", service_url, detail="401/403 during recall")
+            clear_slow_streak(service_url)
+        elif scopes_ok:
+            # The server answered — an authenticated, real-workload proof of
+            # life. Refresh the marker only when it isn't already fresh-ready,
+            # so steady-state prompts don't rewrite the file every keystroke.
+            clear_slow_streak(service_url)
+            if not server_ready_hint(service_url):
+                mark_server_ready(service_url)
+            if cloud_mode:
+                try:
+                    from _cognee_client import record_success as _breaker_success
+
+                    _breaker_success(service_url)
+                except Exception:
+                    pass
+        elif server_errors:
+            # Reachable but failing (5xx on every answered scope, none ok):
+            # record the state and, mirroring the explicit-search path, one
+            # breaker failure for the prompt.
+            write_connection_state("server_error", service_url, detail="5xx during recall")
+            clear_slow_streak(service_url)
+            if cloud_mode:
+                try:
+                    from _cognee_client import record_failure as _breaker_failure
+
+                    _breaker_failure("http 5xx", service_url=service_url, reason="server_error")
+                except Exception:
+                    pass
+        elif scope_timeouts and not scopes_answered_err:
+            # Every attempted scope timed out and none got an HTTP answer: no
+            # verdict on its own, but N consecutive such prompts are a pattern.
+            # Escalate to "not_responding" — deliberately distinct from
+            # "unreachable" (positively absent: refused/DNS): the server exists
+            # but is not answering. A lone timeout never writes anything.
+            streak = record_slow_probe(service_url)
+            if streak >= slow_streak_threshold():
+                write_connection_state(
+                    "not_responding",
+                    service_url,
+                    detail="%d consecutive timeout-only prompts" % streak,
+                )
+                hook_log("slow_streak_escalated", {"base_url": service_url, "streak": streak})
+    except Exception as exc:
+        hook_log("recall_health_accounting_failed", {"error": str(exc)[:200]})
 
     # Bucket results by _source for human-readable output.
     # Local SDK mode returns Pydantic models (ResponseQAEntry, etc.); cloud

--- a/integrations/claude-code/scripts/session-start.py
+++ b/integrations/claude-code/scripts/session-start.py
@@ -38,9 +38,9 @@ from _plugin_common import (
     apply_cognee_env,
     ensure_launch_record,
     hook_log,
+    probe_health,
     quiet_hook_output,
     resolve_session_key_from_payload,
-    server_health_ok,
     server_ready_hint,
     set_session_key,
     touch_activity,
@@ -988,19 +988,29 @@ async def _run_heavy(
             print(f"cognee-plugin: agent lifecycle failed ({message})", file=sys.stderr)
             # Classify for the status line. Preserve an earlier health-derived
             # state; otherwise a reachable server rejecting registration is almost
-            # always auth, while an unreachable one is a connection failure.
+            # always auth, while a positively-absent one is a connection failure.
+            # A timed-out probe is NO verdict (busy != down): keep the prior
+            # recorded state rather than stamp a false "unreachable".
             if _conn_state is None:
                 try:
-                    healthy = server_health_ok(
+                    health = probe_health(
                         _normalize_service_url(str(config.get("base_url", "") or "")), timeout=1.5
                     )
                 except Exception:
-                    healthy = False
-                _conn_state = "auth_failed" if healthy else "unreachable"
-                _conn_detail = message
-            write_connection_state(
-                _conn_state, str(config.get("base_url", "") or ""), detail=_conn_detail
-            )
+                    health = "unknown"
+                if health == "ready":
+                    _conn_state, _conn_detail = "auth_failed", message
+                elif health == "down":
+                    _conn_state, _conn_detail = "unreachable", message
+            if _conn_state:
+                write_connection_state(
+                    _conn_state, str(config.get("base_url", "") or ""), detail=_conn_detail
+                )
+            else:
+                hook_log(
+                    "conn_state_unverified",
+                    {"reason": "probe returned no verdict after registration failure"},
+                )
             return "", "", False
     else:
         # Local SDK fallback path.
@@ -1053,11 +1063,19 @@ async def _run_heavy(
             write_connection_state(
                 _conn_state, str(config.get("base_url", "") or ""), detail=_conn_detail
             )
-        elif service_url and server_health_ok(service_url, timeout=1.5):
-            write_connection_state("ready", service_url)
-        else:
-            write_connection_state("unreachable", str(config.get("base_url", "") or ""))
-    elif service_url and server_health_ok(service_url, timeout=1.5):
+        elif service_url:
+            health = probe_health(service_url, timeout=1.5)
+            if health == "ready":
+                write_connection_state("ready", service_url)
+            elif health == "down":
+                write_connection_state(
+                    "unreachable", str(config.get("base_url", "") or service_url)
+                )
+            else:
+                # "slow"/"unknown": no verdict — keep whatever state is already
+                # recorded instead of branding a busy server unreachable.
+                hook_log("conn_state_unverified", {"base_url": service_url, "health": health})
+    elif service_url and probe_health(service_url, timeout=1.5) == "ready":
         write_connection_state("ready", service_url)
 
     return user_id, agent_api_key, True

--- a/integrations/claude-code/tests/test_cognee_client.py
+++ b/integrations/claude-code/tests/test_cognee_client.py
@@ -4,6 +4,14 @@ The breaker is file-based (each plugin hook is a short-lived process), so these
 tests point COGNEE_PLUGIN_STATE_DIR at a temp dir and patch the transport
 (`do_recall`) to drive each branch.
 
+Breaker semantics under test (SDK-356):
+  * state is keyed by base_url — one server's failures never open another's
+  * failures only count inside a sliding window (no accumulation across days)
+  * tripping consumes the counted failures (half-open: one post-cooldown
+    failure starts a fresh count instead of instantly re-opening)
+  * transient results (timeouts) are no-verdict: neither failure nor success
+  * the trip reason (unreachable vs server_error) is recorded
+
 Run: `pytest integrations/claude-code/tests/test_cognee_client.py`
 (or `python integrations/claude-code/tests/test_cognee_client.py` standalone).
 """
@@ -22,9 +30,14 @@ os.environ["COGNEE_PLUGIN_STATE_DIR"] = _TMP
 import _cognee_client as cc  # noqa: E402
 from _recall_http import UNREACHABLE  # noqa: E402
 
+URL = "http://x"
+
 
 def _reset():
-    p = pathlib.Path(_TMP) / "recall-breaker.json"
+    # Resolve through _state_path(): other test modules (e.g. test_doctor) also
+    # set COGNEE_PLUGIN_STATE_DIR at import, and under pytest the last import
+    # wins — unlinking a hardcoded _TMP path would silently stop resetting.
+    p = cc._state_path()
     if p.exists():
         p.unlink()
 
@@ -37,66 +50,123 @@ def _stub(value):
 def test_closed_passes_results_through():
     _reset()
     _stub([{"text": "hit"}])
-    assert cc.recall("http://x", "", "q", "", '["graph"]', "5") == [{"text": "hit"}]
-    assert cc.breaker_open()[0] is False
+    assert cc.recall(URL, "", "q", "", '["graph"]', "5") == [{"text": "hit"}]
+    assert cc.breaker_open(URL)[0] is False
 
 
 def test_opens_after_threshold_unreachable_then_short_circuits():
     _reset()
     _stub(UNREACHABLE)
     for _ in range(cc._THRESHOLD):
-        cc.recall("http://x", "", "q", "", '["graph"]', "5")
-    is_open, retry = cc.breaker_open()
+        cc.recall(URL, "", "q", "", '["graph"]', "5")
+    is_open, retry = cc.breaker_open(URL)
     assert is_open and retry > 0
+    assert cc.breaker_reason(URL) == "unreachable"
 
     # While open, recall must NOT call the transport and must surface a 503 envelope.
     def _boom(*a, **k):
         raise AssertionError("transport must not be called while breaker is open")
 
     cc.do_recall = _boom
-    out = cc.recall("http://x", "", "q", "", '["graph"]', "5")
+    out = cc.recall(URL, "", "q", "", '["graph"]', "5")
     assert isinstance(out, dict) and out["status"] == 503 and out["authoritative"] is False
 
 
-def test_5xx_trips_breaker():
+def test_5xx_trips_breaker_with_server_error_reason():
     _reset()
     _stub({"error": "boom", "status": 503, "authoritative": False})
     for _ in range(cc._THRESHOLD):
-        cc.recall("http://x", "", "q", "", '["graph"]', "5")
-    assert cc.breaker_open()[0] is True
+        cc.recall(URL, "", "q", "", '["graph"]', "5")
+    assert cc.breaker_open(URL)[0] is True
+    assert cc.breaker_reason(URL) == "server_error"
 
 
 def test_auth_4xx_does_not_trip():
     _reset()
     _stub({"error": "unauthorized", "status": 403, "authoritative": False})
     for _ in range(cc._THRESHOLD + 2):
-        cc.recall("http://x", "k", "q", "", '["graph"]', "5")
-    assert cc.breaker_open()[0] is False  # config problem, not a backend outage
+        cc.recall(URL, "k", "q", "", '["graph"]', "5")
+    assert cc.breaker_open(URL)[0] is False  # config problem, not a backend outage
+
+
+def test_transient_timeout_is_no_verdict():
+    """A timeout envelope neither trips the breaker nor clears prior failures."""
+    _reset()
+    for _ in range(cc._THRESHOLD - 1):
+        cc.record_failure("x", service_url=URL)
+    _stub(
+        {"error": "recall slow: timed out", "status": 0, "authoritative": False, "transient": True}
+    )
+    for _ in range(cc._THRESHOLD + 2):
+        cc.recall(URL, "", "q", "", '["graph"]', "5")
+    # Still one failure short of the threshold: transients counted as nothing.
+    assert cc.breaker_open(URL)[0] is False
+    cc.record_failure("x", service_url=URL)
+    assert cc.breaker_open(URL)[0] is True
 
 
 def test_empty_list_is_success_not_failure():
     _reset()
     _stub([])
     for _ in range(cc._THRESHOLD + 2):
-        cc.recall("http://x", "", "q", "", '["graph"]', "5")
-    assert cc.breaker_open()[0] is False
+        cc.recall(URL, "", "q", "", '["graph"]', "5")
+    assert cc.breaker_open(URL)[0] is False
 
 
-def test_resets_after_cooldown():
+def test_failures_are_keyed_by_server():
+    """Cloud failures must not open the breaker for a local server (or Codex's)."""
+    _reset()
+    for _ in range(cc._THRESHOLD):
+        cc.record_failure("x", service_url="https://cloud.example")
+    assert cc.breaker_open("https://cloud.example")[0] is True
+    assert cc.breaker_open("http://localhost:8011")[0] is False
+    # No-URL callers (doctor) still see the worst open entry.
+    assert cc.breaker_open()[0] is True
+
+
+def test_failures_outside_window_do_not_count():
+    """Five blips spread over days must not open the breaker."""
+    _reset()
+    now = 1_000_000.0
+    step = cc._WINDOW + 1
+    for i in range(cc._THRESHOLD):
+        cc.record_failure("x", now=now + i * step, service_url=URL)
+    assert cc.breaker_open(URL, now=now + cc._THRESHOLD * step)[0] is False
+
+
+def test_half_open_after_cooldown():
+    """Tripping consumes the failures: one post-cooldown failure must not re-open."""
     _reset()
     now = 1000.0
     for _ in range(cc._THRESHOLD):
-        cc.record_failure("x", now=now)
-    assert cc.breaker_open(now=now)[0] is True
-    assert cc.breaker_open(now=now + cc._COOLDOWN + 1)[0] is False
+        cc.record_failure("x", now=now, service_url=URL)
+    assert cc.breaker_open(URL, now=now)[0] is True
+    after = now + cc._COOLDOWN + 1
+    assert cc.breaker_open(URL, now=after)[0] is False
+    cc.record_failure("x", now=after, service_url=URL)
+    assert cc.breaker_open(URL, now=after)[0] is False  # fresh count, not instant re-open
 
 
 def test_record_success_clears():
     _reset()
     for _ in range(cc._THRESHOLD):
-        cc.record_failure("x")
-    assert cc.breaker_open()[0] is True
-    cc.record_success()
+        cc.record_failure("x", service_url=URL)
+    assert cc.breaker_open(URL)[0] is True
+    cc.record_success(URL)
+    assert cc.breaker_open(URL)[0] is False
+
+
+def test_legacy_flat_schema_is_discarded():
+    """A pre-upgrade flat breaker file (machine-wide) must read as closed."""
+    _reset()
+    import json as _json
+    import time as _time
+
+    path = pathlib.Path(_TMP) / "recall-breaker.json"
+    path.write_text(
+        _json.dumps({"failures": 99, "cooldown_until": _time.time() + 3600}), encoding="utf-8"
+    )
+    assert cc.breaker_open(URL)[0] is False
     assert cc.breaker_open()[0] is False
 
 
@@ -109,7 +179,7 @@ def test_dataset_forwarded_to_transport():
         return []
 
     cc.do_recall = _capture
-    cc.recall("http://x", "", "q", "", '["graph"]', "5", "my_dataset")
+    cc.recall(URL, "", "q", "", '["graph"]', "5", "my_dataset")
     assert captured.get("dataset") == "my_dataset"
 
 

--- a/integrations/claude-code/tests/test_doctor.py
+++ b/integrations/claude-code/tests/test_doctor.py
@@ -37,7 +37,11 @@ def _reset_env(*keys):
 
 
 def _reset_breaker():
-    p = pathlib.Path(_TMP) / "recall-breaker.json"
+    # Resolve through _state_path(): other test modules also set
+    # COGNEE_PLUGIN_STATE_DIR at import, and under pytest the last import wins.
+    from _cognee_client import _state_path
+
+    p = _state_path()
     if p.exists():
         p.unlink()
 
@@ -233,9 +237,21 @@ def test_breaker_closed():
 def test_breaker_open():
     import time as _time
 
-    breaker_path = pathlib.Path(_TMP) / "recall-breaker.json"
-    breaker_path.write_text(
-        json.dumps({"failures": 10, "cooldown_until": _time.time() + 60}),
+    from _cognee_client import _state_path
+
+    # Per-server schema (SDK-356): entries are keyed by base_url; the no-URL
+    # doctor view reports the worst open entry across all servers.
+    _state_path().write_text(
+        json.dumps(
+            {
+                "servers": {
+                    "http://x": {
+                        "cooldown_until": _time.time() + 60,
+                        "reason": "unreachable",
+                    }
+                }
+            }
+        ),
         encoding="utf-8",
     )
     try:

--- a/integrations/claude-code/tests/test_improve_session_lock.py
+++ b/integrations/claude-code/tests/test_improve_session_lock.py
@@ -94,9 +94,15 @@ def test_dead_holder_lock_is_reclaimed():
     # dead-pid branch must be what clears it. pid_alive is stubbed rather than
     # guessing an unused pid, so the test can't flake on a recycled pid.
     p.write_text(json.dumps({"owner": "dead", "pid": 4242, "created_at": 9e9}))
+    # c._proc is the SHARED module object (sys.modules singleton): restore the
+    # stub or it leaks into every later test module (seen in test_proc).
+    _orig_pid_alive = c._proc.pid_alive
     c._proc.pid_alive = lambda pid: False
-    with c.improve_session_lock("sess-A", "reclaimer") as claimed:
-        assert claimed is True, "stale lock from a dead pid must be reclaimed"
+    try:
+        with c.improve_session_lock("sess-A", "reclaimer") as claimed:
+            assert claimed is True, "stale lock from a dead pid must be reclaimed"
+    finally:
+        c._proc.pid_alive = _orig_pid_alive
 
 
 def test_live_holder_lock_is_not_stolen():
@@ -112,9 +118,13 @@ def test_live_holder_lock_is_not_stolen():
 
     now = _dt.datetime.now(_dt.timezone.utc).timestamp()
     p.write_text(json.dumps({"owner": "live", "pid": 4242, "created_at": now}))
+    _orig_pid_alive = c._proc.pid_alive
     c._proc.pid_alive = lambda pid: True
-    with c.improve_session_lock("sess-A", "intruder") as claimed:
-        assert claimed is False, "a live holder's lock must be respected"
+    try:
+        with c.improve_session_lock("sess-A", "intruder") as claimed:
+            assert claimed is False, "a live holder's lock must be respected"
+    finally:
+        c._proc.pid_alive = _orig_pid_alive
 
 
 def test_missing_session_id_never_blocks():

--- a/integrations/claude-code/tests/test_per_scope_timing.py
+++ b/integrations/claude-code/tests/test_per_scope_timing.py
@@ -58,8 +58,12 @@ def _drive_run(recall_map, *, breaker=(False, 0), recall_fn=None):
 
     # The breaker is imported lazily inside _run (cloud mode); inject a fake so
     # the test is deterministic regardless of any on-disk breaker state.
+    # breaker_open is keyed by service_url since SDK-356; record_success /
+    # record_failure are the hot-path accounting hooks (no-ops here).
     fake_client = types.ModuleType("_cognee_client")
-    fake_client.breaker_open = lambda: breaker
+    fake_client.breaker_open = lambda service_url="": breaker
+    fake_client.record_success = lambda service_url="": None
+    fake_client.record_failure = lambda *a, **k: None
     saved_client = sys.modules.get("_cognee_client")
     sys.modules["_cognee_client"] = fake_client
 

--- a/integrations/claude-code/tests/test_recall_health_accounting.py
+++ b/integrations/claude-code/tests/test_recall_health_accounting.py
@@ -1,0 +1,216 @@
+"""Tests for the hot-path health accounting in session-context-lookup._run (SDK-356).
+
+The recall attempt IS the probe: each prompt's scope calls are folded back into
+the shared connection state. Under test:
+
+  * 401/403 → "auth_failed" written, remaining scopes skipped (shared key —
+    they are doomed to the same rejection). This restores the auth detection
+    the old pre-recall authed probe provided, from a real request.
+  * 5xx on every answered scope → "server_error" written + one breaker failure.
+  * connection refused → "unreachable" written (with warm-up suppression when
+    there is no prior ready marker) and remaining scopes skipped.
+  * all-timeout prompt → nothing written below the streak threshold; "slow"
+    written at the threshold.
+  * success → marker refreshed (when stale) and the breaker cleared.
+
+Follows the test_per_scope_timing conventions: the hyphenated hook module is
+loaded via importlib, seams are stubbed as module attributes, a fake
+_cognee_client is injected, and HOME is redirected for the best-effort
+last_recall writes.
+
+Run: python integrations/claude-code/tests/test_recall_health_accounting.py
+(or via pytest).
+"""
+
+import asyncio
+import importlib.util
+import os
+import pathlib
+import sys
+import tempfile
+import types
+import urllib.error
+
+os.environ.setdefault("COGNEE_PLUGIN_IN_VENV", "1")
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+_URL = "https://cloud.example"
+
+
+def _load_hook_module():
+    path = SCRIPTS / "session-context-lookup.py"
+    spec = importlib.util.spec_from_file_location("session_context_lookup_health", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _drive(recall_fn, *, prior=None, ready_hint=False, streak=1, threshold=3):
+    """Run _run in cloud mode with all state seams captured.
+
+    Returns (events, state_writes, breaker_calls, recall_calls).
+    """
+    mod = _load_hook_module()
+    events, writes, breaker_calls, calls = [], [], [], []
+
+    def _recall(prompt, **kw):
+        calls.append(kw["scope"][0])
+        return recall_fn(prompt, **kw)
+
+    mod.hook_log = lambda ev, detail=None: events.append((ev, detail or {}))
+    mod.notify = lambda *a, **k: None
+    mod.load_config = lambda: {}
+    mod.resolve_runtime_mode = lambda: {"mode": "http", "base_url": _URL}
+    mod.read_connection_state = lambda: dict(prior or {})
+    mod.server_ready_hint = lambda url: ready_hint
+    mod.mark_server_ready = lambda url: writes.append(("ready", url, ""))
+    mod.write_connection_state = lambda state, url, detail="": writes.append((state, url, detail))
+    mod.clear_slow_streak = lambda url: None
+    mod.record_slow_probe = lambda url: streak
+    mod.slow_streak_threshold = lambda: threshold
+    mod._load_session_id = lambda: "sid"
+    mod.read_and_reset_save_counter = lambda sid: {"prompt": 0, "trace": 0, "answer": 0}
+    mod.recall_via_http = _recall
+
+    fake_client = types.ModuleType("_cognee_client")
+    fake_client.breaker_open = lambda service_url="": (False, 0)
+    fake_client.record_success = lambda service_url="": breaker_calls.append(
+        ("success", service_url)
+    )
+    fake_client.record_failure = lambda error="", now=None, service_url="", reason="": (
+        breaker_calls.append(("failure", service_url, reason))
+    )
+    saved_client = sys.modules.get("_cognee_client")
+    sys.modules["_cognee_client"] = fake_client
+
+    saved_env = {k: os.environ.get(k) for k in ("HOME", "USERPROFILE")}
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        os.environ["USERPROFILE"] = home
+        try:
+            asyncio.run(mod._run("please recall something relevant"))
+        finally:
+            for k, v in saved_env.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+            if saved_client is None:
+                sys.modules.pop("_cognee_client", None)
+            else:
+                sys.modules["_cognee_client"] = saved_client
+    return events, writes, breaker_calls, calls
+
+
+def _raiser(exc_factory):
+    def _fn(prompt, **kw):
+        raise exc_factory()
+
+    return _fn
+
+
+def _http_error(code):
+    return urllib.error.HTTPError(_URL, code, "boom", {}, None)
+
+
+_READY_PRIOR = {"state": "ready", "base_url": _URL, "checked_at": 1.0}
+
+
+# ── auth failure: detected from the real request, budget not wasted ─────────
+
+
+def test_401_writes_auth_failed_and_skips_remaining_scopes():
+    events, writes, _breaker, calls = _drive(_raiser(lambda: _http_error(401)))
+    assert ("auth_failed", _URL, "401/403 during recall") in writes
+    assert len(calls) == 1, f"remaining scopes must be skipped, got {calls}"
+    assert any(ev == "recall_auth_rejected" for ev, _ in events)
+
+
+def test_403_also_writes_auth_failed():
+    _events, writes, _breaker, _calls = _drive(_raiser(lambda: _http_error(403)))
+    assert any(w[0] == "auth_failed" for w in writes)
+
+
+# ── 5xx: reachable but failing ───────────────────────────────────────────────
+
+
+def test_5xx_on_all_scopes_writes_server_error_and_one_breaker_failure():
+    _events, writes, breaker, calls = _drive(_raiser(lambda: _http_error(503)))
+    assert ("server_error", _URL, "5xx during recall") in writes
+    assert breaker == [("failure", _URL, "server_error")], breaker
+    assert len(calls) == 4, "5xx is not a shared-key verdict — all scopes still try"
+
+
+# ── refused: definitive down, warming-suppressed on cold start ───────────────
+
+
+def test_refused_with_prior_ready_writes_unreachable_and_stops():
+    def _refused():
+        return urllib.error.URLError(ConnectionRefusedError(61, "refused"))
+
+    _events, writes, breaker, calls = _drive(_raiser(_refused), prior=_READY_PRIOR)
+    assert any(w[0] == "unreachable" for w in writes)
+    assert ("failure", _URL, "unreachable") in breaker
+    assert len(calls) == 1, f"remaining scopes must be skipped, got {calls}"
+
+
+def test_refused_without_prior_ready_is_warming_and_writes_nothing():
+    def _refused():
+        return urllib.error.URLError(ConnectionRefusedError(61, "refused"))
+
+    _events, writes, breaker, _calls = _drive(_raiser(_refused), prior=None)
+    assert writes == [], writes
+    assert breaker == [], breaker
+
+
+# ── timeouts: no verdict until the streak threshold ──────────────────────────
+
+
+def test_all_timeout_below_threshold_writes_nothing():
+    _events, writes, breaker, calls = _drive(
+        _raiser(lambda: TimeoutError("timed out")), streak=1, threshold=3
+    )
+    assert writes == [], writes
+    assert breaker == [], "timeouts must not feed the breaker"
+    assert len(calls) == 4
+
+
+def test_all_timeout_at_threshold_writes_not_responding():
+    """N consecutive timeout-only prompts escalate — but never to "unreachable":
+    the server exists (nothing refused), it just isn't answering."""
+    events, writes, breaker, _calls = _drive(
+        _raiser(lambda: TimeoutError("timed out")), streak=3, threshold=3
+    )
+    assert any(w[0] == "not_responding" for w in writes), writes
+    assert not any(w[0] == "unreachable" for w in writes), writes
+    assert breaker == [], "timeouts must not feed the breaker even at threshold"
+    assert any(ev == "slow_streak_escalated" for ev, _ in events)
+
+
+# ── success: the attempt is the ready probe ──────────────────────────────────
+
+
+def test_success_refreshes_stale_marker_and_clears_breaker():
+    _events, writes, breaker, _calls = _drive(lambda prompt, **kw: [], ready_hint=False)
+    assert ("ready", _URL, "") in writes
+    assert ("success", _URL) in breaker
+
+
+def test_success_with_fresh_marker_does_not_rewrite():
+    _events, writes, _breaker, _calls = _drive(lambda prompt, **kw: [], ready_hint=True)
+    assert writes == [], writes
+
+
+if __name__ == "__main__":
+    failures = 0
+    for _name, _fn in sorted(globals().items()):
+        if _name.startswith("test_") and callable(_fn):
+            try:
+                _fn()
+                print("PASS", _name)
+            except AssertionError as exc:
+                failures += 1
+                print("FAIL", _name, exc)
+    sys.exit(1 if failures else 0)

--- a/integrations/claude-code/tests/test_recall_http.py
+++ b/integrations/claude-code/tests/test_recall_http.py
@@ -91,8 +91,8 @@ def test_http_401_403_auth_is_error_envelope_not_fallback():
         assert out != rh.UNREACHABLE
 
 
-def test_connection_error_is_unreachable():
-    # Only a genuine connection failure may fall back to the local CLI.
+def test_connection_refused_is_unreachable():
+    # Only a POSITIVE absence (refused/DNS/unroutable) may fall back to the CLI.
     assert (
         rh.do_recall(
             "http://x",
@@ -101,10 +101,67 @@ def test_connection_error_is_unreachable():
             "",
             '["graph"]',
             "5",
-            opener=_raises(urllib.error.URLError("refused")),
+            opener=_raises(urllib.error.URLError(ConnectionRefusedError(61, "refused"))),
         )
         == rh.UNREACHABLE
     )
+
+
+def test_dns_failure_is_unreachable():
+    import socket
+
+    assert (
+        rh.do_recall(
+            "http://x",
+            "",
+            "q",
+            "",
+            '["graph"]',
+            "5",
+            opener=_raises(urllib.error.URLError(socket.gaierror(8, "no such host"))),
+        )
+        == rh.UNREACHABLE
+    )
+
+
+def test_timeout_is_transient_envelope_not_unreachable():
+    """A timeout is 'alive but busy' — no CLI fallback, no breaker failure."""
+    for exc in (TimeoutError("timed out"), urllib.error.URLError(TimeoutError("timed out"))):
+        out = rh.do_recall("http://x", "", "q", "", '["graph"]', "5", opener=_raises(exc))
+        assert out != rh.UNREACHABLE
+        assert isinstance(out, dict) and out.get("transient") is True
+        assert out["authoritative"] is False
+
+
+def test_unclassifiable_error_is_transient_envelope():
+    """SSL trouble / vague reasons / our own bugs must not read as 'server down'."""
+    out = rh.do_recall(
+        "http://x", "", "q", "", '["graph"]', "5", opener=_raises(urllib.error.URLError("weird"))
+    )
+    assert out != rh.UNREACHABLE
+    assert isinstance(out, dict) and out.get("transient") is True
+
+
+def test_classifier_verdicts():
+    import socket
+
+    cases = [
+        (ConnectionRefusedError(61, "refused"), rh.DOWN),
+        (socket.gaierror(8, "no such host"), rh.DOWN),
+        (OSError(65, "no route to host"), rh.DOWN),  # EHOSTUNREACH
+        (TimeoutError("timed out"), rh.SLOW),
+        (urllib.error.URLError(TimeoutError("timed out")), rh.SLOW),
+        (urllib.error.URLError("timed out"), rh.SLOW),  # string reason
+        (urllib.error.URLError(ConnectionRefusedError(61, "x")), rh.DOWN),
+        (ConnectionResetError(54, "reset"), rh.UNKNOWN),
+        (ValueError("bug in our own code"), rh.UNKNOWN),
+    ]
+    import ssl as _ssl
+
+    cases.append((_ssl.SSLError("handshake"), rh.UNKNOWN))
+    for exc, want in cases:
+        got = rh.classify_transport_exception(exc)
+        assert got == want, f"{exc!r}: want {want}, got {got}"
 
 
 def test_malformed_json_is_error_not_unreachable():

--- a/integrations/claude-code/tests/test_statusline_connection_state.py
+++ b/integrations/claude-code/tests/test_statusline_connection_state.py
@@ -200,10 +200,15 @@ def test_a_fresher_shared_ready_does_not_clear_our_failure():
 # ── the pre-existing rules still hold ────────────────────────────────────
 
 
+def _breaker_for(url, *, cooldown_delta=60, reason="unreachable"):
+    """A per-server breaker file (SDK-356 schema) for `url`."""
+    return {"servers": {url: {"cooldown_until": time.time() + cooldown_delta, "reason": reason}}}
+
+
 def test_open_breaker_overrides_our_ready():
     with _Markers(
         mine=_rec("ready", _MINE),
-        breaker={"cooldown_until": time.time() + 60},
+        breaker=_breaker_for(_URL),
     ):
         assert sl._health_prefix(_MINE) == _fail("unreachable")
 
@@ -211,9 +216,67 @@ def test_open_breaker_overrides_our_ready():
 def test_expired_breaker_leaves_ready_alone():
     with _Markers(
         mine=_rec("ready", _MINE),
-        breaker={"cooldown_until": time.time() - 60},
+        breaker=_breaker_for(_URL, cooldown_delta=-60),
     ):
         assert sl._health_prefix(_MINE) == _READY
+
+
+def test_breaker_reports_its_real_trip_reason():
+    """A breaker opened by 5xx must read server_error, not a false unreachable."""
+    with _Markers(
+        mine=_rec("ready", _MINE),
+        breaker=_breaker_for(_URL, reason="server_error"),
+    ):
+        assert sl._health_prefix(_MINE) == _fail("server_error")
+
+
+def test_another_servers_breaker_does_not_red_this_bar():
+    """Cloud failures (or Codex's target) must not red a local terminal."""
+    with _Markers(
+        mine=_rec("ready", _MINE),
+        breaker=_breaker_for("https://tenant-x.aws.cognee.ai"),
+    ):
+        assert sl._health_prefix(_MINE) == _READY
+
+
+def test_legacy_flat_breaker_file_is_ignored():
+    """The pre-upgrade machine-wide breaker was target-blind — never render it."""
+    with _Markers(
+        mine=_rec("ready", _MINE),
+        breaker={"failures": 99, "cooldown_until": time.time() + 3600},
+    ):
+        assert sl._health_prefix(_MINE) == _READY
+
+
+# ── SDK-356: honest, fresh, definitive ─────────────────────────────────────
+
+
+def test_not_responding_renders_its_own_reason():
+    """The escalated timeout streak is its own state — never "unreachable"."""
+    with _Markers(mine=_rec("not_responding", _MINE)):
+        out = sl._health_prefix(_MINE)
+    assert out == sl._fail_glyph("not_responding"), repr(out)
+    assert "unreachable" not in out
+
+
+def test_fresher_shared_not_responding_overrides_our_older_ready():
+    """Server-wide: a server that isn't answering isn't answering anyone."""
+    with _Markers(
+        shared=_rec("not_responding", _THEIRS, age=1),
+        mine=_rec("ready", _MINE, age=600),
+    ):
+        assert sl._health_prefix(_MINE) == sl._fail_glyph("not_responding")
+
+
+def test_stale_failure_marker_renders_no_glyph():
+    """A failure nobody has re-confirmed within the TTL is ambiguity, not red."""
+    with _Markers(mine=_rec("unreachable", _MINE, age=sl._FAIL_STATE_STALE_SECONDS + 60)):
+        assert sl._health_prefix(_MINE) == ""
+
+
+def test_fresh_failure_marker_still_renders():
+    with _Markers(mine=_rec("unreachable", _MINE, age=60)):
+        assert sl._health_prefix(_MINE) == _fail("unreachable")
 
 
 def test_base_url_mismatch_is_ignored():

--- a/integrations/claude-code/tests/test_statusline_llm_state.py
+++ b/integrations/claude-code/tests/test_statusline_llm_state.py
@@ -219,9 +219,13 @@ def test_cloud_mode_suppresses_llm_glyph():
 
 
 def test_server_failure_wins_over_llm_failure():
+    import time as _time
+
     with _Renderer(
         llm_state={"llm_state": "not_set"},
-        server_marker={"state": "auth_failed", "base_url": _LOCAL_URL},
+        # checked_at present and fresh: red is reserved for fresh failures
+        # (a failure marker of unknown age renders no glyph since SDK-356).
+        server_marker={"state": "auth_failed", "base_url": _LOCAL_URL, "checked_at": _time.time()},
     ):
         assert sl._status_prefix() == sl._fail_glyph(sl._COGNEE_KEY_REASON)
 

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -179,7 +179,7 @@ cognee: my-project · cloud
 
 `<dataset>` is the active Cognee dataset. `<mode>` is `local` when no `COGNEE_BASE_URL` is set or when it points to localhost, and `cloud` when it points to a remote host.
 
-A connection glyph precedes the line: `●` once the server is confirmed up **and** authenticated, or `✕ (<reason>)` on failure — `incorrect_cognee_api_key` (a missing, wrong, or expired `COGNEE_API_KEY`), `unreachable` (server down, including a server that dies mid-session), or `server_error` (5xx). The state is recorded by the hooks that already talk to the server (SessionStart, and the per-prompt recall), so it stays green until a failure is actually observed and clears back to `●` on the next success. Read from local state only — no network on refresh.
+A connection glyph precedes the line: `●` once the server is confirmed up **and** authenticated, or `✕ (<reason>)` on failure — `incorrect_cognee_api_key` (a missing, wrong, or expired `COGNEE_API_KEY`), `unreachable` (server positively absent: connection refused or DNS failure, including a server that dies mid-session), `server_error` (5xx), or `not_responding` (the server accepts connections but hasn't answered for several consecutive prompts — a single slow response never triggers it, so a busy server is not misreported as unreachable). The state is recorded by the hooks that already talk to the server (SessionStart, and the per-prompt recall), so it stays green until a failure is actually observed and clears back to `●` on the next success. Read from local state only — no network on refresh.
 
 | Env var | Default | Effect |
 |---|---|---|

--- a/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
+++ b/integrations/codex/plugins/cognee/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cognee",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "CLI-first Cognee workflows for memory, knowledge graphs, codebase ingestion, and local UI launch.",
   "author": {
     "name": "Topoteretes",

--- a/integrations/codex/plugins/cognee/CHANGELOG.md
+++ b/integrations/codex/plugins/cognee/CHANGELOG.md
@@ -10,6 +10,38 @@ is the cache key and semver record, bumped on each release, not the update trigg
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.3]
+
+### Fixed
+- **False `✕ (unreachable)` in the status line.** Probe and recall
+  timeouts were classified as "unreachable" and persisted into the shared
+  connection state, so a busy-but-healthy server randomly turned the status red
+  and skipped recall — in both local and cloud mode. Timeouts are now a
+  no-verdict: transport failures are classified (connection refused / DNS →
+  `unreachable`; timeout → keep prior state), and `unreachable` is only ever
+  written on positive absence.
+  - The recall attempt itself is now the health probe: a successful scope call
+    marks ready, a refused connection marks `unreachable`, a 401/403 marks
+    `auth_failed` (detected from the real request, remaining scopes skipped),
+    and all-5xx marks `server_error`. The synthetic pre-recall probe survives
+    only as a re-entry check while the marker holds a failure state.
+  - The recall circuit breaker is keyed by `base_url` (cloud failures no
+    longer red a local status, and vice versa — including across the Claude
+    Code plugin, which shares the breaker file), counts failures in a sliding
+    window instead of forever, re-arms half-open after cooldown, never counts
+    timeouts, and the status line renders its real trip reason.
+  - The renderer shows a ✕ only for fresh, definitive failures (30 min TTL);
+    stale or ambiguous state renders no glyph.
+  - Breaker state writes use tmp + atomic replace so readers never see a torn
+    file.
+
+### Added
+- **`✕ (not_responding)` status** — distinct from `unreachable`: the server
+  accepts connections but hasn't answered for N consecutive timeout-only
+  prompts (default 3, `COGNEE_SLOW_STREAK_THRESHOLD`; streak window
+  `COGNEE_SLOW_STREAK_WINDOW`, 600s). A single slow response never triggers
+  it. Lifted back to `●` by the next successful probe or recall.
+
 ## [1.3.2]
 
 ### Fixed

--- a/integrations/codex/plugins/cognee/scripts/_cognee_client.py
+++ b/integrations/codex/plugins/cognee/scripts/_cognee_client.py
@@ -63,7 +63,13 @@ def _write(servers):
     try:
         path = _state_path()
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps({"servers": servers}), encoding="utf-8")
+        # pid-suffixed tmp + atomic replace, matching the other marker writers:
+        # readers (other hooks, the status-line renderer) can never see a torn
+        # file. Concurrent writers remain last-write-wins — accepted for this
+        # advisory state; serializing them would need file locking.
+        tmp = path.with_name(".breaker-%d.json.tmp" % os.getpid())
+        tmp.write_text(json.dumps({"servers": servers}), encoding="utf-8")
+        os.replace(tmp, path)
     except Exception:
         pass
 

--- a/integrations/codex/plugins/cognee/scripts/_cognee_client.py
+++ b/integrations/codex/plugins/cognee/scripts/_cognee_client.py
@@ -30,6 +30,10 @@ load_env_file()
 # Tunables (mirror Hermes's provider defaults).
 _THRESHOLD = int(os.environ.get("COGNEE_BREAKER_THRESHOLD", "5"))
 _COOLDOWN = float(os.environ.get("COGNEE_BREAKER_COOLDOWN", "120"))
+# Sliding window: only failures within this many seconds of each other count
+# toward the threshold. Without it, five isolated blips spread over days would
+# open the breaker "out of nowhere" long after the last real problem.
+_WINDOW = float(os.environ.get("COGNEE_BREAKER_WINDOW", "300"))
 _RECALL_TIMEOUT = float(os.environ.get("COGNEE_RECALL_TIMEOUT", "120"))
 
 
@@ -38,55 +42,129 @@ def _state_path():
     return pathlib.Path(base) / "recall-breaker.json"
 
 
+def _norm_url(service_url):
+    return str(service_url or "").strip().rstrip("/")
+
+
 def _read():
+    """The per-server breaker map {url: entry}. A legacy flat file (top-level
+    ``failures``/``cooldown_until``, not keyed by server) is discarded rather
+    than migrated: it conflated every server on the machine, which is one of
+    the bugs this schema exists to fix."""
     try:
         data = json.loads(_state_path().read_text(encoding="utf-8"))
-        return data if isinstance(data, dict) else {}
     except Exception:
         return {}
+    servers = data.get("servers") if isinstance(data, dict) else None
+    return servers if isinstance(servers, dict) else {}
 
 
-def _write(state):
+def _write(servers):
     try:
         path = _state_path()
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(state), encoding="utf-8")
+        path.write_text(json.dumps({"servers": servers}), encoding="utf-8")
     except Exception:
         pass
 
 
-def breaker_open(now=None):
-    """Return (is_open, retry_in_seconds). Open while we're inside the cooldown window."""
+def _entry(servers, url):
+    entry = servers.get(url)
+    return entry if isinstance(entry, dict) else {}
+
+
+def _recent_failures(entry, now):
+    """This server's failure timestamps still inside the sliding window."""
+    stamps = entry.get("failures")
+    if not isinstance(stamps, list):
+        return []
+    out = []
+    for value in stamps:
+        try:
+            ts = float(value)
+        except (TypeError, ValueError):
+            continue
+        if now - ts <= _WINDOW:
+            out.append(ts)
+    return out
+
+
+def breaker_open(service_url="", now=None):
+    """Return (is_open, retry_in_seconds) for this server.
+
+    Open while inside the cooldown window. With no ``service_url`` (doctor /
+    legacy callers), reports the worst open entry across all servers.
+    """
     now = time.time() if now is None else now
-    until = float(_read().get("cooldown_until") or 0.0)
-    return (True, int(until - now)) if now < until else (False, 0)
+    servers = _read()
+    urls = [_norm_url(service_url)] if _norm_url(service_url) else list(servers)
+    worst = 0.0
+    for url in urls:
+        try:
+            until = float(_entry(servers, url).get("cooldown_until") or 0.0)
+        except (TypeError, ValueError):
+            until = 0.0
+        worst = max(worst, until)
+    return (True, int(worst - now)) if now < worst else (False, 0)
 
 
-def record_failure(error="", now=None):
-    """Count a backend failure; open the breaker once we hit the threshold."""
+def breaker_reason(service_url=""):
+    """The reason the breaker last tripped for this server ("" if never)."""
+    servers = _read()
+    url = _norm_url(service_url)
+    if not url and servers:
+        url = next(iter(servers))
+    return str(_entry(servers, url).get("reason") or "")
+
+
+def record_failure(error="", now=None, service_url="", reason="unreachable"):
+    """Count a hard backend failure; open the breaker at the windowed threshold.
+
+    Only definitive trouble belongs here — UNREACHABLE (positively absent) or
+    5xx. Timeouts are no-verdict and must NOT be recorded (see the transient
+    envelope handling in ``recall``). When the breaker trips, the counted
+    failures are consumed: after the cooldown the breaker is half-open, and a
+    single new failure starts a fresh count instead of instantly re-opening.
+    """
     now = time.time() if now is None else now
-    state = _read()
-    failures = int(state.get("failures") or 0) + 1
-    state["failures"] = failures
-    state["last_error"] = str(error)[:200]
-    if failures >= _THRESHOLD:
-        state["cooldown_until"] = now + _COOLDOWN
-    _write(state)
+    url = _norm_url(service_url)
+    servers = _read()
+    entry = _entry(servers, url)
+    failures = _recent_failures(entry, now)
+    failures.append(now)
+    if len(failures) >= _THRESHOLD:
+        entry = {
+            "failures": [],
+            "cooldown_until": now + _COOLDOWN,
+            "reason": str(reason or "unreachable"),
+            "last_error": str(error)[:200],
+        }
+    else:
+        entry = dict(entry)
+        entry["failures"] = failures
+        entry["last_error"] = str(error)[:200]
+    servers[url] = entry
+    _write(servers)
 
 
-def record_success():
-    """Backend answered — clear the breaker."""
-    _write({"failures": 0, "cooldown_until": 0.0})
+def record_success(service_url=""):
+    """Backend answered — clear this server's breaker entry."""
+    servers = _read()
+    servers.pop(_norm_url(service_url), None)
+    _write(servers)
 
 
 def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *, timeout=None):
     """Breaker-wrapped recall. Returns a list, an error-envelope dict, or UNREACHABLE.
 
-    Only genuine backend trouble trips the breaker: UNREACHABLE (connection
-    failure) or a 5xx. A reachable 4xx (e.g. 401/403 auth) is a config problem —
-    surfaced, but it does NOT open the breaker (waiting wouldn't fix it).
+    Only genuine backend trouble trips the breaker: UNREACHABLE (positively
+    absent — refused/DNS) or a 5xx. A reachable 4xx (e.g. 401/403 auth) is a
+    config problem — surfaced, but it does NOT open the breaker (waiting
+    wouldn't fix it). A transient envelope (timeout / unclassifiable transport
+    error) is no verdict at all: it neither counts as a failure nor clears the
+    window — a busy server must not be branded unreachable by its own latency.
     """
-    is_open, retry = breaker_open()
+    is_open, retry = breaker_open(service_url)
     if is_open:
         # We're in cooldown: surface a clear message and do NOT call (and, since
         # this isn't UNREACHABLE, the wrapper won't fall back to the CLI either —
@@ -104,11 +182,15 @@ def recall(service_url, api_key, query, session_id, scope, top_k, dataset="", *,
         timeout=timeout or _RECALL_TIMEOUT,
     )
     if result == UNREACHABLE:
-        record_failure("unreachable")
+        record_failure("unreachable", service_url=service_url, reason="unreachable")
     elif isinstance(result, dict) and int(result.get("status") or 0) >= 500:
-        record_failure("http %s" % result.get("status"))
+        record_failure(
+            "http %s" % result.get("status"), service_url=service_url, reason="server_error"
+        )
+    elif isinstance(result, dict) and result.get("transient"):
+        pass  # no verdict: leave the breaker exactly as it was
     else:
-        record_success()
+        record_success(service_url)
     return result
 
 

--- a/integrations/codex/plugins/cognee/scripts/_plugin_common.py
+++ b/integrations/codex/plugins/cognee/scripts/_plugin_common.py
@@ -24,6 +24,7 @@ from typing import Optional
 
 import _proc
 from _env_file import load_env_file
+from _recall_http import DOWN, SLOW, UNKNOWN, classify_transport_exception
 
 # One-time config: ~/.cognee/.env acts like shell exports (setdefault — a real
 # export still wins). Loaded before any env read below or in importers.
@@ -1287,30 +1288,51 @@ def http_api_ready() -> bool:
     return bool(service_url and api_key)
 
 
-def server_health_ok(service_url: str = "", timeout: float = 1.0) -> bool:
-    """Return True iff GET {service_url}/health responds 200 (server serving).
+def probe_health(service_url: str = "", timeout: float = 1.0) -> str:
+    """Classified GET {service_url}/health probe.
 
-    The Cognee server runs migrations in its FastAPI lifespan *before* it
-    serves, so a 200 here reliably means migrations are done and the DBs are
-    reachable.
+    Returns:
+      "ready"   — 200 (the server runs migrations in its FastAPI lifespan
+                  *before* it serves, so this reliably means migrations are
+                  done and the DBs are reachable)
+      "down"    — connection refused / DNS / unroutable: positively absent
+      "slow"    — timed out: NO verdict (a busy server times out; a dead one
+                  refuses in milliseconds). Callers must keep prior state.
+      "unknown" — non-200 status, SSL trouble, resets, or no URL: no verdict
     """
     base = _normalize_service_url(service_url or _local_api_url())
     if not base:
-        return False
+        return UNKNOWN
     try:
         with urllib.request.urlopen(
             f"{base}/health", timeout=timeout, context=_https_context()
         ) as resp:
-            return resp.status == 200
-    except (urllib.error.URLError, TimeoutError, OSError):
-        return False
+            return "ready" if resp.status == 200 else UNKNOWN
+    except Exception as exc:
+        verdict = classify_transport_exception(exc)
+        return verdict if verdict in (DOWN, SLOW) else UNKNOWN
+
+
+def server_health_ok(service_url: str = "", timeout: float = 1.0) -> bool:
+    """Return True iff /health responds 200. Boolean face of ``probe_health``.
+
+    Callers that must react to *failures* should use ``probe_health`` instead:
+    this bool cannot distinguish "down" (write a failure state) from "slow"
+    (no verdict — keep prior state).
+    """
+    return probe_health(service_url, timeout=timeout) == "ready"
 
 
 # Connection states recorded in the (shared) server-ready marker. "ready" means
 # the server is up AND authenticated; the failure states carry the reason shown
 # in the status line as "✕ (<state>)". Any non-"ready" state makes
 # server_ready_hint return False so recall does not attempt against a bad backend.
-CONNECTION_STATES = ("ready", "auth_failed", "unreachable", "server_error")
+# "unreachable" is reserved for POSITIVE absence (connection refused / DNS /
+# unroutable). "not_responding" is deliberately distinct: the server exists
+# (connections are not refused) but has not answered within budget for N
+# consecutive prompts — written only by the slow-streak escalation (see
+# record_slow_probe), never by a lone timeout.
+CONNECTION_STATES = ("ready", "auth_failed", "unreachable", "server_error", "not_responding")
 
 
 # Per-session copies of the status markers. The shared files above are
@@ -1398,6 +1420,83 @@ def mark_server_ready(service_url: str, version: str = "") -> None:
     write_connection_state("ready", service_url, version=version)
 
 
+# Slow-server hysteresis. A single timeout is "no verdict" and must not touch
+# the connection marker — but N consecutive timeout-only prompts with no
+# success in between are a pattern (wedged server, packet-dropping network),
+# not a blip. This counter, keyed by base_url, is how a lone blip stays
+# invisible while a persistent stall still escalates to a visible "slow" state
+# (and recall backoff) instead of leaving the bar green forever.
+_SLOW_STREAK_FILE = _PLUGIN_DIR / "slow-streak.json"
+
+
+def slow_streak_threshold() -> int:
+    """Consecutive timeout-only prompts before escalating to state "slow"."""
+    try:
+        return max(1, int(os.environ.get("COGNEE_SLOW_STREAK_THRESHOLD", "3") or 3))
+    except (TypeError, ValueError):
+        return 3
+
+
+def _slow_streak_window_seconds() -> float:
+    """Ticks further apart than this don't chain — a streak must be recent."""
+    try:
+        return float(os.environ.get("COGNEE_SLOW_STREAK_WINDOW", "600") or 600)
+    except (TypeError, ValueError):
+        return 600.0
+
+
+def _read_slow_streaks() -> dict:
+    try:
+        raw = json.loads(_SLOW_STREAK_FILE.read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else {}
+    except Exception:
+        return {}
+
+
+def _write_slow_streaks(state: dict) -> None:
+    try:
+        _SLOW_STREAK_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _SLOW_STREAK_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(state), encoding="utf-8")
+        os.replace(tmp, _SLOW_STREAK_FILE)
+    except Exception:
+        pass
+
+
+def record_slow_probe(service_url: str) -> int:
+    """Count a consecutive no-verdict (timeout) observation; return the streak.
+
+    The streak resets itself when the previous tick is older than the window —
+    two timeouts hours apart are noise, not a pattern. The caller escalates to
+    ``write_connection_state("not_responding", ...)`` once the return value
+    reaches ``slow_streak_threshold()``.
+    """
+    url = _normalize_service_url(service_url)
+    now = datetime.now(timezone.utc).timestamp()
+    state = _read_slow_streaks()
+    entry = state.get(url) if isinstance(state.get(url), dict) else {}
+    try:
+        last_at = float(entry.get("last_at") or 0)
+        count = int(entry.get("count") or 0)
+    except (TypeError, ValueError):
+        last_at, count = 0.0, 0
+    if now - last_at > _slow_streak_window_seconds():
+        count = 0
+    count += 1
+    state[url] = {"count": count, "last_at": now}
+    _write_slow_streaks(state)
+    return count
+
+
+def clear_slow_streak(service_url: str) -> None:
+    """A definitive observation (success OR hard failure) ends the streak."""
+    url = _normalize_service_url(service_url)
+    state = _read_slow_streaks()
+    if url in state:
+        state.pop(url, None)
+        _write_slow_streaks(state)
+
+
 def same_connection_target(service_url: str, prior_url: str) -> bool:
     """True unless the two URLs are *provably* different servers.
 
@@ -1447,10 +1546,14 @@ def authed_liveness(service_url: str = "", api_key: str = "", timeout: float = 1
       "ready"        — 2xx (server up and the key is accepted)
       "auth_failed"  — 401/403 (server up, key rejected)
       "server_error" — 5xx
-      "unreachable"  — connection refused / timeout / DNS
-      "unknown"      — endpoint absent (404/405) or no key to send; caller should
-                       fall back to ``server_health_ok`` rather than trust this
-    Returns a string in ``CONNECTION_STATES`` or "unknown". Never raises.
+      "unreachable"  — connection refused / DNS / unroutable (positively absent)
+      "slow"         — timed out: NO verdict, the server may simply be busy.
+                       Callers must keep their prior state, not record a failure.
+      "unknown"      — endpoint absent (404/405), no key to send, or an
+                       unclassifiable transport error; caller should fall back
+                       to ``probe_health`` rather than trust this
+    Returns a string in ``CONNECTION_STATES``, "slow", or "unknown" — "slow"
+    is a probe verdict only, never a recorded marker state. Never raises.
     """
     base = _normalize_service_url(service_url or _local_api_url())
     if not base:
@@ -1476,8 +1579,11 @@ def authed_liveness(service_url: str = "", api_key: str = "", timeout: float = 1
         if exc.code >= 500:
             return "server_error"
         return "unknown"
-    except (urllib.error.URLError, TimeoutError, OSError):
-        return "unreachable"
+    except Exception as exc:
+        verdict = classify_transport_exception(exc)
+        if verdict == DOWN:
+            return "unreachable"
+        return "slow" if verdict == SLOW else "unknown"
 
 
 # LLM-key health surfaced in the status line — LOCAL mode only, since LLM_API_KEY

--- a/integrations/codex/plugins/cognee/scripts/_recall_http.py
+++ b/integrations/codex/plugins/cognee/scripts/_recall_http.py
@@ -7,9 +7,13 @@ plugin venv (the same constraint ``cognee-search.sh`` already works under).
 Contract — what gets printed to stdout:
   * a JSON **list** on a 2xx response. An **empty list is authoritative**:
     the server searched and found nothing.
-  * the sentinel ``UNREACHABLE`` ONLY when the server cannot be reached
-    (connection refused, timeout, DNS). The caller may then fall back to the
-    local CLI as a degraded path.
+  * the sentinel ``UNREACHABLE`` ONLY when the server is positively absent
+    (connection refused, DNS failure, unroutable host). The caller may then
+    fall back to the local CLI as a degraded path. A **timeout is NOT
+    unreachable**: a dead server refuses in milliseconds, a busy one times
+    out — so timeouts return a *transient* error envelope instead (see below),
+    and the caller keeps its prior view of the server rather than declaring
+    it down.
   * a JSON **error object** ``{"error", "status", "authoritative": false}`` on
     any HTTP error (5xx, 4xx, and especially **401/403** auth rejections) or an
     error-shaped 2xx body. The caller MUST NOT fall back to the local CLI here:
@@ -21,8 +25,10 @@ Contract — what gets printed to stdout:
 Diagnostics also go to stderr so the caller can surface them.
 """
 
+import errno
 import json
 import os
+import socket
 import ssl
 import sys
 import urllib.error
@@ -30,6 +36,46 @@ import urllib.parse
 import urllib.request
 
 UNREACHABLE = "UNREACHABLE"
+
+# Transport-exception verdicts (classify_transport_exception). Only DOWN is
+# evidence the server is absent; SLOW means it exists but did not answer in
+# time, and UNKNOWN is anything we cannot classify. The distinction matters:
+# a dead local server refuses connections in milliseconds, while a busy one
+# times out — conflating the two is what painted false "unreachable" states.
+DOWN = "down"
+SLOW = "slow"
+UNKNOWN = "unknown"
+
+# Errnos that positively identify an absent/unroutable server.
+_DOWN_ERRNOS = {errno.ECONNREFUSED, errno.EHOSTUNREACH, errno.ENETUNREACH}
+
+
+def classify_transport_exception(exc) -> str:
+    """Classify a transport failure as DOWN, SLOW, or UNKNOWN.
+
+    Unwraps ``urllib.error.URLError`` (the real cause lives in ``.reason``, and
+    can be an exception *or* a plain string). Order matters below:
+    ``TimeoutError`` and ``ConnectionRefusedError`` are OSError subclasses, and
+    ``ssl.SSLError`` is too, so the generic errno check must come last.
+    """
+    if isinstance(exc, urllib.error.HTTPError):
+        # The server answered; HTTP statuses are the caller's business.
+        return UNKNOWN
+    if isinstance(exc, urllib.error.URLError):
+        exc = exc.reason
+    if isinstance(exc, str):
+        return SLOW if "timed out" in exc else UNKNOWN
+    if isinstance(exc, (TimeoutError, socket.timeout)):
+        return SLOW
+    if isinstance(exc, socket.gaierror):
+        return DOWN
+    if isinstance(exc, ConnectionRefusedError):
+        return DOWN
+    if isinstance(exc, ssl.SSLError):
+        return UNKNOWN
+    if isinstance(exc, OSError) and getattr(exc, "errno", None) in _DOWN_ERRNOS:
+        return DOWN
+    return UNKNOWN
 
 
 # macOS Python installations often lack root CA certs in the default bundle.
@@ -88,12 +134,18 @@ def coerce_scope(value, default="auto"):
         return default
 
 
-def _error(status, message):
-    """An error envelope — reachable server, but the request was rejected/failed.
+def _error(status, message, *, transient=False):
+    """An error envelope — the request failed, but the server is NOT known dead.
 
     Distinct from UNREACHABLE so the caller does NOT fall back to the local CLI.
+    ``transient=True`` marks a no-verdict failure (timeout / unclassifiable
+    transport error): the breaker must count it as neither success nor failure,
+    and no connection state should be rewritten because of it.
     """
-    return {"error": message, "status": status, "authoritative": False}
+    envelope = {"error": message, "status": status, "authoritative": False}
+    if transient:
+        envelope["transient"] = True
+    return envelope
 
 
 def do_recall(
@@ -154,11 +206,21 @@ def do_recall(
             msg = "server returned HTTP %s for /api/v1/recall" % e.code
         sys.stderr.write("[cognee-search] %s — NOT falling back to local CLI\n" % msg)
         return _error(e.code, msg)
-    except Exception as e:  # URLError / timeout / OSError → genuinely unreachable
+    except Exception as e:
+        verdict = classify_transport_exception(e)
+        if verdict == DOWN:  # refused / DNS / unroutable → positively absent
+            sys.stderr.write(
+                "[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+            )
+            return UNREACHABLE
+        # SLOW (timed out — alive but busy) or UNKNOWN (SSL / reset / a bug in
+        # our own request building): no verdict on the server. Not UNREACHABLE
+        # (no CLI fallback, no "down" marker) and flagged transient so the
+        # breaker counts it as neither success nor failure.
         sys.stderr.write(
-            "[cognee-search] server unreachable at %s: %s\n" % (service_url, str(e)[:160])
+            "[cognee-search] no verdict (%s) from %s: %s\n" % (verdict, service_url, str(e)[:160])
         )
-        return UNREACHABLE
+        return _error(0, "recall %s: %s" % (verdict, str(e)[:160]), transient=True)
 
     # The server responded. A body we can't parse is a SERVER-side bug, not an
     # unreachable server — report it as an error (do NOT trigger the CLI fallback).

--- a/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
+++ b/integrations/codex/plugins/cognee/scripts/cognee_statusline_render.py
@@ -72,14 +72,22 @@ def _active_mode() -> str:
     return "local" if (urlparse(url).hostname or "") in _LOOPBACK else "cloud"
 
 
-_FAIL_STATES = ("auth_failed", "unreachable", "server_error")
+_FAIL_STATES = ("auth_failed", "unreachable", "server_error", "not_responding")
 # Of those, the ones that are a property of the SERVER rather than of the credential
 # the observing session happened to use. Only these may cross session boundaries: if
 # one terminal can't reach the server, neither can the others — but one terminal's
 # rejected API key says nothing about anyone else's. Letting auth_failed cross put a
 # red ✕ (incorrect_cognee_api_key) on a healthy local terminal for a few seconds
 # whenever a keyless cloud terminal started up.
-_SERVER_WIDE_FAIL_STATES = ("unreachable", "server_error")
+# "not_responding" (N consecutive recall timeouts) is server-wide too: a server
+# that isn't answering one terminal isn't answering the others either.
+_SERVER_WIDE_FAIL_STATES = ("unreachable", "server_error", "not_responding")
+
+# A failure verdict is only worth a ✕ while it is FRESH. The hooks refresh a
+# genuine outage on every prompt (probe or recall attempt), so a failure marker
+# older than this means no session has re-confirmed it — ambiguous, and ambiguity
+# renders no glyph (same as the warming case) rather than a stale accusation.
+_FAIL_STATE_STALE_SECONDS = 30 * 60
 
 
 def _active_base_url() -> str:
@@ -179,14 +187,44 @@ def _url_mismatch(active_url: str, marked_url: str) -> bool:
     return bool(active_url and marked_url and active_url != marked_url)
 
 
+def _breaker_glyph(active_url: str) -> str:
+    """ "✕ (<trip reason>) " when THIS server's breaker is open, else "".
+
+    The breaker file is keyed by base_url (SDK-356): an entry for a different
+    server — a cloud tenant while this terminal is local, or Claude Code's
+    target — must not red this bar. A legacy flat file (machine-wide,
+    target-blind) is ignored for the same reason. The reason travels from the
+    trip site, so a breaker opened by 5xx reads ``server_error``, not a false
+    ``unreachable``.
+    """
+    try:
+        raw = json.loads(_BREAKER_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    servers = raw.get("servers") if isinstance(raw, dict) else None
+    if not isinstance(servers, dict):
+        return ""
+    entry = servers.get(active_url.rstrip("/"))
+    if not isinstance(entry, dict):
+        return ""
+    try:
+        if float(entry.get("cooldown_until", 0) or 0) <= time.time():
+            return ""
+    except (TypeError, ValueError):
+        return ""
+    reason = str(entry.get("reason") or "unreachable")
+    return f"✕ ({_REASON_LABELS.get(reason, reason)}) "
+
+
 def _health_prefix(session_id: str = "") -> str:
     """Server-connection glyph for THIS session, from local markers (no network).
 
-    Precedence — we keep it green until we actually know it is red:
-      1. a recorded failure state in the marker → ``✕ (<reason>)``
-      2. an open recall breaker (repeated recall failure) → ``✕ (unreachable)``
+    Precedence — the ✕ is reserved for CONFIRMED, FRESH, DEFINITIVE failures:
+      1. a fresh recorded failure state in the marker → ``✕ (<reason>)``
+         (older than _FAIL_STATE_STALE_SECONDS → ambiguous → no glyph)
+      2. an open recall breaker for THIS base_url → ``✕ (<trip reason>)``
       3. a "ready" marker → ``● ``
-      4. otherwise (no marker / warming / different target) → no glyph
+      4. otherwise (no marker / warming / stale / different target) → no glyph
     The marker (``server-ready.json``) carries {state, base_url, ...}; a state is
     trusted only when its base_url matches this session's, so a local-ready marker
     never greens a cloud session (or vice versa).
@@ -200,23 +238,15 @@ def _health_prefix(session_id: str = "") -> str:
     if marker and not url_mismatch:
         state = str(marker.get("state") or ("ready" if marker.get("ready_at") else ""))
         if state in _FAIL_STATES:
-            return f"✕ ({_REASON_LABELS.get(state, state)}) "
+            if time.time() - _checked_at(marker) <= _FAIL_STATE_STALE_SECONDS:
+                return f"✕ ({_REASON_LABELS.get(state, state)}) "
+            # Stale verdict: nobody has re-confirmed the failure — treat as
+            # unknown rather than keep accusing a server that may be fine.
+            return _breaker_glyph(active_url)
         if state == "ready":
-            try:
-                raw = json.loads(_BREAKER_PATH.read_text(encoding="utf-8"))
-                if isinstance(raw, dict) and float(raw.get("cooldown_until", 0) or 0) > time.time():
-                    return "✕ (unreachable) "
-            except Exception:
-                pass
-            return "● "
+            return _breaker_glyph(active_url) or "● "
 
-    try:
-        raw = json.loads(_BREAKER_PATH.read_text(encoding="utf-8"))
-        if isinstance(raw, dict) and float(raw.get("cooldown_until", 0) or 0) > time.time():
-            return "✕ (unreachable) "
-    except Exception:
-        pass
-    return ""
+    return _breaker_glyph(active_url)
 
 
 def _update_segment() -> str:

--- a/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
+++ b/integrations/codex/plugins/cognee/scripts/session-context-lookup.py
@@ -22,25 +22,29 @@ sys.path.insert(0, os.path.dirname(__file__))
 from _plugin_common import (
     authed_liveness,
     bounded_dim_mismatch_hint,
+    clear_slow_streak,
     get_session_key,
     hook_log,
     load_resolved,
     mark_server_ready,
     notify,
+    probe_health,
     quiet_hook_output,
     read_and_reset_save_counter,
     read_connection_state,
     recall_via_http,
+    record_slow_probe,
     resolve_runtime_mode,
     resolve_session_key_from_payload,
     resolve_user,
     same_connection_target,
-    server_health_ok,
     server_ready_hint,
     service_url_is_local,
     set_session_key,
+    slow_streak_threshold,
     write_connection_state,
 )
+from _recall_http import DOWN, SLOW, classify_transport_exception
 from cognee_statusline_render import render_status_for_host
 from config import ensure_cognee_ready, get_dataset, get_session_id, load_config
 
@@ -170,42 +174,49 @@ async def _run(prompt: str) -> dict | None:
     config = load_config()
     runtime = resolve_runtime_mode()
     cloud_mode = runtime["mode"] == "http"
-    # Readiness gate: never block the user's prompt on a warming/migrating
-    # backend. Trust a fresh readiness marker (zero-network); on a miss, do one
-    # short /health probe and record the result. If still not ready, skip recall
-    # entirely so the prompt is answered at full speed (memory turns on later).
+    # Readiness gate, redesigned (SDK-356): the recall attempt itself is the
+    # probe. A fresh "ready" marker or a merely-stale/unknown state goes
+    # STRAIGHT to recall — a successful scope call is an authenticated,
+    # real-workload confirmation that beats any synthetic /health check, and
+    # the recall budget already bounds the worst case. Probing survives only
+    # as a cheap re-entry gate while the marker holds a KNOWN failure state,
+    # so a confirmed-bad backend costs one bounded probe per prompt instead of
+    # the full budget.
     service_url = runtime.get("base_url", "")
     probe_timeout = _float_env("COGNEE_READY_PROBE_TIMEOUT", 1.0)
-    if not server_ready_hint(service_url):
+    prior = read_connection_state()
+    # Permissive on purpose: "same target" unless the two URLs provably differ,
+    # so a recorded state still applies when a URL is unknown. Mirrors the
+    # renderer's _url_mismatch (equivalence pinned by
+    # tests/test_connection_target_match.py).
+    prior_same_target = same_connection_target(service_url, str(prior.get("base_url") or ""))
+    prior_state = str(prior.get("state") or ("ready" if prior.get("ready_at") else ""))
+    known_bad = prior_same_target and prior_state in (
+        "auth_failed",
+        "unreachable",
+        "server_error",
+        "not_responding",
+    )
+    if known_bad:
         # Prefer an AUTHENTICATED probe so a bad/expired key is classified as
         # auth_failed instead of being masked as "ready" by an unauthenticated
         # /health 200. Fall back to /health only when the authed probe can't
         # classify (no key, or the endpoint is absent on an older server).
         state = authed_liveness(service_url, timeout=probe_timeout)
         if state == "unknown":
-            state = (
-                "ready" if server_health_ok(service_url, timeout=probe_timeout) else "unreachable"
-            )
-
+            health = probe_health(service_url, timeout=probe_timeout)
+            state = {"ready": "ready", "down": "unreachable"}.get(health, health)
         if state == "ready":
             mark_server_ready(service_url)
+            clear_slow_streak(service_url)
+            # fall through to recall below
         else:
-            # A recorded failure (auth_failed / unreachable / server_error) makes
-            # the status line show ✕ (<reason>) and recall skip this turn. Suppress
-            # the write only during a genuine cold-start warm-up: an "unreachable"
-            # with no prior ready marker for this URL is likely the server still
-            # migrating, so stay silent rather than flash a false red.
-            prior = read_connection_state()
-            # Permissive on purpose: "same target" unless the two URLs provably differ,
-            # so a server that really did die is still reported when a URL is unknown.
-            # Mirrors the renderer's _url_mismatch (equivalence pinned by
-            # tests/test_connection_target_match.py).
-            same_target = same_connection_target(service_url, str(prior.get("base_url") or ""))
-            warming = state == "unreachable" and not (
-                str(prior.get("state")) == "ready" and same_target
-            )
-            if not warming:
+            if state in ("auth_failed", "unreachable", "server_error"):
+                # A definitive verdict: refresh/replace the recorded failure.
                 write_connection_state(state, service_url, detail="authed liveness probe")
+                clear_slow_streak(service_url)
+            # "slow"/"unknown" from the probe is NO verdict — keep the recorded
+            # state untouched rather than promote a timeout to a failure.
             hook_log("recall_skipped_not_ready", {"base_url": service_url, "state": state})
             return None
 
@@ -273,12 +284,21 @@ async def _run(prompt: str) -> dict | None:
         try:
             from _cognee_client import breaker_open
 
-            _bopen, _bretry = breaker_open()
+            _bopen, _bretry = breaker_open(service_url)
         except Exception:
             _bopen, _bretry = False, 0
         if _bopen:
             hook_log("recall_breaker_open", {"retry_in": _bretry})
             scope_specs = []
+    # Health accounting for this prompt's recall attempts (the attempt IS the
+    # probe): a scope that returns is proof of life; a refused connection is
+    # proof of death; timeouts alone are no verdict and only feed the streak.
+    scopes_ok = 0  # calls that returned (even empty — the server answered)
+    scopes_answered_err = 0  # HTTP-level errors: reachable, but not healthy
+    scope_timeouts = 0
+    server_down = False
+    auth_rejected = False  # 401/403: the server answered and rejected OUR key
+    server_errors = 0  # 5xx answers: reachable but failing
     for scope_list, qtype, context_profile in scope_specs:
         # Clamp each call to what is left of the budget so a single scope can
         # never overshoot the deadline (previously a scope dispatched just
@@ -322,8 +342,28 @@ async def _run(prompt: str) -> dict | None:
                 )
             if part:
                 results.extend(part)
+            scopes_ok += 1
         except Exception as exc:
-            hook_log("recall_error", {"scope": scope_list, "error": str(exc)[:200]})
+            import urllib.error as _urlerr
+
+            if isinstance(exc, asyncio.TimeoutError):
+                verdict = SLOW  # pre-3.11 asyncio.TimeoutError isn't TimeoutError
+            else:
+                verdict = classify_transport_exception(exc)
+            if isinstance(exc, _urlerr.HTTPError):
+                scopes_answered_err += 1
+                if exc.code in (401, 403):
+                    auth_rejected = True
+                elif exc.code >= 500:
+                    server_errors += 1
+            elif verdict == SLOW:
+                scope_timeouts += 1
+            elif verdict == DOWN:
+                server_down = True
+            hook_log(
+                "recall_error",
+                {"scope": scope_list, "error": str(exc)[:200], "verdict": verdict},
+            )
         finally:
             # hits = raw count from this scope's call (pre-bucketing/filtering);
             # elapsed_ms measured around the call, recorded even when it errored.
@@ -331,6 +371,92 @@ async def _run(prompt: str) -> dict | None:
                 "hits": len(part or []),
                 "elapsed_ms": round((time.monotonic() - t0) * 1000, 1),
             }
+        if server_down:
+            # Positively absent (refused/DNS): the remaining scopes would fail
+            # the same way in milliseconds each — stop here.
+            hook_log("recall_server_down", {"base_url": service_url})
+            break
+        if auth_rejected:
+            # Every scope shares the same API key, so the remaining scopes are
+            # doomed to the same 401/403 — don't spend the budget on them.
+            hook_log("recall_auth_rejected", {"base_url": service_url})
+            break
+
+    # Fold this prompt's recall outcomes back into the shared health state.
+    # Best-effort: accounting must never break the keystroke->answer path.
+    try:
+        if server_down:
+            # Suppress the write during a genuine cold-start warm-up: a refused
+            # connection with no prior ready marker for this URL is likely the
+            # server still launching/migrating — stay quiet rather than flash a
+            # false red (and don't feed the breaker with warm-up refusals).
+            warming = not (prior_state == "ready" and prior_same_target)
+            if not warming:
+                write_connection_state(
+                    "unreachable", service_url, detail="connection refused during recall"
+                )
+                clear_slow_streak(service_url)
+                if cloud_mode:
+                    try:
+                        from _cognee_client import record_failure as _breaker_failure
+
+                        _breaker_failure(
+                            "connection refused",
+                            service_url=service_url,
+                            reason="unreachable",
+                        )
+                    except Exception:
+                        pass
+        elif auth_rejected and not scopes_ok:
+            # The server answered and rejected the key — definitive, and the
+            # same signal the pre-recall authed probe used to provide, now from
+            # a real request. The re-entry gate's authed probe lifts the state
+            # once the key is fixed.
+            write_connection_state("auth_failed", service_url, detail="401/403 during recall")
+            clear_slow_streak(service_url)
+        elif scopes_ok:
+            # The server answered — an authenticated, real-workload proof of
+            # life. Refresh the marker only when it isn't already fresh-ready,
+            # so steady-state prompts don't rewrite the file every keystroke.
+            clear_slow_streak(service_url)
+            if not server_ready_hint(service_url):
+                mark_server_ready(service_url)
+            if cloud_mode:
+                try:
+                    from _cognee_client import record_success as _breaker_success
+
+                    _breaker_success(service_url)
+                except Exception:
+                    pass
+        elif server_errors:
+            # Reachable but failing (5xx on every answered scope, none ok):
+            # record the state and, mirroring the explicit-search path, one
+            # breaker failure for the prompt.
+            write_connection_state("server_error", service_url, detail="5xx during recall")
+            clear_slow_streak(service_url)
+            if cloud_mode:
+                try:
+                    from _cognee_client import record_failure as _breaker_failure
+
+                    _breaker_failure("http 5xx", service_url=service_url, reason="server_error")
+                except Exception:
+                    pass
+        elif scope_timeouts and not scopes_answered_err:
+            # Every attempted scope timed out and none got an HTTP answer: no
+            # verdict on its own, but N consecutive such prompts are a pattern.
+            # Escalate to "not_responding" — deliberately distinct from
+            # "unreachable" (positively absent: refused/DNS): the server exists
+            # but is not answering. A lone timeout never writes anything.
+            streak = record_slow_probe(service_url)
+            if streak >= slow_streak_threshold():
+                write_connection_state(
+                    "not_responding",
+                    service_url,
+                    detail="%d consecutive timeout-only prompts" % streak,
+                )
+                hook_log("slow_streak_escalated", {"base_url": service_url, "streak": streak})
+    except Exception as exc:
+        hook_log("recall_health_accounting_failed", {"error": str(exc)[:200]})
 
     # Bucket results by _source for human-readable output.
     # Local SDK mode returns Pydantic models (ResponseQAEntry, etc.); cloud

--- a/integrations/codex/plugins/cognee/scripts/session-start.py
+++ b/integrations/codex/plugins/cognee/scripts/session-start.py
@@ -37,9 +37,9 @@ from _plugin_common import (
     apply_cognee_env,
     ensure_launch_record,
     hook_log,
+    probe_health,
     quiet_hook_output,
     resolve_session_key_from_payload,
-    server_health_ok,
     set_session_key,
     touch_activity,
     write_connection_state,
@@ -987,19 +987,29 @@ async def _run_heavy(
             print(f"cognee-plugin: agent lifecycle failed ({message})", file=sys.stderr)
             # Classify for the status line. Preserve an earlier health-derived
             # state; otherwise a reachable server rejecting registration is almost
-            # always auth, while an unreachable one is a connection failure.
+            # always auth, while a positively-absent one is a connection failure.
+            # A timed-out probe is NO verdict (busy != down): keep the prior
+            # recorded state rather than stamp a false "unreachable".
             if _conn_state is None:
                 try:
-                    healthy = server_health_ok(
+                    health = probe_health(
                         _normalize_service_url(str(config.get("base_url", "") or "")), timeout=1.5
                     )
                 except Exception:
-                    healthy = False
-                _conn_state = "auth_failed" if healthy else "unreachable"
-                _conn_detail = message
-            write_connection_state(
-                _conn_state, str(config.get("base_url", "") or ""), detail=_conn_detail
-            )
+                    health = "unknown"
+                if health == "ready":
+                    _conn_state, _conn_detail = "auth_failed", message
+                elif health == "down":
+                    _conn_state, _conn_detail = "unreachable", message
+            if _conn_state:
+                write_connection_state(
+                    _conn_state, str(config.get("base_url", "") or ""), detail=_conn_detail
+                )
+            else:
+                hook_log(
+                    "conn_state_unverified",
+                    {"reason": "probe returned no verdict after registration failure"},
+                )
             return "", "", False
     else:
         # Local SDK fallback path.
@@ -1052,11 +1062,19 @@ async def _run_heavy(
             write_connection_state(
                 _conn_state, str(config.get("base_url", "") or ""), detail=_conn_detail
             )
-        elif service_url and server_health_ok(service_url, timeout=1.5):
-            write_connection_state("ready", service_url)
-        else:
-            write_connection_state("unreachable", str(config.get("base_url", "") or ""))
-    elif service_url and server_health_ok(service_url, timeout=1.5):
+        elif service_url:
+            health = probe_health(service_url, timeout=1.5)
+            if health == "ready":
+                write_connection_state("ready", service_url)
+            elif health == "down":
+                write_connection_state(
+                    "unreachable", str(config.get("base_url", "") or service_url)
+                )
+            else:
+                # "slow"/"unknown": no verdict — keep whatever state is already
+                # recorded instead of branding a busy server unreachable.
+                hook_log("conn_state_unverified", {"base_url": service_url, "health": health})
+    elif service_url and probe_health(service_url, timeout=1.5) == "ready":
         write_connection_state("ready", service_url)
 
     return user_id, agent_api_key, True

--- a/integrations/codex/plugins/cognee/tests/test_doctor.py
+++ b/integrations/codex/plugins/cognee/tests/test_doctor.py
@@ -42,7 +42,11 @@ def _reset_env(*keys):
 
 
 def _reset_breaker():
-    p = pathlib.Path(_TMP) / "recall-breaker.json"
+    # Resolve through _state_path(): other test modules also set
+    # COGNEE_PLUGIN_STATE_DIR at import, and under pytest the last import wins.
+    from _cognee_client import _state_path
+
+    p = _state_path()
     if p.exists():
         p.unlink()
 
@@ -342,9 +346,21 @@ def test_breaker_closed():
 def test_breaker_open():
     import time as _time
 
-    breaker_path = pathlib.Path(_TMP) / "recall-breaker.json"
-    breaker_path.write_text(
-        json.dumps({"failures": 10, "cooldown_until": _time.time() + 60}),
+    from _cognee_client import _state_path
+
+    # Per-server schema (SDK-356): entries are keyed by base_url; the no-URL
+    # doctor view reports the worst open entry across all servers.
+    _state_path().write_text(
+        json.dumps(
+            {
+                "servers": {
+                    "http://x": {
+                        "cooldown_until": _time.time() + 60,
+                        "reason": "unreachable",
+                    }
+                }
+            }
+        ),
         encoding="utf-8",
     )
     try:

--- a/integrations/codex/tests/test_improve_session_lock.py
+++ b/integrations/codex/tests/test_improve_session_lock.py
@@ -94,9 +94,15 @@ def test_dead_holder_lock_is_reclaimed():
     # dead-pid branch must be what clears it. pid_alive is stubbed rather than
     # guessing an unused pid, so the test can't flake on a recycled pid.
     p.write_text(json.dumps({"owner": "dead", "pid": 4242, "created_at": 9e9}))
+    # c._proc is the SHARED module object (sys.modules singleton): restore the
+    # stub or it leaks into every later test module (seen in test_proc).
+    _orig_pid_alive = c._proc.pid_alive
     c._proc.pid_alive = lambda pid: False
-    with c.improve_session_lock("sess-A", "reclaimer") as claimed:
-        assert claimed is True, "stale lock from a dead pid must be reclaimed"
+    try:
+        with c.improve_session_lock("sess-A", "reclaimer") as claimed:
+            assert claimed is True, "stale lock from a dead pid must be reclaimed"
+    finally:
+        c._proc.pid_alive = _orig_pid_alive
 
 
 def test_live_holder_lock_is_not_stolen():
@@ -112,9 +118,13 @@ def test_live_holder_lock_is_not_stolen():
 
     now = _dt.datetime.now(_dt.timezone.utc).timestamp()
     p.write_text(json.dumps({"owner": "live", "pid": 4242, "created_at": now}))
+    _orig_pid_alive = c._proc.pid_alive
     c._proc.pid_alive = lambda pid: True
-    with c.improve_session_lock("sess-A", "intruder") as claimed:
-        assert claimed is False, "a live holder's lock must be respected"
+    try:
+        with c.improve_session_lock("sess-A", "intruder") as claimed:
+            assert claimed is False, "a live holder's lock must be respected"
+    finally:
+        c._proc.pid_alive = _orig_pid_alive
 
 
 def test_missing_session_id_never_blocks():

--- a/integrations/codex/tests/test_statusline_connection_state.py
+++ b/integrations/codex/tests/test_statusline_connection_state.py
@@ -193,10 +193,15 @@ def test_a_fresher_shared_ready_does_not_clear_our_failure():
 # ── the pre-existing rules still hold ────────────────────────────────────
 
 
+def _breaker_for(url, *, cooldown_delta=60, reason="unreachable"):
+    """A per-server breaker file (SDK-356 schema) for `url`."""
+    return {"servers": {url: {"cooldown_until": time.time() + cooldown_delta, "reason": reason}}}
+
+
 def test_open_breaker_overrides_our_ready():
     with _Markers(
         mine=_rec("ready", _MINE),
-        breaker={"cooldown_until": time.time() + 60},
+        breaker=_breaker_for(_URL),
     ):
         assert sl._health_prefix(_MINE) == "✕ (unreachable) "
 
@@ -204,9 +209,65 @@ def test_open_breaker_overrides_our_ready():
 def test_expired_breaker_leaves_ready_alone():
     with _Markers(
         mine=_rec("ready", _MINE),
-        breaker={"cooldown_until": time.time() - 60},
+        breaker=_breaker_for(_URL, cooldown_delta=-60),
     ):
         assert sl._health_prefix(_MINE) == _READY
+
+
+def test_breaker_reports_its_real_trip_reason():
+    """A breaker opened by 5xx must read server_error, not a false unreachable."""
+    with _Markers(
+        mine=_rec("ready", _MINE),
+        breaker=_breaker_for(_URL, reason="server_error"),
+    ):
+        assert sl._health_prefix(_MINE) == "✕ (server_error) "
+
+
+def test_another_servers_breaker_does_not_red_this_bar():
+    """Cloud failures (or Claude Code's target) must not red a local terminal."""
+    with _Markers(
+        mine=_rec("ready", _MINE),
+        breaker=_breaker_for("https://tenant-x.aws.cognee.ai"),
+    ):
+        assert sl._health_prefix(_MINE) == _READY
+
+
+def test_legacy_flat_breaker_file_is_ignored():
+    """The pre-upgrade machine-wide breaker was target-blind — never render it."""
+    with _Markers(
+        mine=_rec("ready", _MINE),
+        breaker={"failures": 99, "cooldown_until": time.time() + 3600},
+    ):
+        assert sl._health_prefix(_MINE) == _READY
+
+
+# ── SDK-356: honest, fresh, definitive ─────────────────────────────────────
+
+
+def test_not_responding_renders_its_own_reason():
+    """The escalated timeout streak is its own state — never "unreachable"."""
+    with _Markers(mine=_rec("not_responding", _MINE)):
+        assert sl._health_prefix(_MINE) == "✕ (not_responding) "
+
+
+def test_fresher_shared_not_responding_overrides_our_older_ready():
+    """Server-wide: a server that isn't answering isn't answering anyone."""
+    with _Markers(
+        shared=_rec("not_responding", _THEIRS, age=1),
+        mine=_rec("ready", _MINE, age=600),
+    ):
+        assert sl._health_prefix(_MINE) == "✕ (not_responding) "
+
+
+def test_stale_failure_marker_renders_no_glyph():
+    """A failure nobody has re-confirmed within the TTL is ambiguity, not red."""
+    with _Markers(mine=_rec("unreachable", _MINE, age=sl._FAIL_STATE_STALE_SECONDS + 60)):
+        assert sl._health_prefix(_MINE) == ""
+
+
+def test_fresh_failure_marker_still_renders():
+    with _Markers(mine=_rec("unreachable", _MINE, age=60)):
+        assert sl._health_prefix(_MINE) == "✕ (unreachable) "
 
 
 def test_base_url_mismatch_is_ignored():

--- a/integrations/codex/tests/test_statusline_llm_state.py
+++ b/integrations/codex/tests/test_statusline_llm_state.py
@@ -219,9 +219,13 @@ def test_cloud_mode_suppresses_llm_glyph():
 
 
 def test_server_failure_wins_over_llm_failure():
+    import time as _time
+
     with _Renderer(
         llm_state={"llm_state": "not_set"},
-        server_marker={"state": "auth_failed", "base_url": _LOCAL_URL},
+        # checked_at present and fresh: red is reserved for fresh failures
+        # (a failure marker of unknown age renders no glyph since SDK-356).
+        server_marker={"state": "auth_failed", "base_url": _LOCAL_URL, "checked_at": _time.time()},
     ):
         assert sl._status_prefix() == f"✕ ({sl._COGNEE_KEY_REASON}) "
 


### PR DESCRIPTION
Fix false ✕ (unreachable) in the status line (SDK-356)

The status line randomly showed ✕ (unreachable) (and recall was skipped) while the server was healthy, in both local and cloud mode. Root cause: probe/recall timeouts were classified as "unreachable" and persisted into shared state — amplified by a machine-wide circuit breaker that never decayed and wasn't keyed by server.

Changes

- Transport classification (_recall_http.py): connection refused / DNS → down; timeout → slow (no verdict, never written); everything else → unknown. UNREACHABLE (and the CLI fallback) is now reserved for positive absence.
- Recall is the probe (session-context-lookup.py): the pre-recall health probe is gone from the happy path — recall runs within its existing budget, and its real outcomes drive the connection state: success → ready, refused → unreachable, 401/403 → auth_failed (remaining scopes skipped), all-5xx → server_error. A probe remains only as a cheap re-entry gate while the marker holds a failure state.
- New not_responding state: written only after N consecutive timeout-only prompts (default 3) — a busy server is never misreported as unreachable; a single slow response changes nothing.
- Circuit breaker (_cognee_client.py): keyed by base_url, sliding-window failure decay, half-open after cooldown, real trip reason recorded; timeouts count as nothing.
- Renderer: red ✕ only for fresh, definitive failures (30 min TTL); breaker glyph is per-server and shows the actual trip reason.
- Session start: failure written only on definitive down; timeout keeps prior state.
- Mirrored into the Codex plugin; brief README notes for the new state.

Tests

Claude Code suite: 346 passed / 0 failed (main baseline: 317/5). Codex: 209 passed; the 4 remaining failures pre-exist on main (unrelated test_improve_sync fakes). New coverage for the classifier, breaker semantics, hot-path health accounting, and renderer states; also fixed two pre-existing suite-order flakes.

Follow-up: SDK-359 (idle-watcher re-probe to self-heal stale failure states).