### PR TITLE
fix: remove update message mid-session when plugin is updated

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "cognee-memory",
       "source": "./integrations/claude-code",
       "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "author": {
         "name": "Cognee"
       },

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cognee-memory",
   "description": "Cognee knowledge graph memory for Claude Code — session-aware storage, auto-routing recall, and persistent learning across sessions. Supports local mode and Cognee Cloud.",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "author": {
     "name": "Cognee"
   },

--- a/integrations/claude-code/CHANGELOG.md
+++ b/integrations/claude-code/CHANGELOG.md
@@ -10,6 +10,23 @@ Code only offers an update when that string changes. Tag releases as
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.2.4]
+
+### Fixed
+- **The "update available" nudge now clears in the same session the update is
+  applied in.** The v1.1.1 fix compared the marker against the *running* plugin
+  version, but installs are version-pinned directories: after `/plugin update`
+  the old copy keeps rendering the status line until a restart re-points it, so
+  the running version never moved and the nudge survived the whole session.
+  Both surfaces (status-line segment and SessionStart message) now also consult
+  Claude Code's install registry (`~/.claude/plugins/installed_plugins.json`),
+  which is rewritten the moment an update lands: once it records a version at or
+  past the marker's `latest_version`, the nudge is suppressed — the status line
+  clears on its next refresh (~2s), no restart needed. A missing or malformed
+  registry changes nothing (previous behaviour). The Codex plugin is unaffected:
+  it updates in place, so its existing running-version guard already clears
+  mid-session.
+
 ## [1.2.3]
 
 ### Fixed

--- a/integrations/claude-code/scripts/_plugin_common.py
+++ b/integrations/claude-code/scripts/_plugin_common.py
@@ -1813,6 +1813,10 @@ _UPDATE_DEFAULT_REPO = "topoteretes/cognee-integrations"
 _UPDATE_DEFAULT_REF = "main"
 _UPDATE_PLUGIN_ENTRY = "cognee-memory"
 _KNOWN_MARKETPLACES = Path.home() / ".claude" / "plugins" / "known_marketplaces.json"
+# Claude Code's install registry: rewritten the moment `/plugin update` (or a
+# marketplace auto-update) installs a new version — unlike the version-pinned
+# plugin dirs, it reflects an update in the same session it happened in.
+_INSTALLED_PLUGINS_FILE = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
 
 
 def _update_check_enabled() -> bool:
@@ -1855,6 +1859,33 @@ def _installed_plugin_version() -> str:
         except Exception:
             continue
     return ""
+
+
+def _recorded_install_version() -> str:
+    """Newest cognee-memory version recorded in Claude Code's install registry.
+
+    ``installed_plugins.json`` maps ``<plugin>@<marketplace>`` to a list of
+    installs. '' when the file is missing, unreadable, or has no parseable
+    cognee-memory entry. Mirrored (not imported) by the status-line renderer,
+    which stays free of this module.
+    """
+    try:
+        data = json.loads(_INSTALLED_PLUGINS_FILE.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    plugins = data.get("plugins") if isinstance(data, dict) else None
+    if not isinstance(plugins, dict):
+        return ""
+    best, best_str = (), ""
+    for key, installs in plugins.items():
+        if str(key).split("@", 1)[0] != _UPDATE_PLUGIN_ENTRY:
+            continue
+        for install in installs if isinstance(installs, list) else []:
+            version = str(install.get("version") or "") if isinstance(install, dict) else ""
+            parsed = _parse_semver(version)
+            if parsed and parsed > best:
+                best, best_str = parsed, version
+    return best_str
 
 
 def _update_source() -> Optional[tuple]:
@@ -1971,8 +2002,15 @@ def read_update_status() -> dict:
     the snapshot is only trustworthy while its ``installed_version`` is still the
     version actually running. A mismatch means the update already landed, so the
     nudge is suppressed immediately rather than after the next network check.
-    Note this compares against the RUNNING version, not the newest on disk — an
-    auto-update that a session has not reloaded yet correctly keeps nudging.
+    Two suppression signals, either one clears the nudge:
+    - the running version moved past the marker's ``installed_version`` (the
+      session restarted into the new copy), or
+    - Claude Code's install registry (``installed_plugins.json``) already
+      records a version at or past ``latest_version`` — `/plugin update`
+      rewrites it immediately, so this clears the nudge in the very session
+      the update happened in, even though that session still RUNS the old
+      copy (installs are version-pinned dirs and only a restart re-points
+      the hooks).
     """
     if not _update_check_enabled():
         return {}
@@ -1988,6 +2026,10 @@ def read_update_status() -> dict:
     # missing/unreadable plugin.json degrades to the previous behaviour.
     running = _installed_plugin_version()
     if running and running != marker.get("installed_version"):
+        return {}
+    recorded = _parse_semver(_recorded_install_version())
+    published = _parse_semver(str(marker.get("latest_version") or ""))
+    if recorded and published and recorded >= published:
         return {}
     return marker
 

--- a/integrations/claude-code/scripts/cognee_statusline_render.py
+++ b/integrations/claude-code/scripts/cognee_statusline_render.py
@@ -28,6 +28,10 @@ _CONFIG_PATH = _SHARED_ROOT / "claude-code" / "config.json"
 _SERVER_READY_PATH = _SHARED_ROOT / "server-ready.json"
 _BREAKER_PATH = _SHARED_ROOT / "recall-breaker.json"
 _UPDATE_CHECK_PATH = _SHARED_ROOT / "claude-code" / "update-check.json"
+# Claude Code's own install registry: rewritten the moment `/plugin update`
+# (or a marketplace auto-update) installs a new version, which makes it the
+# only signal that clears the update nudge mid-session (see _update_segment).
+_INSTALLED_PLUGINS_PATH = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
 _PIPELINE_HEALTH_PATH = _SHARED_ROOT / "pipeline-health.json"
 _LLM_STATE_PATH = _SHARED_ROOT / "claude-code" / "llm-state.json"
 _RECALL_PATH = _SHARED_ROOT / "claude-code" / "last_recall.json"
@@ -343,6 +347,17 @@ def _update_segment() -> str:
     running = _running_plugin_version()
     if running and running != installed:
         return ""
+    # Mid-session update guard: `/plugin update` installs the new version into
+    # its own version-pinned cache dir, but settings.json keeps pointing the
+    # status line at THIS (old) copy until the next SessionStart — so the
+    # running-version check above never trips in the session where the update
+    # happened. Claude Code does rewrite installed_plugins.json immediately,
+    # so a recorded install at or past `latest` means the user already
+    # updated: clear the nudge on this refresh instead of after a restart.
+    recorded = _parse_semver(_recorded_install_version())
+    published = _parse_semver(latest)
+    if recorded and published and recorded >= published:
+        return ""
     return f"   \033[1;33m⬆ Cognee update available {installed}→{latest}\033[0m"
 
 
@@ -367,6 +382,49 @@ def _running_plugin_version() -> str:
         except Exception:
             continue
     return ""
+
+
+def _parse_semver(value: str):
+    """Numeric X.Y.Z core as a tuple (ignoring -pre/+build), or None.
+
+    Kept in sync with ``_plugin_common._parse_semver`` — duplicated because the
+    renderer never imports the plugin runtime (see module docstring).
+    """
+    core = str(value or "").strip().lstrip("vV").split("-", 1)[0].split("+", 1)[0]
+    parts = core.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        return tuple(int(p) for p in parts)
+    except ValueError:
+        return None
+
+
+def _recorded_install_version() -> str:
+    """Newest cognee-memory version recorded in Claude Code's install registry.
+
+    ``installed_plugins.json`` maps ``<plugin>@<marketplace>`` to a list of
+    installs; it is rewritten the moment an update lands, regardless of which
+    (possibly older) plugin copy this renderer belongs to. '' when the file is
+    missing, unreadable, or has no parseable cognee-memory entry.
+    """
+    try:
+        data = json.loads(_INSTALLED_PLUGINS_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    plugins = data.get("plugins") if isinstance(data, dict) else None
+    if not isinstance(plugins, dict):
+        return ""
+    best, best_str = (), ""
+    for key, installs in plugins.items():
+        if str(key).split("@", 1)[0] != "cognee-memory":
+            continue
+        for install in installs if isinstance(installs, list) else []:
+            version = str(install.get("version") or "") if isinstance(install, dict) else ""
+            parsed = _parse_semver(version)
+            if parsed and parsed > best:
+                best, best_str = parsed, version
+    return best_str
 
 
 def _pipeline_health_glyph() -> str:

--- a/integrations/claude-code/tests/test_update_nudge_staleness.py
+++ b/integrations/claude-code/tests/test_update_nudge_staleness.py
@@ -8,9 +8,12 @@ that read it — the status-line segment and the SessionStart nudge — therefor
 compare the marker's ``installed_version`` against the version *running*, and
 suppress the nudge on a mismatch.
 
-The comparison is deliberately against the RUNNING version rather than the newest
-copy on disk: a background auto-update that the session has not reloaded yet must
-keep nudging, because the session really is still on the old version.
+The running-version comparison alone cannot clear the nudge in the session the
+update happened in: installs are version-pinned dirs, and the old copy keeps
+running (and rendering) until a restart re-points the status line. Claude Code's
+install registry (``installed_plugins.json``) IS rewritten immediately, so both
+surfaces also suppress when it records a version at or past the marker's
+``latest_version`` — that is what makes the nudge disappear mid-session.
 
 Run: `python integrations/claude-code/tests/test_update_nudge_staleness.py` (or via pytest).
 """
@@ -49,17 +52,33 @@ def _marker(installed: str, latest: str) -> dict:
     }
 
 
+def _registry(version: str) -> dict:
+    """A minimal ~/.claude/plugins/installed_plugins.json payload."""
+    return {
+        "version": 2,
+        "plugins": {"cognee-memory@cognee": [{"scope": "user", "version": version}]},
+    }
+
+
 # --- status-line segment ------------------------------------------------------
 
 
-def _segment_with(marker: dict) -> str:
-    """Render just the update segment against a temp marker file."""
+def _segment_with(marker: dict, registry=None) -> str:
+    """Render just the update segment against temp marker/registry files.
+
+    The install-registry path is always redirected (to nothing, unless
+    ``registry`` is given) so a real ~/.claude/plugins/installed_plugins.json
+    on the machine running the tests cannot leak in.
+    """
     sl = _load("sl_staleness", "cognee_statusline_render.py")
     tmp = pathlib.Path(tempfile.mkdtemp())
     saved = os.environ.pop("COGNEE_UPDATE_CHECK", None)
     try:
         sl._UPDATE_CHECK_PATH = tmp / "update-check.json"
+        sl._INSTALLED_PLUGINS_PATH = tmp / "installed_plugins.json"
         _write(sl._UPDATE_CHECK_PATH, marker)
+        if registry is not None:
+            _write(sl._INSTALLED_PLUGINS_PATH, registry)
         return sl._update_segment()
     finally:
         if saved is not None:
@@ -83,6 +102,38 @@ def test_segment_hidden_once_running_version_moved_past_marker():
     assert out == "", repr(out)
 
 
+def test_segment_hidden_once_registry_records_latest():
+    """Mid-session update: the old copy still renders, but the registry moved."""
+    sl = _load("sl_staleness", "cognee_statusline_render.py")
+    running = sl._running_plugin_version()
+    out = _segment_with(_marker(running, "99.0.0"), registry=_registry("99.0.0"))
+    assert out == "", repr(out)
+
+
+def test_segment_hidden_when_registry_moved_past_latest():
+    sl = _load("sl_staleness", "cognee_statusline_render.py")
+    running = sl._running_plugin_version()
+    out = _segment_with(_marker(running, "99.0.0"), registry=_registry("99.0.1"))
+    assert out == "", repr(out)
+
+
+def test_segment_still_shown_while_registry_behind_latest():
+    """No update yet: the registry records the same old version that runs."""
+    sl = _load("sl_staleness", "cognee_statusline_render.py")
+    running = sl._running_plugin_version()
+    out = _segment_with(_marker(running, "99.0.0"), registry=_registry(running))
+    assert "update available" in out, repr(out)
+
+
+def test_segment_malformed_registry_is_ignored():
+    """A broken registry must not disable the nudge."""
+    sl = _load("sl_staleness", "cognee_statusline_render.py")
+    running = sl._running_plugin_version()
+    for payload in ({}, {"plugins": []}, {"plugins": {"cognee-memory@cognee": [{}]}}):
+        out = _segment_with(_marker(running, "99.0.0"), registry=payload)
+        assert "update available" in out, (payload, out)
+
+
 def test_running_version_matches_plugin_manifest():
     """The renderer resolves its own version from its own location, not the env."""
     sl = _load("sl_staleness", "cognee_statusline_render.py")
@@ -95,13 +146,16 @@ def test_running_version_matches_plugin_manifest():
 # --- SessionStart nudge (shared read used by _apply_update_nudge) -------------
 
 
-def _status_with(marker: dict) -> dict:
+def _status_with(marker: dict, registry=None) -> dict:
     common = _load("common_staleness", "_plugin_common.py")
     tmp = pathlib.Path(tempfile.mkdtemp())
     saved = os.environ.pop("COGNEE_UPDATE_CHECK", None)
     try:
         common._UPDATE_CHECK_FILE = tmp / "update-check.json"
+        common._INSTALLED_PLUGINS_FILE = tmp / "installed_plugins.json"
         _write(common._UPDATE_CHECK_FILE, marker)
+        if registry is not None:
+            _write(common._INSTALLED_PLUGINS_FILE, registry)
         return common.read_update_status()
     finally:
         if saved is not None:
@@ -120,6 +174,21 @@ def test_read_update_status_returns_marker_when_current():
 
 def test_read_update_status_suppressed_after_update():
     assert _status_with(_marker("0.0.1", "99.0.0")) == {}
+
+
+def test_read_update_status_suppressed_once_registry_records_latest():
+    """Mid-session update: still running the old copy, but the registry moved."""
+    common = _load("common_staleness", "_plugin_common.py")
+    running = common._installed_plugin_version()
+    status = _status_with(_marker(running, "99.0.0"), registry=_registry("99.0.0"))
+    assert status == {}, repr(status)
+
+
+def test_read_update_status_kept_while_registry_behind_latest():
+    common = _load("common_staleness", "_plugin_common.py")
+    running = common._installed_plugin_version()
+    status = _status_with(_marker(running, "99.0.0"), registry=_registry(running))
+    assert status.get("update_available") is True, repr(status)
 
 
 def test_unreadable_running_version_falls_back_to_marker():


### PR DESCRIPTION
This PR fixes an issue where the Cognee update message remained visible during the current session even after updating the plugin.